### PR TITLE
Request Travel Advance

### DIFF
--- a/src/api/data/migrations/034-normalize-forms-travel-advance-type.ts
+++ b/src/api/data/migrations/034-normalize-forms-travel-advance-type.ts
@@ -1,0 +1,27 @@
+import * as knex from "knex"
+
+exports.up = async function (knex: knex.Knex) {
+  await knex.schema.alterTable("forms", function (table) {
+    table.integer("travelAdvanceInCents")
+  })
+
+  // Move data from the old column to the new one, and convert to cents.
+  await knex.raw(`
+    UPDATE "forms"
+    SET "travelAdvanceInCents" = "travelAdvance" * 100
+    WHERE "travelAdvance" IS NOT NULL;
+  `)
+}
+
+exports.down = async function (knex: knex.Knex) {
+  // Move data back from the new column to the old one, and convert to dollars.
+  await knex.raw(`
+    UPDATE "forms"
+    SET "travelAdvance" = ceil("travelAdvanceInCents" / 100.0)
+    WHERE "travelAdvance" IS NOT NULL;
+  `)
+
+  await knex.schema.alterTable("forms", function (table) {
+    table.dropColumn("travelAdvanceInCents")
+  })
+}

--- a/src/api/models/form.ts
+++ b/src/api/models/form.ts
@@ -34,7 +34,9 @@ export interface FormRecord {
   //  and purpose association
   // purpose?: string
   purposeId?: number
-  travelAdvance?: string
+  // DEPRECATED: travelAdvance column on forms table is replaced by travelAdvanceInCents column
+  // travelAdvance?: number
+  travelAdvanceInCents?: number
   eventName?: string
   summary?: string
   benefits?: string

--- a/src/api/serializers/form-serializers.ts
+++ b/src/api/serializers/form-serializers.ts
@@ -1,0 +1,16 @@
+import { pick } from "lodash"
+
+import Form from "../models/form"
+
+export class FormSerializers {
+  static asTable(forms: Form[]) {
+    return forms.map((form) => {
+      return {
+        ...pick(form, ["id", "department", "branch", "status"]),
+        purpose: form.purpose?.purpose,
+      }
+    })
+  }
+}
+
+export default FormSerializers

--- a/src/web/src/modules/travelForm/components/TravelDetailsForm.vue
+++ b/src/web/src/modules/travelForm/components/TravelDetailsForm.vue
@@ -71,7 +71,7 @@
         <v-col cols="3">
           <v-text-field
             dense
-            v-model="request.travelAdvance"
+            v-model="travelAdvanceInDollars"
             label="Travel Advance"
             required
             background-color="white"
@@ -160,6 +160,14 @@ export default {
   }),
   computed: {
     ...mapState("travelForm", ["purposes", "request"]),
+    travelAdvanceInDollars: {
+      get() {
+        return Math.ceil(this.request.travelAdvanceInCents / 100.0);
+      },
+      set(value) {
+        this.request.travelAdvanceInCents = Math.ceil(value * 100);
+      },
+    },
   },
   async mounted() {
     this.loadPurposes();

--- a/src/web/src/modules/travelForm/router/index.js
+++ b/src/web/src/modules/travelForm/router/index.js
@@ -4,20 +4,20 @@ const routes = [
     component: () => import("@/layouts/Layout"),
     children: [
       {
-        name: "TravelFormManagerList",
-        path: "/managerView",
-        meta: {
-          requiresAuth: true
-        },
-        component: () => import("../views/ManagerView")
-      },
-      {
         name: "travelRequestsList",
         path: "",
         meta: {
           requiresAuth: true
         },
         component: () => import("../views/FormList")
+      },
+      {
+        name: "TravelFormManagerList",
+        path: "/managerView",
+        meta: {
+          requiresAuth: true
+        },
+        component: () => import("../views/ManagerView")
       },
       {
         name: "travelRequestCreate",

--- a/src/web/src/modules/travelForm/store/index.js
+++ b/src/web/src/modules/travelForm/store/index.js
@@ -94,7 +94,7 @@ const actions = {
       travelDuration: "1",
       daysOffTravelStatus: "0",
       dateBackToWork: "",
-      travelAdvance: 0,
+      travelAdvanceInCents: 0,
       purposeId: -1,
       eventName: "",
       summary: "",

--- a/src/web/src/modules/travelForm/store/index.js
+++ b/src/web/src/modules/travelForm/store/index.js
@@ -10,11 +10,12 @@ const state = {
   departments: [],
   purposes: [],
   destinations: [],
-  request: {},
+  request: {}, // TODO: make this name match the back-end object name.
 }
 
 const actions = {
   async initialize(store) {
+    await store.dispatch("initializeForm")
     await store.dispatch("loadDepartments")
     await store.dispatch("loadPurposes")
     await store.dispatch("loadDestinations")
@@ -71,7 +72,7 @@ const actions = {
       return form
     })
   },
-  start({ commit }) {
+  initializeForm({ commit }) {
     let form = {
       //personal info
       firstName: "",

--- a/src/web/src/modules/travelForm/views/TravelFormCreate.vue
+++ b/src/web/src/modules/travelForm/views/TravelFormCreate.vue
@@ -197,7 +197,6 @@ export default {
   }),
   async mounted() {
     this.loading = true
-    await this.start()
     await this.initialize()
     await this.loadUser()
     this.$refs.form.resetValidation()


### PR DESCRIPTION
Depends on https://github.com/icefoganalytics/travel-authorization/pull/8
Fixes https://github.com/icefoganalytics/travel-authorization/issues/4

# User Story

As a user, I want to request a travel advance so that I can cover my travel expenses upfront.

# Context

On the http://localhost:8080/my-travel-requests/:form-id and http://localhost:8080/my-travel-requests/create pages, in the "Enter details about the trip and purpose" section, I should be able to enter a value for a travel advance.
This field, like all money fields should be stored in the database as a value in cents.

# Testing Instructions

1. Boot the database service via `dev up`
2. Boot the api service via `cd src/api && npm run start`
3. Boot the web service via `cd src/web && npm run start`
4. Go to http://localhost:8080/my-travel-requests.
5. Click on the "+ Travel Authorization" button.
6. Complete the "Enter your personal details" section.
7. Complete the "Tell us about the travel" section.
8. Complete the "Enter details about the trip and purpose" section.
9. Check that the "travel advance" field is displayed in dollars.
10. Click the "Save Draft" button. This will redirect you back to the http://localhost:8080/my-travel-requests page.
11. If you have database access check that the values is stored in the database in dollars.
12. Click on the newly created travel request (bottom of the list), and you will be redirected to the "edit" page for that request at http://localhost:8080/my-travel-requests/:travel-request-id
13. Click through the form, and check that the "travel advance" field is displayed the same as when it was saved.