### PR TITLE
Add Relative Path Support To Api Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@
 
 4. Start the application via `npm start`
 
+   > If you have the `dev` command you can also boot via `dev up_api` from the root directory.
+
 5. Access the api, by logging in to the front-end, then going to http://localhost:3000
 
 ### Web Service (a.k.a. front-end)
@@ -88,6 +90,8 @@
 2. Install the project using `npm install`
 
 3. Start the application via `npm start`
+
+   > If you have the `dev` command you can also boot via `dev up_web` from the root directory.
 
 4. Log in to the front-end service at http://localhost:8080
 
@@ -187,10 +191,14 @@ Files:
 
    - [ ] TODO: investigate if custom environment variables are needed
 
-2. Build and boot the production image via
+2. Duplicate the `.env.production` file to `.env` in the top level directory.
+
+3. TODO: figutre out the relevant environment variables to support login
+
+4. Build and boot the production image via
 
    ```bash
    docker compose up --build
    ```
 
-3. Go to http://localhost:3000/ and check that you can log in and use the application.
+5. Go to http://localhost:8088/ and check that you can log in and use the application.

--- a/bin/dev
+++ b/bin/dev
@@ -72,6 +72,10 @@ class DevHelper
     compose(*%w[exec dbpostgres], *args, **kwargs)
   end
 
+  def ts_node(*args, **kwargs)
+    exec("cd #{project_root}/src/api && npm run ts-node")
+  end
+
   def ownit(*args, **kwargs)
     file_or_directory = args[0]
     raise ScriptError, "Must provide a file or directory path." if file_or_directory.nil?

--- a/bin/dev
+++ b/bin/dev
@@ -64,6 +64,14 @@ class DevHelper
   end
 
   # Custom helpers
+  def up_api(*args, **kwargs)
+    exec("cd #{project_root}/src/api && npm run start")
+  end
+
+  def up_web(*args, **kwargs)
+    exec("cd #{project_root}/src/web && npm run start")
+  end
+
   def psql(*args, **kwargs)
     db(*%w[psql "postgresql://user:itsallgood@localhost:5432/travel"], *args, **kwargs)
   end

