### PR TITLE
Per Stop Accommodation Selection

### DIFF
--- a/src/api/data/migrations/038-add-accommodation-type-to-stops-table.ts
+++ b/src/api/data/migrations/038-add-accommodation-type-to-stops-table.ts
@@ -1,0 +1,65 @@
+import * as knex from "knex"
+
+exports.up = async function (knex: knex.Knex) {
+  await knex.schema.alterTable("stops", function (table) {
+    table.string("accommodationType", 255)
+  })
+
+  await knex.raw(`
+    UPDATE "stops"
+    SET "accommodationType" = "forms"."accommodationType"
+    FROM "forms"
+    WHERE "stops"."taid" = "forms"."id";
+  `)
+
+  await knex.schema.alterTable("forms", function (table) {
+    table.dropColumn("accommodationType")
+  })
+}
+
+exports.down = async function (knex: knex.Knex) {
+  await knex.schema.alterTable("forms", function (table) {
+    table.string("accommodationType", 255)
+  })
+
+  await knex.raw(`
+    WITH "deduplicatedAccommodationTypes" AS (
+      SELECT DISTINCT ON ("taid", "accommodationType")
+        "taid"
+        , "accommodationType"
+        , "departureDate"
+        , "departureTime"
+      FROM
+        stops
+      ORDER BY
+        "taid"
+        , "accommodationType"
+        , "departureDate"
+        , "departureTime"
+    )
+    , "accommodationTypesArray" AS (
+      SELECT
+        "taid"
+        , array_to_string(
+            array_agg("accommodationType" ORDER BY "departureDate", "departureTime")
+            , ','
+          ) AS "accommodationTypes"
+      FROM
+        "deduplicatedAccommodationTypes"
+      GROUP BY
+        "taid"
+    )
+    UPDATE
+      "forms"
+    SET
+      "accommodationType" = "accommodationTypesArray"."accommodationTypes"
+    FROM
+      "accommodationTypesArray"
+    WHERE
+      "accommodationTypesArray"."taid" = "forms"."id";
+  `)
+
+  await knex.schema.alterTable("stops", function (table) {
+    table.dropColumn("accommodationType")
+  })
+}

--- a/src/api/models/form.ts
+++ b/src/api/models/form.ts
@@ -149,7 +149,12 @@ class Form extends BaseModel {
     }
 
     if (include.includes("stops")) {
-      const stops = await db("stops").where({ taid: formId })
+      const stops = await db("stops")
+        .where({ taid: formId })
+        .orderBy([
+          { column: "departureDate", order: "asc" },
+          { column: "departureTime", order: "asc" },
+        ])
       form.stops = stops
     }
 

--- a/src/api/models/stop.ts
+++ b/src/api/models/stop.ts
@@ -3,19 +3,21 @@ import BaseModel from "./base-model"
 export class Stop extends BaseModel {
   id: number
   taid: number // TODO: taid === forms.id, rename this column to form_id
-  locationId?: number | null
-  departureDate?: Date | null
-  departureTime?: string | null
-  transport?: string | null
+  locationId: number | null
+  departureDate: Date | null
+  departureTime: string | null
+  transport: string | null
+  accommodationType: string | null
 
   constructor(attributes: Pick<Stop, "id" | "taid"> & Partial<Stop>) {
     super()
     this.id = attributes.id
     this.taid = attributes.taid
-    this.locationId = attributes.locationId
-    this.departureDate = attributes.departureDate
-    this.departureTime = attributes.departureTime
-    this.transport = attributes.transport
+    this.locationId = attributes.locationId || null
+    this.departureDate = attributes.departureDate || null
+    this.departureTime = attributes.departureTime || null
+    this.transport = attributes.transport || null
+    this.accommodationType = attributes.accommodationType || null
   }
 }
 

--- a/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
+++ b/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
@@ -19,7 +19,9 @@
 </template>
 
 <script>
-const ACCOMMODATION_TYPES = Object.freeze({
+import { isNil } from "lodash"
+
+export const ACCOMMODATION_TYPES = Object.freeze({
   HOTEL: "Hotel",
   PRIVATE: "Private",
   OTHER: "Other:",
@@ -47,7 +49,7 @@ export default {
     }
   },
   mounted() {
-    if (this.accommodationTypes.includes(this.value)) {
+    if (isNil(this.value) || this.accommodationTypes.includes(this.value)) {
       this.accommodationType = this.value
     } else {
       this.accommodationType = ACCOMMODATION_TYPES.OTHER

--- a/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
+++ b/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-row>
+    <v-col
+      cols="12"
+      md="6"
+    >
+      <v-select
+        :value="accommodationType"
+        :items="accommodationTypes"
+        label="Type of Accommodation"
+        v-bind="$attrs"
+        @input="updateAccommodationType"
+      ></v-select>
+    </v-col>
+    <v-col
+      cols="12"
+      md="6"
+    >
+      <v-text-field
+        v-if="accommodationType === ACCOMMODATION_TYPES.OTHER"
+        :value="accommodationTypeOther"
+        label="Type of Accommodation - Other:"
+        v-bind="$attrs"
+        @input="updateAccommodationTypeOther"
+      ></v-text-field>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+const ACCOMMODATION_TYPES = Object.freeze({
+  HOTEL: "Hotel",
+  PRIVATE: "Private",
+  OTHER: "Other:",
+})
+
+export default {
+  name: "AccommodationTypeSelect",
+  inheritAttrs: false,
+  props: {
+    value: {
+      type: String,
+      default: ACCOMMODATION_TYPES.HOTEL,
+    },
+  },
+  data() {
+    return {
+      ACCOMMODATION_TYPES,
+      accommodationType: "",
+      accommodationTypeOther: "",
+      accommodationTypes: Object.values(ACCOMMODATION_TYPES),
+    }
+  },
+  mounted() {
+    if (this.accommodationTypes.includes(this.value)) {
+      this.accommodationType = this.value
+    } else {
+      this.accommodationType = ACCOMMODATION_TYPES.OTHER
+      this.accommodationTypeOther = this.value
+    }
+  },
+  methods: {
+    updateAccommodationType(value) {
+      if (value === ACCOMMODATION_TYPES.OTHER) {
+        this.$emit("input", this.accommodationTypeOther)
+      } else {
+        this.$emit("input", value)
+      }
+
+      this.accommodationType = value
+    },
+    updateAccommodationTypeOther(value) {
+      this.$emit("input", value)
+      this.accommodationTypeOther = value
+    },
+  },
+}
+</script>

--- a/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
+++ b/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
@@ -1,30 +1,21 @@
 <template>
-  <v-row>
-    <v-col
-      cols="12"
-      md="6"
-    >
-      <v-select
-        :value="accommodationType"
-        :items="accommodationTypes"
-        :label="label"
-        v-bind="$attrs"
-        @input="updateAccommodationType"
-      ></v-select>
-    </v-col>
-    <v-col
-      cols="12"
-      md="6"
-    >
-      <v-text-field
-        v-if="accommodationType === ACCOMMODATION_TYPES.OTHER"
-        :value="accommodationTypeOther"
-        :label="`${label} - Other:`"
-        v-bind="$attrs"
-        @input="updateAccommodationTypeOther"
-      ></v-text-field>
-    </v-col>
-  </v-row>
+  <div class="d-inlin-flex d-md-flex">
+    <v-select
+      :value="accommodationType"
+      :items="accommodationTypes"
+      :label="label"
+      class="mr-md-4"
+      v-bind="$attrs"
+      @input="updateAccommodationType"
+    ></v-select>
+    <v-text-field
+      v-if="accommodationType === ACCOMMODATION_TYPES.OTHER"
+      :value="accommodationTypeOther"
+      :label="`${label} - Other:`"
+      v-bind="$attrs"
+      @input="updateAccommodationTypeOther"
+    ></v-text-field>
+  </div>
 </template>
 
 <script>

--- a/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
+++ b/src/web/src/modules/travelForm/components/AccommodationTypeSelect.vue
@@ -7,7 +7,7 @@
       <v-select
         :value="accommodationType"
         :items="accommodationTypes"
-        label="Type of Accommodation"
+        :label="label"
         v-bind="$attrs"
         @input="updateAccommodationType"
       ></v-select>
@@ -19,7 +19,7 @@
       <v-text-field
         v-if="accommodationType === ACCOMMODATION_TYPES.OTHER"
         :value="accommodationTypeOther"
-        label="Type of Accommodation - Other:"
+        :label="`${label} - Other:`"
         v-bind="$attrs"
         @input="updateAccommodationTypeOther"
       ></v-text-field>
@@ -41,6 +41,10 @@ export default {
     value: {
       type: String,
       default: ACCOMMODATION_TYPES.HOTEL,
+    },
+    label: {
+      type: String,
+      default: "Type of Accommodation",
     },
   },
   data() {

--- a/src/web/src/modules/travelForm/components/TravelMethodSelect.vue
+++ b/src/web/src/modules/travelForm/components/TravelMethodSelect.vue
@@ -1,0 +1,86 @@
+<template>
+  <v-row>
+    <v-col
+      cols="12"
+      md="6"
+    >
+      <v-select
+        :value="travelMethod"
+        :items="travelMethods"
+        :label="label"
+        v-bind="$attrs"
+        @change="updateFromTravelMethod"
+      ></v-select>
+    </v-col>
+    <v-col
+      cols="12"
+      md="6"
+    >
+      <v-text-field
+        v-if="travelMethod === TRAVEL_METHODS.OTHER"
+        v-model="travelMethodOther"
+        :label="`${label} - Other:`"
+        v-bind="$attrs"
+        @change="updateFromTravelMethodOther"
+      ></v-text-field>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+// TODO: load from back-end?
+const TRAVEL_METHODS = Object.freeze({
+  AIRCRAFT: "Aircraft",
+  POOL_VEHICLE: "Pool Vehicle",
+  PERSONAL_VEHICLE: "Personal Vehicle",
+  RENTAL_VEHICLE: "Rental Vehicle",
+  BUS: "Bus",
+  OTHER: "Other:",
+})
+
+export default {
+  name: "TravelMethodSelect",
+  inheritAttrs: false,
+  props: {
+    value: {
+      type: String,
+      default: TRAVEL_METHODS.AIRCRAFT,
+    },
+    label: {
+      type: String,
+      default: "Travel Method",
+    },
+  },
+  data() {
+    return {
+      TRAVEL_METHODS,
+      travelMethods: Object.values(TRAVEL_METHODS),
+      travelMethod: "",
+      travelMethodOther: "",
+    }
+  },
+  mounted() {
+    if (this.travelMethods.includes(this.value)) {
+      this.travelMethod = this.value
+    } else {
+      this.travelMethod = TRAVEL_METHODS.OTHER
+      this.travelMethodOther = this.value
+    }
+  },
+  methods: {
+    updateFromTravelMethod(value) {
+      if (value === TRAVEL_METHODS.OTHER) {
+        this.$emit("input", this.travelMethodOther)
+      } else {
+        this.$emit("input", value)
+      }
+
+      this.travelMethod = value
+    },
+    updateFromTravelMethodOther(value) {
+      this.$emit("input", value)
+      this.travelMethodOther = value
+    },
+  },
+}
+</script>

--- a/src/web/src/modules/travelForm/components/TravelMethodSelect.vue
+++ b/src/web/src/modules/travelForm/components/TravelMethodSelect.vue
@@ -1,30 +1,21 @@
 <template>
-  <v-row>
-    <v-col
-      cols="12"
-      md="6"
-    >
-      <v-select
-        :value="travelMethod"
-        :items="travelMethods"
-        :label="label"
-        v-bind="$attrs"
-        @change="updateFromTravelMethod"
-      ></v-select>
-    </v-col>
-    <v-col
-      cols="12"
-      md="6"
-    >
-      <v-text-field
-        v-if="travelMethod === TRAVEL_METHODS.OTHER"
-        v-model="travelMethodOther"
-        :label="`${label} - Other:`"
-        v-bind="$attrs"
-        @change="updateFromTravelMethodOther"
-      ></v-text-field>
-    </v-col>
-  </v-row>
+  <div class="d-inlin-flex d-md-flex">
+    <v-select
+      :value="travelMethod"
+      :items="travelMethods"
+      :label="label"
+      class="mr-md-4"
+      v-bind="$attrs"
+      @change="updateFromTravelMethod"
+    ></v-select>
+    <v-text-field
+      v-if="travelMethod === TRAVEL_METHODS.OTHER"
+      v-model="travelMethodOther"
+      :label="`${label} - Other:`"
+      v-bind="$attrs"
+      @change="updateFromTravelMethodOther"
+    ></v-text-field>
+  </div>
 </template>
 
 <script>

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -39,20 +39,6 @@
               @change="updateTripType"
             ></v-select>
           </v-col>
-          <v-col></v-col>
-          <v-col
-            cols="12"
-            md="5"
-          >
-            <AccommodationTypeSelect
-              v-model="currentForm.accommodationType"
-              :rules="[required]"
-              background-color="white"
-              dense
-              outlined
-              required
-            />
-          </v-col>
         </v-row>
 
         <RoundTripStopsSection v-if="tripType === TRIP_TYPES.ROUND_TRIP" />
@@ -111,7 +97,6 @@
 import { mapState, mapGetters } from "vuex"
 import { last } from "lodash"
 
-import AccommodationTypeSelect from "@/modules/travelForm/components/AccommodationTypeSelect"
 import DatePicker from "@/components/Utils/DatePicker"
 import MuliDestinationStopsSection from "./details-form-card/MuliDestinationStopsSection"
 import OneWayStopsSection from "./details-form-card/OneWayStopsSection"
@@ -126,7 +111,6 @@ const TRIP_TYPES = Object.freeze({
 export default {
   name: "DetailsFormCard",
   components: {
-    AccommodationTypeSelect,
     DatePicker,
     MuliDestinationStopsSection,
     OneWayStopsSection,

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -155,6 +155,10 @@ export default {
       }
 
       this.tripType = value
+
+      this.$nextTick(() => {
+        this.$refs.form.resetValidation()
+      })
     },
   },
 }

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -135,7 +135,7 @@ export default {
   data: () => ({
     TRIP_TYPES,
     tripTypes: Object.values(TRIP_TYPES),
-    tripType: TRIP_TYPES.ONE_WAY,
+    tripType: "",
     required: (v) => !!v || "This field is required",
     isNumber: (v) => v == 0 || Number.isInteger(Number(v)) || "This field must be a number",
   }),
@@ -145,6 +145,15 @@ export default {
     finalDestination() {
       return last(this.currentForm.stops) || { taid: this.currentFormId }
     },
+  },
+  mounted() {
+    if (this.currentForm.oneWayTrip) {
+      this.tripType = TRIP_TYPES.ONE_WAY
+    } else if (this.currentForm.multiStop) {
+      this.tripType = TRIP_TYPES.MULI_DESTINATION
+    } else {
+      this.tripType = TRIP_TYPES.ROUND_TRIP
+    }
   },
   methods: {
     updateTripType(value) {

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -67,7 +67,7 @@
           >
             <v-text-field
               v-model="currentForm.daysOffTravelStatus"
-              :rules="[required, isNumber]"
+              :rules="[isNumber]"
               label="Days on non-travel status"
               background-color="white"
               dense

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -42,36 +42,16 @@
           <v-col></v-col>
           <v-col
             cols="12"
-            md="2"
+            md="5"
           >
-            <!-- If accommodation type is other, support text field entry -->
-            <v-select
-              :value="accommodationType"
-              :items="accommodationTypes"
+            <AccommodationTypeSelect
+              v-model="currentForm.accommodationType"
               :rules="[required]"
-              label="Type of Accommodation"
               background-color="white"
               dense
               outlined
               required
-              @input="updateAccommodationType"
-            ></v-select>
-          </v-col>
-          <v-col
-            cols="12"
-            md="3"
-          >
-            <v-text-field
-              v-if="accommodationType === ACCOMMODATION_TYPES.OTHER"
-              :value="accommodationTypeOther"
-              :rules="[required]"
-              label="Type of Accommodation - Other:"
-              background-color="white"
-              dense
-              outlined
-              required
-              @input="updateAccommodationTypeOther"
-            ></v-text-field>
+            />
           </v-col>
         </v-row>
 
@@ -129,12 +109,13 @@
 
 <script>
 import { mapState, mapGetters } from "vuex"
-import { isEmpty, last } from "lodash"
+import { last } from "lodash"
 
+import AccommodationTypeSelect from "@/modules/travelForm/components/AccommodationTypeSelect"
 import DatePicker from "@/components/Utils/DatePicker"
-import RoundTripStopsSection from "./details-form-card/RoundTripStopsSection"
-import OneWayStopsSection from "./details-form-card/OneWayStopsSection"
 import MuliDestinationStopsSection from "./details-form-card/MuliDestinationStopsSection"
+import OneWayStopsSection from "./details-form-card/OneWayStopsSection"
+import RoundTripStopsSection from "./details-form-card/RoundTripStopsSection"
 
 const TRIP_TYPES = Object.freeze({
   ROUND_TRIP: "Round Trip",
@@ -142,25 +123,16 @@ const TRIP_TYPES = Object.freeze({
   MULI_DESTINATION: "Muli-Destination",
 })
 
-const ACCOMMODATION_TYPES = Object.freeze({
-  HOTEL: "Hotel",
-  PRIVATE: "Private",
-  OTHER: "Other:",
-})
-
 export default {
   name: "DetailsFormCard",
   components: {
+    AccommodationTypeSelect,
     DatePicker,
     MuliDestinationStopsSection,
     OneWayStopsSection,
     RoundTripStopsSection,
   },
   data: () => ({
-    ACCOMMODATION_TYPES,
-    accommodationType: ACCOMMODATION_TYPES.HOTEL,
-    accommodationTypeOther: "",
-    accommodationTypes: Object.values(ACCOMMODATION_TYPES),
     TRIP_TYPES,
     tripTypes: Object.values(TRIP_TYPES),
     tripType: TRIP_TYPES.ONE_WAY,
@@ -174,25 +146,7 @@ export default {
       return last(this.currentForm.stops) || { taid: this.currentFormId }
     },
   },
-  async mounted() {
-    if (isEmpty(this.currentForm.accommodationType)) {
-      this.currentForm.accommodationType = ACCOMMODATION_TYPES.HOTEL
-    }
-  },
   methods: {
-    updateAccommodationType(value) {
-      if (value === ACCOMMODATION_TYPES.OTHER) {
-        this.currentForm.accommodationType = this.accommodationTypeOther
-      } else {
-        this.currentForm.accommodationType = value
-      }
-
-      this.accommodationType = value
-    },
-    updateAccommodationTypeOther(value) {
-      this.currentForm.accommodationType = value
-      this.accommodationTypeOther = value
-    },
     updateTripType(value) {
       if (value === TRIP_TYPES.ROUND_TRIP) {
         this.currentForm.oneWayTrip = false

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/MuliDestinationStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/MuliDestinationStopsSection.vue
@@ -57,35 +57,17 @@
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="4"
       >
-        <v-select
-          :value="stop1TravelMethod"
-          :items="travelMethods"
+        <TravelMethodSelect
+          v-model="stop1.transport"
           :rules="[required]"
-          label="Travel Method"
           background-color="white"
           dense
           persistent-hint
           required
           outlined
-          @change="updateStop1TravelMethod"
-        ></v-select>
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          v-if="stop1TravelMethod === TRAVEL_METHODS.OTHER"
-          v-model="stop1.transport"
-          :rules="[required]"
-          label="Travel Method - Other:"
-          background-color="white"
-          dense
-          outlined
-          required
-        ></v-text-field>
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -145,35 +127,17 @@
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="4"
       >
-        <v-select
-          :value="stop2TravelMethod"
-          :items="travelMethods"
+        <TravelMethodSelect
+          v-model="stop2.transport"
           :rules="[required]"
-          label="Travel Method"
           background-color="white"
           dense
           persistent-hint
           required
           outlined
-          @change="updateStop2TravelMethod"
-        ></v-select>
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          v-if="stop2TravelMethod === TRAVEL_METHODS.OTHER"
-          v-model="stop2.transport"
-          :rules="[required]"
-          label="Travel Method - Other:"
-          background-color="white"
-          dense
-          outlined
-          required
-        ></v-text-field>
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -233,35 +197,17 @@
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="4"
       >
-        <v-select
-          :value="stop3TravelMethod"
-          :items="travelMethods"
+        <TravelMethodSelect
+          v-model="stop3.transport"
           :rules="[required]"
-          label="Travel Method"
           background-color="white"
           dense
           persistent-hint
           required
           outlined
-          @change="updateStop3TravelMethod"
-        ></v-select>
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          v-if="stop3TravelMethod === TRAVEL_METHODS.OTHER"
-          v-model="stop3.transport"
-          :rules="[required]"
-          label="Travel Method - Other:"
-          background-color="white"
-          dense
-          outlined
-          required
-        ></v-text-field>
+        />
       </v-col>
     </v-row>
   </div>
@@ -271,33 +217,19 @@
 import { mapActions, mapState, mapGetters } from "vuex"
 import { isArray, isEmpty } from "lodash"
 
+import { required } from "@/utils/validators"
+
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
-
-// TODO: abstract this to a shared helper
-const TRAVEL_METHODS = Object.freeze({
-  AIRCRAFT: "Aircraft",
-  POOL_VEHICLE: "Pool Vehicle",
-  PERSONAL_VEHICLE: "Personal Vehicle",
-  RENTAL_VEHICLE: "Rental Vehicle",
-  BUS: "Bus",
-  OTHER: "Other:",
-})
+import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSelect"
 
 export default {
   name: "MuliDestinationStopsSection",
   components: {
     DatePicker,
     TimePicker,
+    TravelMethodSelect,
   },
-  data: () => ({
-    required: (v) => !!v || "This field is required",
-    stop1TravelMethod: TRAVEL_METHODS.AIRCRAFT,
-    stop2TravelMethod: TRAVEL_METHODS.AIRCRAFT,
-    stop3TravelMethod: TRAVEL_METHODS.AIRCRAFT,
-    TRAVEL_METHODS,
-    travelMethods: Object.values(TRAVEL_METHODS),
-  }),
   computed: {
     ...mapState("travelForm", ["currentForm"]),
     ...mapGetters("travelForm", ["currentFormId", "destinationsByCurrentFormTravelRestriction"]),
@@ -351,35 +283,9 @@ export default {
   },
   methods: {
     ...mapActions("travelForm", ["loadDestinations"]),
+    required,
     newStop() {
       return { taid: this.currentFormId }
-    },
-    updateStop1TravelMethod(value) {
-      this.stop1TravelMethod = value
-
-      if (value === TRAVEL_METHODS.OTHER) {
-        this.stop1.transport = ""
-      } else {
-        this.stop1.transport = value
-      }
-    },
-    updateStop2TravelMethod(value) {
-      this.stop2TravelMethod = value
-
-      if (value === TRAVEL_METHODS.OTHER) {
-        this.stop2.transport = ""
-      } else {
-        this.stop2.transport = value
-      }
-    },
-    updateStop3TravelMethod(value) {
-      this.stop3TravelMethod = value
-
-      if (value === TRAVEL_METHODS.OTHER) {
-        this.stop3.transport = ""
-      } else {
-        this.stop3.transport = value
-      }
     },
   },
 }

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/MuliDestinationStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/MuliDestinationStopsSection.vue
@@ -68,6 +68,14 @@
           required
           outlined
         />
+        <AccommodationTypeSelect
+          v-model="stop1.accommodationType"
+          :rules="[required]"
+          background-color="white"
+          dense
+          outlined
+          required
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -137,6 +145,14 @@
           persistent-hint
           required
           outlined
+        />
+        <AccommodationTypeSelect
+          v-model="stop2.accommodationType"
+          :rules="[required]"
+          background-color="white"
+          dense
+          outlined
+          required
         />
       </v-col>
     </v-row>
@@ -208,6 +224,14 @@
           required
           outlined
         />
+        <AccommodationTypeSelect
+          v-model="stop3.accommodationType"
+          :rules="[required]"
+          background-color="white"
+          dense
+          outlined
+          required
+        />
       </v-col>
     </v-row>
   </div>
@@ -219,6 +243,7 @@ import { isArray, isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
+import AccommodationTypeSelect from "@/modules/travelForm/components/AccommodationTypeSelect"
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
 import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSelect"
@@ -226,6 +251,7 @@ import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSele
 export default {
   name: "MuliDestinationStopsSection",
   components: {
+    AccommodationTypeSelect,
     DatePicker,
     TimePicker,
     TravelMethodSelect,

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -57,35 +57,17 @@
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="4"
       >
-        <v-select
-          :value="fromTravelMethod"
-          :items="travelMethods"
+        <TravelMethodSelect
+          v-model="from.transport"
           :rules="[required]"
-          label="Travel Method"
           background-color="white"
           dense
           persistent-hint
           required
           outlined
-          @change="updateFromTravelMethod"
-        ></v-select>
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          v-if="fromTravelMethod === TRAVEL_METHODS.OTHER"
-          v-model="from.transport"
-          :rules="[required]"
-          label="Travel Method - Other:"
-          background-color="white"
-          dense
-          outlined
-          required
-        ></v-text-field>
+        />
       </v-col>
     </v-row>
   </div>
@@ -95,31 +77,19 @@
 import { mapActions, mapState, mapGetters } from "vuex"
 import { isArray, isEmpty } from "lodash"
 
+import { required } from "@/utils/validators"
+
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
-
-// TODO: abstract this to a shared helper
-const TRAVEL_METHODS = Object.freeze({
-  AIRCRAFT: "Aircraft",
-  POOL_VEHICLE: "Pool Vehicle",
-  PERSONAL_VEHICLE: "Personal Vehicle",
-  RENTAL_VEHICLE: "Rental Vehicle",
-  BUS: "Bus",
-  OTHER: "Other:",
-})
+import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSelect"
 
 export default {
   name: "OneWayStopsSection",
   components: {
     DatePicker,
     TimePicker,
+    TravelMethodSelect,
   },
-  data: () => ({
-    required: (v) => !!v || "This field is required",
-    fromTravelMethod: TRAVEL_METHODS.AIRCRAFT,
-    TRAVEL_METHODS,
-    travelMethods: Object.values(TRAVEL_METHODS),
-  }),
   computed: {
     ...mapState("travelForm", ["currentForm"]),
     ...mapGetters("travelForm", ["currentFormId", "destinationsByCurrentFormTravelRestriction"]),
@@ -152,17 +122,9 @@ export default {
   },
   methods: {
     ...mapActions("travelForm", ["loadDestinations"]),
+    required,
     newStop() {
       return { taid: this.currentFormId }
-    },
-    updateFromTravelMethod(value) {
-      this.fromTravelMethod = value
-
-      if (value === TRAVEL_METHODS.OTHER) {
-        this.from.transport = ""
-      } else {
-        this.from.transport = value
-      }
     },
   },
 }

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -68,6 +68,14 @@
           required
           outlined
         />
+        <AccommodationTypeSelect
+          v-model="from.accommodationType"
+          :rules="[required]"
+          background-color="white"
+          dense
+          outlined
+          required
+        />
       </v-col>
     </v-row>
   </div>
@@ -79,6 +87,7 @@ import { isArray, isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
+import AccommodationTypeSelect from "@/modules/travelForm/components/AccommodationTypeSelect"
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
 import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSelect"
@@ -86,6 +95,7 @@ import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSele
 export default {
   name: "OneWayStopsSection",
   components: {
+    AccommodationTypeSelect,
     DatePicker,
     TimePicker,
     TravelMethodSelect,

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -148,11 +148,13 @@
         />
         <AccommodationTypeSelect
           v-model="to.accommodationType"
-          :rules="[required]"
           background-color="white"
+          hint="Optional, set only if neccessary"
+          placeholder="N/A"
+          clearable
           dense
           outlined
-          required
+          persistent-hint
         />
       </v-col>
     </v-row>

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -57,35 +57,17 @@
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="4"
       >
-        <v-select
-          :value="fromTravelMethod"
-          :items="travelMethods"
+        <TravelMethodSelect
+          v-model="from.transport"
           :rules="[required]"
-          label="Travel Method"
           background-color="white"
           dense
           persistent-hint
           required
           outlined
-          @change="updateFromTravelMethod"
-        ></v-select>
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          v-if="fromTravelMethod === TRAVEL_METHODS.OTHER"
-          v-model="from.transport"
-          :rules="[required]"
-          label="Travel Method - Other:"
-          background-color="white"
-          dense
-          outlined
-          required
-        ></v-text-field>
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -145,35 +127,17 @@
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="4"
       >
-        <v-select
-          :value="toTravelMethod"
-          :items="travelMethods"
+        <TravelMethodSelect
+          v-model="to.transport"
           :rules="[required]"
-          label="Travel Method"
           background-color="white"
           dense
           persistent-hint
           required
           outlined
-          @change="updateToTravelMethod"
-        ></v-select>
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          v-if="toTravelMethod === TRAVEL_METHODS.OTHER"
-          v-model="to.transport"
-          :rules="[required]"
-          label="Travel Method - Other:"
-          background-color="white"
-          dense
-          outlined
-          required
-        ></v-text-field>
+        />
       </v-col>
     </v-row>
   </div>
@@ -183,32 +147,19 @@
 import { mapActions, mapState, mapGetters } from "vuex"
 import { isArray, isEmpty } from "lodash"
 
+import { required } from "@/utils/validators"
+
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
-
-// TODO: abstract this to a shared helper
-const TRAVEL_METHODS = Object.freeze({
-  AIRCRAFT: "Aircraft",
-  POOL_VEHICLE: "Pool Vehicle",
-  PERSONAL_VEHICLE: "Personal Vehicle",
-  RENTAL_VEHICLE: "Rental Vehicle",
-  BUS: "Bus",
-  OTHER: "Other:",
-})
+import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSelect"
 
 export default {
   name: "RoundTripStopsSection",
   components: {
     DatePicker,
     TimePicker,
+    TravelMethodSelect,
   },
-  data: () => ({
-    required: (v) => !!v || "This field is required",
-    TRAVEL_METHODS,
-    toTravelMethod: TRAVEL_METHODS.AIRCRAFT,
-    fromTravelMethod: TRAVEL_METHODS.AIRCRAFT,
-    travelMethods: Object.values(TRAVEL_METHODS),
-  }),
   computed: {
     ...mapState("travelForm", ["currentForm"]),
     ...mapGetters("travelForm", ["currentFormId", "destinationsByCurrentFormTravelRestriction"]),
@@ -241,26 +192,9 @@ export default {
   },
   methods: {
     ...mapActions("travelForm", ["loadDestinations"]),
+    required,
     newStop() {
       return { taid: this.currentFormId }
-    },
-    updateFromTravelMethod(value) {
-      this.fromTravelMethod = value
-
-      if (value === TRAVEL_METHODS.OTHER) {
-        this.from.transport = ""
-      } else {
-        this.from.transport = value
-      }
-    },
-    updateToTravelMethod(value) {
-      this.toTravelMethod = value
-
-      if (value === TRAVEL_METHODS.OTHER) {
-        this.to.transport = ""
-      } else {
-        this.to.transport = value
-      }
     },
   },
 }

--- a/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/src/web/src/modules/travelForm/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -68,6 +68,14 @@
           required
           outlined
         />
+        <AccommodationTypeSelect
+          v-model="from.accommodationType"
+          :rules="[required]"
+          background-color="white"
+          dense
+          outlined
+          required
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -138,6 +146,14 @@
           required
           outlined
         />
+        <AccommodationTypeSelect
+          v-model="to.accommodationType"
+          :rules="[required]"
+          background-color="white"
+          dense
+          outlined
+          required
+        />
       </v-col>
     </v-row>
   </div>
@@ -149,6 +165,7 @@ import { isArray, isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
+import AccommodationTypeSelect from "@/modules/travelForm/components/AccommodationTypeSelect"
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
 import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSelect"
@@ -156,6 +173,7 @@ import TravelMethodSelect from "@/modules/travelForm/components/TravelMethodSele
 export default {
   name: "RoundTripStopsSection",
   components: {
+    AccommodationTypeSelect,
     DatePicker,
     TimePicker,
     TravelMethodSelect,


### PR DESCRIPTION
Analysis
- [Modeling, Per-Stop Accommodation Selection, 2023-10-10](https://docs.google.com/document/d/1jb4pDv-4GpfAwjSREc5RYMiiM7mCCGN1S-Zd3ajujrM/edit?pli=1)

# User Story

As a user,
I want to specify the type of accommodation for each stop in a travel request,
So that I can generate an accurate expense estimate for each trip segment, ensuring a well-planned and budgeted journey.

# Context

Q. Is the "Type of Accommodation" field per-stop, or a single use field for the whole travel request?
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/7d528cd3-d736-4114-9857-f9315e602dd7)


A. Well that is a good question...I was thinking that there would only be one accommodation per request. But now that I think of it each stop could have an accommodation.  The last stop or the return flight will should not have an accommodation.  So maybe in the drop down we add N/A and the last stop on the trip should default to N/A... Give them the ability to overide this though.

# Implementation

Move `accommodationType` from the `forms` table to the `stops` table.
Build an "Accommodation Type Select" component that handles standard, and "Other:" option.
Build a "Travel Method Select" component that handles standard, and "Other:" option.

# Screenshots

One Way
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/9513ad9b-eb0b-4704-9ba6-1aeed3806d27)

Round Trip
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/c9c30872-cc05-4d81-9bc0-610858e9c12c)

Multi-Destination
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/0526813d-3d0e-4f0d-8961-6d4aaf0ad370)

# Testing Instructions

1. Boot the database via `dev up`
2. Boot the api service via `cd src/api && npm run start`
3. Boot the web service via `cd src/web && npm run start`
4. Go to http://localhost:8080/my-travel-requests and log in.
5. Click on a "Draft" submission, or create one as needed through the "+ Travel Authorization" button.
6. Scroll down to the "Details" section, check that you can now set a "Type of Accommodation" on a per-stop basis.
7. Check that this works for the "Round Trip", "One Way", and "Multi-Destination" trip types.
8. Check that the "Round Trip" has an optional final field for "Type of Accommodation"