--- a/src/api/controllers/README.md
+++ b/src/api/controllers/README.md
@@ -36,7 +36,7 @@ src/
 
 ```typescript
 // src/api/controllers/forms/estimates/generate-controller.ts
-import BaseController from "../../base-controller"
+import BaseController from "@/base-controller"
 
 export class GenerateController extends BaseController {
   static create() {
@@ -70,7 +70,7 @@ export { forms }
 // src/api/routes/index.ts
 import { Router } from "express"
 
-import { forms } from "../controllers"
+import { forms } from "@/controllers"
 
 const router = Router()
 

--- a/src/api/controllers/base-controller.ts
+++ b/src/api/controllers/base-controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express"
 
-import User from "../models/user"
+import User from "@/models/user"
 
 export type Actions = "index" | "show" | "new" | "edit" | "create" | "update" | "destroy"
 

--- a/src/api/controllers/expenses-controller.ts
+++ b/src/api/controllers/expenses-controller.ts
@@ -2,10 +2,10 @@ import { isNil } from "lodash"
 
 import BaseController from "./base-controller"
 
-import { Expense, Form } from "../models"
-import { ExpensesPolicy } from "../policies"
-import { ExpensesSerializer } from "../serializers"
-import { ExpensesService } from "../services"
+import { Expense, Form } from "@/models"
+import { ExpensesPolicy } from "@/policies"
+import { ExpensesSerializer } from "@/serializers"
+import { ExpensesService } from "@/services"
 
 export class ExpensesController extends BaseController {
   index() {

--- a/src/api/controllers/forms-controller.ts
+++ b/src/api/controllers/forms-controller.ts
@@ -2,10 +2,10 @@ import { isNil } from "lodash"
 
 import BaseController from "./base-controller"
 
-import { AuditService, FormsService } from "../services"
-import { Form } from "../models"
-import { FormsSerializer } from "../serializers"
-import { FormsPolicy } from "../policies"
+import { AuditService, FormsService } from "@/services"
+import { Form } from "@/models"
+import { FormsSerializer } from "@/serializers"
+import { FormsPolicy } from "@/policies"
 
 // TODO: push this code back into services where it belongs
 const auditService = new AuditService()

--- a/src/api/controllers/forms/estimates/generate-controller.ts
+++ b/src/api/controllers/forms/estimates/generate-controller.ts
@@ -1,8 +1,8 @@
-import BaseController from "../../base-controller"
+import BaseController from "@/controllers/base-controller"
 
-import { Expense, Form } from "../../../models"
-import { ExpensesPolicy } from "../../../policies"
-import { BulkGenerate } from "../../../services/estimates"
+import { Expense, Form } from "@/models"
+import { ExpensesPolicy } from "@/policies"
+import { BulkGenerate } from "@/services/estimates"
 
 export class GenerateController extends BaseController {
   async create() {

--- a/src/api/controllers/pre-approved-travel-requests-controller.ts
+++ b/src/api/controllers/pre-approved-travel-requests-controller.ts
@@ -1,6 +1,6 @@
 import BaseController from "./base-controller"
 
-import { Preapproved } from "../models"
+import { Preapproved } from "@/models"
 
 export class PreApprovedTravelRequestsController extends BaseController {
   index() {

--- a/src/api/controllers/pre-approved-travelers-controller.ts
+++ b/src/api/controllers/pre-approved-travelers-controller.ts
@@ -1,6 +1,6 @@
 import BaseController from "./base-controller"
 
-import { PreapprovedTraveler } from "../models"
+import { PreapprovedTraveler } from "@/models"
 
 export class PreApprovedTravelersController extends BaseController {
   index() {

--- a/src/api/data/index.ts
+++ b/src/api/data/index.ts
@@ -1,5 +1,5 @@
 import * as knex from "knex";
-import { DB_CONFIG } from "../config";
+import { DB_CONFIG } from "@/config";
 
 export * from "./migrator";
 /*

--- a/src/api/db/db-client-legacy.ts
+++ b/src/api/db/db-client-legacy.ts
@@ -1,6 +1,6 @@
 import knex from "knex"
 
-import { DB_CONFIG, NODE_ENV } from "../config"
+import { DB_CONFIG, NODE_ENV } from "@/config"
 
 export const db = knex(DB_CONFIG)
 

--- a/src/api/db/db-client.ts
+++ b/src/api/db/db-client.ts
@@ -1,6 +1,6 @@
 import { Sequelize, Options } from "sequelize"
 
-import { DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER, NODE_ENV } from "../config"
+import { DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER, NODE_ENV } from "@/config"
 
 if (DB_NAME === undefined) throw new Error("database name is unset.")
 if (DB_USER === undefined) throw new Error("database username is unset.")

--- a/src/api/middleware/authz.middleware.ts
+++ b/src/api/middleware/authz.middleware.ts
@@ -2,8 +2,8 @@ import { NextFunction, Request, Response } from "express";
 import jwt from "express-jwt";
 import axios from "axios";
 import jwksRsa from "jwks-rsa";
-import { AUTH0_DOMAIN, AUTH0_AUDIENCE } from "../config";
-import { UserService } from "../services";
+import { AUTH0_DOMAIN, AUTH0_AUDIENCE } from "@/config";
+import { UserService } from "@/services";
 
 console.log("AUTH0_DOMAIN", `${AUTH0_DOMAIN}/.well-known/jwks.json`);
 

--- a/src/api/middleware/index.ts
+++ b/src/api/middleware/index.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
-import { DB_HOST } from "../config";
+import { DB_HOST } from "@/config";
 
 export function RequiresAuthentication(req: Request, res: Response, next: NextFunction) {
   if (req.isAuthenticated()) {

--- a/src/api/models/destination.ts
+++ b/src/api/models/destination.ts
@@ -6,7 +6,7 @@ import {
   Model,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 
 export class Destination extends Model<
   InferAttributes<Destination>,

--- a/src/api/models/distance-matrix.ts
+++ b/src/api/models/distance-matrix.ts
@@ -6,7 +6,7 @@ import {
   Model,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 
 export class DistanceMatrix extends Model<
   InferAttributes<DistanceMatrix>,

--- a/src/api/models/expense.ts
+++ b/src/api/models/expense.ts
@@ -12,7 +12,7 @@ import {
   NonAttribute,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 
 import Form from "./form"
 

--- a/src/api/models/form.ts
+++ b/src/api/models/form.ts
@@ -20,7 +20,7 @@ import {
   NonAttribute,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 import Expense, { Types as ExpenseVariants } from "./expense"
 import Stop from "./stop"
 import TravelPurpose from "./travel-purpose"

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -1,4 +1,4 @@
-import db from "../db/db-client"
+import db from "@/db/db-client"
 
 import Stop from "./stop"
 import Expense from "./expense"

--- a/src/api/models/per-diem.ts
+++ b/src/api/models/per-diem.ts
@@ -6,7 +6,7 @@ import {
   Model,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 
 export enum ClaimTypes {
   LUNCH = "Lunch",

--- a/src/api/models/preapproved-traveler.ts
+++ b/src/api/models/preapproved-traveler.ts
@@ -1,6 +1,6 @@
 import { keyBy } from "lodash"
 
-import db from "../db/db-client-legacy"
+import db from "@/db/db-client-legacy"
 
 import BaseModel from "./base-model"
 import Preapproved from "./preapproved"

--- a/src/api/models/preapproved.ts
+++ b/src/api/models/preapproved.ts
@@ -1,6 +1,6 @@
 import { groupBy } from "lodash"
 
-import db from "../db/db-client-legacy"
+import db from "@/db/db-client-legacy"
 
 import BaseModel from "./base-model"
 import PreapprovedTraveler from "./preapproved-traveler"

--- a/src/api/models/stop.ts
+++ b/src/api/models/stop.ts
@@ -13,7 +13,7 @@ import {
   NonAttribute,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 
 import Destination from "./destination"
 import Form from "./form"

--- a/src/api/models/travel-purpose.ts
+++ b/src/api/models/travel-purpose.ts
@@ -6,7 +6,7 @@ import {
   CreationOptional,
 } from "sequelize"
 
-import sequelize from "../db/db-client"
+import sequelize from "@/db/db-client"
 
 export class TravelPurpose extends Model<
   InferAttributes<TravelPurpose>,

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -49,6 +49,8 @@
         "@types/uuid": "^8.3.4",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
+        "tsc-alias": "^1.8.8",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^4.7.4"
       }
     },
@@ -575,6 +577,41 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
@@ -1230,6 +1267,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.2",
@@ -1941,6 +1987,18 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
@@ -2370,6 +2428,31 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2643,6 +2726,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -2903,6 +3006,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -3296,6 +3408,18 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -3639,12 +3763,34 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -3996,6 +4142,19 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
     },
     "node_modules/mysql": {
       "version": "2.18.1",
@@ -4455,6 +4614,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pg": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
@@ -4558,6 +4726,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/postcss": {
@@ -4698,6 +4878,35 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -4857,6 +5066,16 @@
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4869,6 +5088,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -5150,6 +5392,15 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -5660,6 +5911,23 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/tsc-alias": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.8.tgz",
+      "integrity": "sha512-OYUOd2wl0H858NvABWr/BoSKNERw3N9GTi3rHPK8Iv4O1UyUXIrTTOAZNHsjlVpXFOhpJBVARI1s+rzwLivN3Q==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      }
+    },
     "node_modules/tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -5670,6 +5938,20 @@
         "@types/strip-json-comments": "0.0.30",
         "strip-bom": "^3.0.0",
         "strip-json-comments": "^2.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -6474,6 +6756,32 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@npmcli/fs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
@@ -7047,6 +7355,12 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "arraybuffer.prototype.slice": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
@@ -7567,6 +7881,15 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
@@ -7915,6 +8238,28 @@
         "validator": "^13.9.0"
       }
     },
+    "fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -8101,6 +8446,20 @@
         "define-properties": "^1.1.3"
       }
     },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -8281,6 +8640,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -8553,6 +8918,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -8828,10 +9199,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -9104,6 +9491,12 @@
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
         }
       }
+    },
+    "mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true
     },
     "mysql": {
       "version": "2.18.1",
@@ -9438,6 +9831,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "pg": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
@@ -9517,6 +9916,15 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "requires": {
+        "queue-lit": "^1.5.1"
+      }
     },
     "postcss": {
       "version": "8.4.29",
@@ -9612,6 +10020,18 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -9731,12 +10151,27 @@
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-array-concat": {
@@ -9928,6 +10363,12 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "smart-buffer": {
       "version": "4.2.0",
@@ -10283,6 +10724,20 @@
         }
       }
     },
+    "tsc-alias": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.8.tgz",
+      "integrity": "sha512-OYUOd2wl0H858NvABWr/BoSKNERw3N9GTi3rHPK8Iv4O1UyUXIrTTOAZNHsjlVpXFOhpJBVARI1s+rzwLivN3Q==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      }
+    },
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -10293,6 +10748,17 @@
         "@types/strip-json-comments": "0.0.30",
         "strip-bom": "^3.0.0",
         "strip-json-comments": "^2.0.0"
+      }
+    },
+    "tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "tslib": {

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -4,11 +4,9 @@
   "description": "API for YHSI Application",
   "main": "server.js",
   "scripts": {
-    "start": "ts-node-dev index.ts",
-    "development": "pm2 start ecosystem.config.js --no-daemon",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start-yhsif": "nodemon index.ts",
-    "build": "tsc"
+    "build": "tsc && tsc-alias",
+    "start": "ts-node-dev -r tsconfig-paths/register index.ts",
+    "ts-node": "ts-node -r tsconfig-paths/register"
   },
   "author": "Michael Johnson",
   "license": "ISC",
@@ -53,6 +51,8 @@
     "@types/uuid": "^8.3.4",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
+    "tsc-alias": "^1.8.8",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^4.7.4"
   }
 }

--- a/src/api/policies/base-policy.ts
+++ b/src/api/policies/base-policy.ts
@@ -1,6 +1,6 @@
 import { pick } from "lodash"
 
-import { User } from "../models"
+import { User } from "@/models"
 
 export type Actions = "show" | "create" | "update" | "destroy"
 

--- a/src/api/policies/expenses-policy.ts
+++ b/src/api/policies/expenses-policy.ts
@@ -2,7 +2,7 @@ import { isNil } from "lodash"
 
 import BasePolicy from "./base-policy"
 import FormsPolicy from "./forms-policy"
-import { Expense } from "../models"
+import { Expense } from "@/models"
 
 export class ExpensesPolicy extends BasePolicy<Expense> {
   create(): boolean {

--- a/src/api/policies/forms-policy.ts
+++ b/src/api/policies/forms-policy.ts
@@ -1,7 +1,6 @@
 import BasePolicy from "./base-policy"
 
-import User from "../models/user"
-import Form, { FormStatuses } from "../models/form"
+import { User, Form, FormStatuses } from "@/models"
 
 export class FormsPolicy extends BasePolicy<Form> {
   show(): boolean {

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -1,13 +1,13 @@
 import { Router, Request, Response } from "express"
 
-import { checkJwt, loadUser } from "../middleware/authz.middleware"
+import { checkJwt, loadUser } from "@/middleware/authz.middleware"
 import {
   ExpensesController,
   FormsController,
   PreApprovedTravelersController,
   PreApprovedTravelRequestsController,
   forms,
-} from "../controllers"
+} from "@/controllers"
 
 export * from "./owner-router"
 export * from "./users-router"

--- a/src/api/serializers/expenses-serializer.ts
+++ b/src/api/serializers/expenses-serializer.ts
@@ -1,6 +1,6 @@
 import { pick } from "lodash"
 
-import { Expense, ExpenseTypes } from "../models"
+import { Expense, ExpenseTypes } from "@/models"
 
 import BaseSerializer from "./base-serializer"
 

--- a/src/api/serializers/forms-serializer.ts
+++ b/src/api/serializers/forms-serializer.ts
@@ -1,6 +1,6 @@
 import { isEmpty, isNil, minBy, pick } from "lodash"
 
-import Form from "../models/form"
+import Form from "@/models/form"
 
 import BaseSerializer from "./base-serializer"
 

--- a/src/api/services/README.md
+++ b/src/api/services/README.md
@@ -80,8 +80,8 @@ export { estimates }
 The usages of this would be
 
 ```typescript
-import { BulkGenerate } from "../../../services/estimates"
-// OR import { estimates } from "../../../services"
+import { BulkGenerate } from "@/services/estimates"
+// OR import { estimates } from "@/services"
 
 export class GenerateController extends BaseController {
   async create() {

--- a/src/api/services/estimates/bulk-generate.ts
+++ b/src/api/services/estimates/bulk-generate.ts
@@ -13,9 +13,9 @@ import {
   PerDiem,
   Stop,
   TravelMethods,
-} from "../../models"
-import { Types as ExpenseVariants } from "../../models/expense"
-import BaseService from "../base-service"
+} from "@/models"
+import { Types as ExpenseVariants } from "@/models/expense"
+import BaseService from "@/services/base-service"
 
 const MAXIUM_AIRCRAFT_ALLOWANCE = 1000
 const AIRCRAFT_ALLOWANCE_PER_SEGMENT = 350

--- a/src/api/services/expenses-service.ts
+++ b/src/api/services/expenses-service.ts
@@ -1,8 +1,8 @@
 import { isEmpty, isNil } from "lodash"
 
-import db from "../db/db-client-legacy"
+import db from "@/db/db-client-legacy"
 
-import { Expense } from "../models"
+import { Expense } from "@/models"
 import BaseService from "./base-service"
 
 export class ExpensesService extends BaseService {

--- a/src/api/services/forms-service.ts
+++ b/src/api/services/forms-service.ts
@@ -1,9 +1,9 @@
 import { isNil, isEmpty } from "lodash"
 import { v4 as uuid } from "uuid"
 
-import db from "../db/db-client-legacy"
+import db from "@/db/db-client-legacy"
 
-import { Form, User } from "../models"
+import { Form, User } from "@/models"
 import StopsService from "./stops-service"
 import LegacyFormSerivce from "./form-service"
 import ExpensesService from "./expenses-service"

--- a/src/api/services/stops-service.ts
+++ b/src/api/services/stops-service.ts
@@ -1,6 +1,6 @@
-import db from '../db/db-client-legacy'
+import db from '@/db/db-client-legacy'
 
-import Stop from "../models/stop"
+import Stop from "@/models/stop"
 import BaseService from "./base-service"
 
 export class StopsService extends BaseService {

--- a/src/api/tsconfig.json
+++ b/src/api/tsconfig.json
@@ -8,6 +8,9 @@
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "baseUrl": "." /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "@/*": ["./*", "./dist/*"]
+    },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [/* List of folders to include type definitions from. */ "./@types"],
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
# Context

See https://github.com/icefoganalytics/elcc-data-management/pull/18/files

This is a massive quality of life improvement, and makes many code references more readable and flexible.

It lets you stop writing code like
```typescript
import { Expense, Form } from "../../../models"
import { ExpensesPolicy } from "../../../policies"
```

And instead write code like
```typescript
import { Expense, Form } from "@/models"
import { ExpensesPolicy } from "@/policies"
```

# Testing Instructions

1. Boot the database service via `dev up`
2. Boot the api service via `dev up_api`
3. Boot the web service via `dev up_web`
4. Check that the app boots correctly and that you can log in.
5. Check that the production build works as well by following the instructions in the README.