### PR TITLE
Standardize `expenses` table in Database

### DIFF
--- a/api/src/controllers/expenses-controller.ts
+++ b/api/src/controllers/expenses-controller.ts
@@ -81,7 +81,7 @@ export class ExpensesController extends BaseController {
 
   private async buildExpense() {
     const attributes = this.request.body
-    const { taid: formId } = attributes
+    const { formId } = attributes
     const expense = Expense.build(attributes)
     expense.form = (await Form.findByPk(formId)) || undefined
     return expense

--- a/api/src/data/migrations/20231016233127_snake-case-columns-in-expenses-table.ts
+++ b/api/src/data/migrations/20231016233127_snake-case-columns-in-expenses-table.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("expenses", (table) => {
+    table.renameColumn("receiptImage", "receipt_image")
+    table.renameColumn("fileSize", "file_size")
+    table.renameColumn("fileName", "file_name")
+    table.renameColumn("expenseType", "expense_type")
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("expenses", (table) => {
+    table.renameColumn("receipt_image", "receiptImage")
+    table.renameColumn("file_size", "fileSize")
+    table.renameColumn("file_name", "fileName")
+    table.renameColumn("expense_type", "expenseType")
+  })
+}

--- a/api/src/data/migrations/20231016233128_fix-foreign-key-reference-to-forms-table-in-expenses-table.ts
+++ b/api/src/data/migrations/20231016233128_fix-foreign-key-reference-to-forms-table-in-expenses-table.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("expenses", (table) => {
+    table.renameColumn("taid", "form_id")
+    table.foreign("form_id").references("id").inTable("forms").onDelete("CASCADE")
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("expenses", (table) => {
+    table.dropForeign("form_id")
+    table.renameColumn("form_id", "taid")
+  })
+}

--- a/api/src/data/migrations/20231016233129_add-timestamp-columns-to-expenses-table.ts
+++ b/api/src/data/migrations/20231016233129_add-timestamp-columns-to-expenses-table.ts
@@ -1,0 +1,14 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("expenses", (table) => {
+    table.timestamps(true, true)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("expenses", (table) => {
+    table.dropColumn("created_at")
+    table.dropColumn("updated_at")
+  })
+}

--- a/api/src/data/migrations/20231017022839_standardize-expense-table-types.ts
+++ b/api/src/data/migrations/20231017022839_standardize-expense-table-types.ts
@@ -1,0 +1,16 @@
+import { Expense } from "@/models"
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  // @ts-expect-error
+  await Expense.update({ type: "Expense" }, { where: { type: "Expenses" } })
+  // @ts-expect-error
+  await Expense.update({ type: "Estimate" }, { where: { type: "Estimates" } })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // @ts-expect-error
+  await Expense.update({ type: "Expenses" }, { where: { type: "Expense" } })
+  // @ts-expect-error
+  await Expense.update({ type: "Estimates" }, { where: { type: "Estimate" } })
+}

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -39,7 +39,7 @@ export class Expense extends Model<InferAttributes<Expense>, InferCreationAttrib
   static ExpenseTypes = ExpenseTypes
 
   declare id: CreationOptional<number>
-  declare taid: ForeignKey<Form["id"]>
+  declare formId: ForeignKey<Form["id"]>
   declare description: string
   declare date: Date | null
   declare cost: number
@@ -66,7 +66,7 @@ export class Expense extends Model<InferAttributes<Expense>, InferCreationAttrib
   static establishAssociations() {
     this.belongsTo(Form, {
       as: "form",
-      foreignKey: "taid",
+      foreignKey: "formId",
     })
   }
 }
@@ -79,7 +79,7 @@ Expense.init(
       primaryKey: true,
       autoIncrement: true,
     },
-    taid: {
+    formId: {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -49,6 +49,8 @@ export class Expense extends Model<InferAttributes<Expense>, InferCreationAttrib
   declare fileSize: number | null
   declare fileName: string | null
   declare expenseType: ExpenseTypes
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
@@ -123,13 +125,23 @@ Expense.init(
       type: DataTypes.STRING(255),
       allowNull: false,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     modelName: "Expense",
     tableName: "expenses",
     underscored: true,
-    timestamps: false,
+    timestamps: true,
   }
 )
 

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -30,8 +30,8 @@ enum ExpenseTypes {
 // and there should be two models, one for each "type".
 // Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
 enum Types {
-  ESTIMATE = "Estimates",
-  EXPENSE = "Expenses",
+  ESTIMATE = "Estimate",
+  EXPENSE = "Expense",
 }
 
 export class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Expense>> {

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -17,7 +17,8 @@ import sequelize from "@/db/db-client"
 import Form from "./form"
 
 // Keep in sync with web/src/modules/travelForm/components/ExpenseTypeSelect.vue
-export enum ExpenseTypes {
+// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
+enum ExpenseTypes {
   ACCOMODATIONS = "Accomodations",
   TRANSPORTATION = "Transportation",
   MEALS_AND_INCIDENTALS = "Meals & Incidentals",
@@ -27,12 +28,16 @@ export enum ExpenseTypes {
 // move estimates to there own table.
 // It's also possible that this is a single table inheritance model,
 // and there should be two models, one for each "type".
-export enum Types {
+// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
+enum Types {
   ESTIMATE = "Estimates",
   EXPENSE = "Expenses",
 }
 
 export class Expense extends Model<InferAttributes<Expense>, InferCreationAttributes<Expense>> {
+  static Types = Types
+  static ExpenseTypes = ExpenseTypes
+
   declare id: CreationOptional<number>
   declare taid: ForeignKey<Form["id"]>
   declare description: string

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -105,28 +105,25 @@ Expense.init(
     receiptImage: {
       type: DataTypes.BLOB,
       allowNull: true,
-      field: "receiptImage",
     },
     fileSize: {
       type: DataTypes.INTEGER,
       allowNull: true,
-      field: "fileSize",
     },
     fileName: {
       type: DataTypes.STRING(255),
       allowNull: true,
-      field: "fileName",
     },
     expenseType: {
       type: DataTypes.STRING(255),
       allowNull: false,
-      field: "expenseType",
     },
   },
   {
     sequelize,
     modelName: "Expense",
     tableName: "expenses",
+    underscored: true,
     timestamps: false,
   }
 )

--- a/api/src/models/form.ts
+++ b/api/src/models/form.ts
@@ -21,7 +21,7 @@ import {
 } from "sequelize"
 
 import sequelize from "@/db/db-client"
-import Expense, { Types as ExpenseVariants } from "./expense"
+import Expense from "./expense"
 import Stop from "./stop"
 import TravelPurpose from "./travel-purpose"
 
@@ -127,7 +127,7 @@ export class Form extends Model<InferAttributes<Form>, InferCreationAttributes<F
   }
 
   get estimates(): NonAttribute<Expense[] | undefined> {
-    return this.expenses?.filter((expense) => expense.type === ExpenseVariants.ESTIMATE)
+    return this.expenses?.filter((expense) => expense.type === Expense.Types.ESTIMATE)
   }
 }
 

--- a/api/src/models/form.ts
+++ b/api/src/models/form.ts
@@ -78,13 +78,13 @@ export class Form extends Model<InferAttributes<Form>, InferCreationAttributes<F
   declare createPurpose: BelongsToCreateAssociationMixin<TravelPurpose>
 
   declare getExpenses: HasManyGetAssociationsMixin<Expense>
-  declare setExpenses: HasManySetAssociationsMixin<Expense, Expense["taid"]>
-  declare hasExpense: HasManyHasAssociationMixin<Expense, Expense["taid"]>
-  declare hasExpenses: HasManyHasAssociationsMixin<Expense, Expense["taid"]>
-  declare addExpense: HasManyAddAssociationMixin<Expense, Expense["taid"]>
-  declare addExpenses: HasManyAddAssociationsMixin<Expense, Expense["taid"]>
-  declare removeExpense: HasManyRemoveAssociationMixin<Expense, Expense["taid"]>
-  declare removeExpenses: HasManyRemoveAssociationsMixin<Expense, Expense["taid"]>
+  declare setExpenses: HasManySetAssociationsMixin<Expense, Expense["formId"]>
+  declare hasExpense: HasManyHasAssociationMixin<Expense, Expense["formId"]>
+  declare hasExpenses: HasManyHasAssociationsMixin<Expense, Expense["formId"]>
+  declare addExpense: HasManyAddAssociationMixin<Expense, Expense["formId"]>
+  declare addExpenses: HasManyAddAssociationsMixin<Expense, Expense["formId"]>
+  declare removeExpense: HasManyRemoveAssociationMixin<Expense, Expense["formId"]>
+  declare removeExpenses: HasManyRemoveAssociationsMixin<Expense, Expense["formId"]>
   declare countExpenses: HasManyCountAssociationsMixin
   declare createExpense: HasManyCreateAssociationMixin<Expense>
 
@@ -122,7 +122,7 @@ export class Form extends Model<InferAttributes<Form>, InferCreationAttributes<F
     this.hasMany(Expense, {
       as: "expenses",
       sourceKey: "id",
-      foreignKey: "taid",
+      foreignKey: "formId",
     })
   }
 

--- a/api/src/policies/expenses-policy.ts
+++ b/api/src/policies/expenses-policy.ts
@@ -26,7 +26,7 @@ export class ExpensesPolicy extends BasePolicy<Expense> {
   }
 
   permittedAttributesForCreate(): string[] {
-    return ["taid", "type", "currency", ...this.permittedAttributes()]
+    return ["formId", "type", "currency", ...this.permittedAttributes()]
   }
 }
 

--- a/api/src/routes/form-router.ts
+++ b/api/src/routes/form-router.ts
@@ -345,7 +345,7 @@ formRouter.get("/:formId/expenses/:type", ReturnValidationErrors, async function
 
       const expenses = Expense.findAll({
         where: {
-          taid: form[0].id,
+          formId: form[0].id,
           type: req.params.type,
         },
       })
@@ -368,13 +368,13 @@ formRouter.post("/:formId/expenses/:type", ReturnValidationErrors, async functio
       db.transaction(async () => {
         await Expense.destroy({
           where: {
-            taid: form[0].id,
+            formId: form[0].id,
             type: req.params.type,
           },
         })
         for (let index = 0; index < req.body.length; index++) {
           const expense = {
-            taid: form[0].id,
+            formId: form[0].id,
             ...req.body[index],
             type: req.params.type
           };
@@ -461,14 +461,14 @@ formRouter.get("/:formId/costDifference", ReturnValidationErrors, async function
       if (form[0]) {
         const estimatesFloat = await Expense.sum("cost", {
           where: {
-            taid: form[0].id,
+            formId: form[0].id,
             type: Expense.Types.ESTIMATE,
           },
         }).then((result) => result.toFixed(2))
 
         const expensesFloat = await Expense.sum("cost", {
           where: {
-            taid: form[0].id,
+            formId: form[0].id,
             type: Expense.Types.EXPENSE,
           },
         }).then((result) => result.toFixed(2))

--- a/api/src/routes/form-router.ts
+++ b/api/src/routes/form-router.ts
@@ -8,6 +8,7 @@ import { Expense } from "@/models"
 import dbLegacy from "@/db/db-client-legacy";
 import db from "@/db/db-client";
 
+// TODO: Check if parser/builtins hack patch code is still needed
 const { setTypeParser, builtins } = require("pg").types;
 
 const typesToReset = [builtins.DATE, builtins.TIME, builtins.TIMETZ, builtins.TIMESTAMP, builtins.TIMESTAMPTZ];

--- a/api/src/routes/form-router.ts
+++ b/api/src/routes/form-router.ts
@@ -4,7 +4,6 @@ import { ReturnValidationErrors } from "../middleware";
 
 import { UserService, FormService, AuditService } from "@/services";
 import { Expense } from "@/models"
-import { Types as ExpenseVariants } from "@/models/expense"
 
 import db from "@/db/db-client-legacy";
 import sequelize from "@/db/db-client";
@@ -462,14 +461,14 @@ formRouter.get("/:formId/costDifference", ReturnValidationErrors, async function
         const estimatesFloat = await Expense.sum("cost", {
           where: {
             taid: form[0].id,
-            type: ExpenseVariants.ESTIMATE,
+            type: Expense.Types.ESTIMATE,
           },
         }).then((result) => result.toFixed(2))
 
         const expensesFloat = await Expense.sum("cost", {
           where: {
             taid: form[0].id,
-            type: ExpenseVariants.EXPENSE,
+            type: Expense.Types.EXPENSE,
           },
         }).then((result) => result.toFixed(2))
 

--- a/api/src/serializers/expenses-serializer.ts
+++ b/api/src/serializers/expenses-serializer.ts
@@ -1,6 +1,6 @@
 import { pick } from "lodash"
 
-import { Expense, ExpenseTypes } from "@/models"
+import { Expense } from "@/models"
 
 import BaseSerializer from "./base-serializer"
 
@@ -16,7 +16,7 @@ export class ExpensesSerializer extends BaseSerializer {
 
   // TODO: investigate whether these should depend on a policy check
   private static actions(expense: Expense): ("delete" | "edit")[] {
-    if (expense.expenseType === ExpenseTypes.MEALS_AND_INCIDENTALS) {
+    if (expense.expenseType === Expense.ExpenseTypes.MEALS_AND_INCIDENTALS) {
       return ["delete"]
     } else {
       return ["edit", "delete"]

--- a/api/src/services/estimates/bulk-generate.ts
+++ b/api/src/services/estimates/bulk-generate.ts
@@ -174,7 +174,7 @@ export class BulkGenerate extends BaseService {
 
     return {
       type: Expense.Types.ESTIMATE,
-      taid: this.formId,
+      formId: this.formId,
       currency: "CAD",
       expenseType: Expense.ExpenseTypes.TRANSPORTATION,
       description,
@@ -205,7 +205,7 @@ export class BulkGenerate extends BaseService {
       const cost = this.determineAccommodationCost(accommodationType)
       return {
         type: Expense.Types.ESTIMATE,
-        taid: this.formId,
+        formId: this.formId,
         currency: "CAD",
         expenseType: Expense.ExpenseTypes.ACCOMODATIONS,
         description,
@@ -244,7 +244,7 @@ export class BulkGenerate extends BaseService {
 
       estimates.push({
         type: Expense.Types.ESTIMATE,
-        taid: this.formId,
+        formId: this.formId,
         currency: "CAD",
         expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS,
         description,

--- a/api/src/services/estimates/bulk-generate.ts
+++ b/api/src/services/estimates/bulk-generate.ts
@@ -7,14 +7,12 @@ import {
   Location,
   DistanceMatrix,
   Expense,
-  ExpenseTypes,
   Form,
   LocationTypes,
   PerDiem,
   Stop,
   TravelMethods,
 } from "@/models"
-import { Types as ExpenseVariants } from "@/models/expense"
 import BaseService from "@/services/base-service"
 
 const MAXIUM_AIRCRAFT_ALLOWANCE = 1000
@@ -175,10 +173,10 @@ export class BulkGenerate extends BaseService {
     const cost = await this.determineTravelMethodCost(fromTransport, fromCity, toCity)
 
     return {
-      type: ExpenseVariants.ESTIMATE,
+      type: Expense.Types.ESTIMATE,
       taid: this.formId,
       currency: "CAD",
-      expenseType: ExpenseTypes.TRANSPORTATION,
+      expenseType: Expense.ExpenseTypes.TRANSPORTATION,
       description,
       cost,
       date: fromDepartureAt,
@@ -206,10 +204,10 @@ export class BulkGenerate extends BaseService {
 
       const cost = this.determineAccommodationCost(accommodationType)
       return {
-        type: ExpenseVariants.ESTIMATE,
+        type: Expense.Types.ESTIMATE,
         taid: this.formId,
         currency: "CAD",
-        expenseType: ExpenseTypes.ACCOMODATIONS,
+        expenseType: Expense.ExpenseTypes.ACCOMODATIONS,
         description,
         cost,
         date: stayedAt,
@@ -245,10 +243,10 @@ export class BulkGenerate extends BaseService {
       const cost = await this.determinePerDiemCost(province, claims)
 
       estimates.push({
-        type: ExpenseVariants.ESTIMATE,
+        type: Expense.Types.ESTIMATE,
         taid: this.formId,
         currency: "CAD",
-        expenseType: ExpenseTypes.MEALS_AND_INCIDENTALS,
+        expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS,
         description,
         cost,
         date: stayedAt,

--- a/api/src/services/expenses-service.ts
+++ b/api/src/services/expenses-service.ts
@@ -29,7 +29,7 @@ export class ExpensesService extends BaseService {
   }
 
   static async bulkCreate(formId: number, expenses: Expense[]): Promise<Expense[]> {
-    if (!expenses.every((expense) => expense.taid === formId)) {
+    if (!expenses.every((expense) => expense.formId === formId)) {
       throw new Error("All expenses must belong to the same form.")
     }
 
@@ -37,12 +37,12 @@ export class ExpensesService extends BaseService {
   }
 
   static async bulkReplace(formId: number, expenses: Expense[]): Promise<Expense[]> {
-    if (!expenses.every((expense) => expense.taid === formId)) {
+    if (!expenses.every((expense) => expense.formId === formId)) {
       throw new Error("All expenses must belong to the same form.")
     }
 
     return db.transaction(async () => {
-      await Expense.destroy({ where: { taid: formId } })
+      await Expense.destroy({ where: { formId } })
       return Expense.bulkCreate(expenses)
     })
   }

--- a/api/src/services/form-service.ts
+++ b/api/src/services/form-service.ts
@@ -1,22 +1,17 @@
-import knex, { Knex } from "knex"
 import { isEmpty, map } from "lodash"
 
-import { DB_CONFIG } from "../config"
+import dbLegacy from "@/db/db-client-legacy"
+import { Expense } from "@/models"
+import ExpensesService from "./expenses-service"
 
 export class FormService {
-  private db: Knex
-
-  constructor() {
-    this.db = knex(DB_CONFIG)
-  }
-
   //returns form
   async getForm(formId: string): Promise<any | undefined> {
     console.warn(
       "This method is deprecated, and will be removed in a future version. Please use Form.findByPK instead, see FormsController#show"
     )
     try {
-      let form: any = await this.db("forms").select("*").first().where({ formId: formId })
+      let form: any = await dbLegacy("forms").select("*").first().where({ formId: formId })
 
       if (isEmpty(form)) {
         return undefined
@@ -25,7 +20,7 @@ export class FormService {
       let expenses = await this.getExpenses(form.id)
       let estimates = await this.getEstimates(form.id)
       let stops = await this.getStops(form.id)
-      let departureDate = await this.db("stops")
+      let departureDate = await dbLegacy("stops")
         .select("departureDate")
         .first()
         .where({ taid: form.id })
@@ -62,7 +57,7 @@ export class FormService {
 
       console.log(form)
 
-      let returnedForm = await this.db("forms").insert(form, "id").onConflict("formId").merge()
+      let returnedForm = await dbLegacy("forms").insert(form, "id").onConflict("formId").merge()
       let id = returnedForm[0].id
 
       await this.saveStops(id, stops)
@@ -78,7 +73,7 @@ export class FormService {
 
   async getStops(taid: number): Promise<any[] | undefined> {
     try {
-      let stops = await this.db("stops")
+      let stops = await dbLegacy("stops")
         .select("*")
         .where({ taid: taid })
         .orderBy("departureDate", "asc")
@@ -91,7 +86,7 @@ export class FormService {
 
   async saveStops(taid: number, stops: any): Promise<Boolean> {
     try {
-      await this.db("stops").delete().where({ taid: taid })
+      await dbLegacy("stops").delete().where({ taid: taid })
 
       if (stops) {
         stops = map(stops, (stop) => {
@@ -99,7 +94,7 @@ export class FormService {
           stop.locationId = stop.locationId != "" ? stop.locationId : null
           return stop
         })
-        await this.db("stops").insert(stops)
+        await dbLegacy("stops").insert(stops)
       }
       return true
     } catch (error: any) {
@@ -110,11 +105,12 @@ export class FormService {
 
   async getExpenses(taid: number): Promise<any[] | undefined> {
     try {
-      let expenses = await this.db("expenses")
-        .select("*")
-        .where({ taid: taid })
-        .andWhere("type", "=", "Expenses")
-      return expenses
+      return Expense.findAll({
+        where: {
+          taid: taid,
+          type: Expense.Types.EXPENSE,
+        },
+      })
     } catch (error: any) {
       console.log(error)
       return undefined
@@ -123,14 +119,7 @@ export class FormService {
 
   async saveExpenses(taid: number, expenses: any): Promise<Boolean> {
     try {
-      await this.db("expenses").delete().where({ taid: taid })
-      if (expenses) {
-        expenses = map(expenses, (expense) => {
-          expense.taid = taid
-          return stop
-        })
-        await this.db("expenses").insert(expenses)
-      }
+      await ExpensesService.bulkReplace(taid, expenses)
       return true
     } catch (error: any) {
       console.log(error)
@@ -140,11 +129,12 @@ export class FormService {
 
   async getEstimates(taid: number): Promise<any[] | undefined> {
     try {
-      let estimates = await this.db("expenses")
-        .select("*")
-        .where({ taid: taid })
-        .andWhere("type", "=", "Estimates")
-      return estimates
+      return Expense.findAll({
+        where: {
+          taid: taid,
+          type: Expense.Types.ESTIMATE,
+        },
+      })
     } catch (error: any) {
       console.log(error)
       return undefined
@@ -152,20 +142,8 @@ export class FormService {
   }
 
   async saveEstimates(taid: number, estimates: any): Promise<Boolean> {
-    try {
-      await this.db("expenses").delete().where({ taid: taid })
-      if (estimates) {
-        estimates = map(estimates, (estimate) => {
-          estimate.taid = taid
-          return stop
-        })
-        await this.db("expenses").insert(estimates)
-      }
-      return true
-    } catch (error: any) {
-      console.log(error)
-      return false
-    }
+    console.warn("DEPRECATED: use saveEstimates instead.")
+    return this.saveExpenses(taid, estimates)
   }
 
   async submitForm(userId: number, form: any): Promise<Boolean> {
@@ -189,7 +167,7 @@ export class FormService {
         form.userId = userId
         form.status = "Submitted"
 
-        let returnedForm = await this.db("forms").insert(form, "id").onConflict("formId").merge()
+        let returnedForm = await dbLegacy("forms").insert(form, "id").onConflict("formId").merge()
         let id = returnedForm[0].id
 
         await this.saveStops(id, stops)

--- a/api/src/services/form-service.ts
+++ b/api/src/services/form-service.ts
@@ -103,11 +103,11 @@ export class FormService {
     }
   }
 
-  async getExpenses(taid: number): Promise<any[] | undefined> {
+  async getExpenses(formId: number): Promise<any[] | undefined> {
     try {
       return Expense.findAll({
         where: {
-          taid: taid,
+          formId,
           type: Expense.Types.EXPENSE,
         },
       })
@@ -117,9 +117,9 @@ export class FormService {
     }
   }
 
-  async saveExpenses(taid: number, expenses: any): Promise<Boolean> {
+  async saveExpenses(formId: number, expenses: any): Promise<Boolean> {
     try {
-      await ExpensesService.bulkReplace(taid, expenses)
+      await ExpensesService.bulkReplace(formId, expenses)
       return true
     } catch (error: any) {
       console.log(error)
@@ -127,11 +127,11 @@ export class FormService {
     }
   }
 
-  async getEstimates(taid: number): Promise<any[] | undefined> {
+  async getEstimates(formId: number): Promise<any[] | undefined> {
     try {
       return Expense.findAll({
         where: {
-          taid: taid,
+          formId,
           type: Expense.Types.ESTIMATE,
         },
       })
@@ -141,9 +141,9 @@ export class FormService {
     }
   }
 
-  async saveEstimates(taid: number, estimates: any): Promise<Boolean> {
+  async saveEstimates(formId: number, estimates: any): Promise<Boolean> {
     console.warn("DEPRECATED: use saveEstimates instead.")
-    return this.saveExpenses(taid, estimates)
+    return this.saveExpenses(formId, estimates)
   }
 
   async submitForm(userId: number, form: any): Promise<Boolean> {

--- a/web/src/apis/expenses-api.js
+++ b/web/src/apis/expenses-api.js
@@ -2,10 +2,11 @@ import http from "@/apis/http-client"
 
 // Must match types in src/api/models/expense.ts
 export const TYPES = Object.freeze({
-  ESTIMATE: "Estimates",
+  ESTIMATE: "Estimate",
 })
 
 export const expensesApi = {
+  TYPES,
   list({ where, page, perPage, ...otherParams } = {}) {
     return http
       .get("/api/expenses", { params: { where, page, perPage, ...otherParams } })

--- a/web/src/modules/travelForm/store/index.js
+++ b/web/src/modules/travelForm/store/index.js
@@ -2,7 +2,7 @@ import { isString, upperFirst, omit } from "lodash"
 
 import { FORM_URL, LOOKUP_URL, USERS_URL } from "@/urls"
 import { secureGet, securePost } from "@/store/jwt"
-import expensesApi, { TYPES as EXPENSE_VARIANT } from "@/apis/expenses-api"
+import expensesApi from "@/apis/expenses-api"
 import formsApi from "@/apis/forms-api"
 import locationsApi from "@/apis/locations-api"
 
@@ -60,7 +60,7 @@ const actions = {
   loadEstimates({ commit, state }, { formId }) {
     state.loadingEstimates = true
     return expensesApi
-      .list({ where: { formId, type: EXPENSE_VARIANT.ESTIMATE } })
+      .list({ where: { formId, type: expensesApi.TYPES.ESTIMATE } })
       .then(({ expenses: estimates }) => {
         commit("SET_ESTIMATES", estimates)
         return estimates

--- a/web/src/modules/travelForm/store/index.js
+++ b/web/src/modules/travelForm/store/index.js
@@ -60,7 +60,7 @@ const actions = {
   loadEstimates({ commit, state }, { formId }) {
     state.loadingEstimates = true
     return expensesApi
-      .list({ where: { taid: formId, type: EXPENSE_VARIANT.ESTIMATE } })
+      .list({ where: { formId, type: EXPENSE_VARIANT.ESTIMATE } })
       .then(({ expenses: estimates }) => {
         commit("SET_ESTIMATES", estimates)
         return estimates

--- a/web/src/modules/travelForm/views/travel-form-edit/details-tab/ApprovalsFormCard.vue
+++ b/web/src/modules/travelForm/views/travel-form-edit/details-tab/ApprovalsFormCard.vue
@@ -84,14 +84,10 @@
 import { isEmpty, sumBy } from "lodash"
 import { mapActions, mapState } from "vuex"
 
+import { TYPES } from "@/apis/expenses-api"
 import preApprovedTravelRequestsApi from "@/apis/pre-approved-travel-requests-api"
 
 import SearchableUserEmailCombobox from "@/components/SearchableUserEmailCombobox"
-
-// Must match types in src/api/models/expense.ts
-const EXPENSE_TYPES = Object.freeze({
-  ESTIMATE: "Estimates",
-})
 
 export default {
   name: "ApprovalsFormCard",
@@ -106,8 +102,9 @@ export default {
   }),
   computed: {
     ...mapState("travelForm", ["currentForm", "currentUser", "loadingCurrentUser"]),
+    // TODO: Make this a getter in the store
     estimates() {
-      return this.currentForm.expenses?.filter((expense) => expense.type === EXPENSE_TYPES.ESTIMATE) || []
+      return this.currentForm.expenses?.filter((expense) => expense.type === TYPES.ESTIMATE) || []
     },
     estimatedCost() {
       return sumBy(this.estimates, "cost")

--- a/web/src/modules/travelForm/views/travel-form-edit/estimate-tab/EstimateCreateDialog.vue
+++ b/web/src/modules/travelForm/views/travel-form-edit/estimate-tab/EstimateCreateDialog.vue
@@ -142,18 +142,18 @@ export default {
     },
     close() {
       this.showDialog = false
-      this.$nextTick(() => {
-        this.estimate = this.newEstimate()
-        this.$refs.form.resetValidation()
-      })
+      this.estimate = this.newEstimate()
+      this.$refs.form.resetValidation()
     },
     createAndClose() {
       this.loading = true
       return expensesApi
         .create(this.estimate)
         .then(() => {
-          this.$emit("created")
           this.close()
+          this.$nextTick(() => {
+            this.$emit("created")
+          })
         })
         .catch((error) => {
           this.$snack(error.message, { color: "error" })

--- a/web/src/modules/travelForm/views/travel-form-edit/estimate-tab/EstimateCreateDialog.vue
+++ b/web/src/modules/travelForm/views/travel-form-edit/estimate-tab/EstimateCreateDialog.vue
@@ -97,11 +97,6 @@ import ExpenseTypeSelect from "@/modules/travelForm/components/ExpenseTypeSelect
 
 import expensesApi from "@/apis/expenses-api"
 
-// Must match types in src/api/models/expense.ts
-const EXPENSE_TYPES = Object.freeze({
-  ESTIMATE: "Estimates",
-})
-
 export default {
   name: "EstimateCreateDialog",
   components: {
@@ -136,7 +131,7 @@ export default {
     newEstimate() {
       return {
         formId: this.formId,
-        type: EXPENSE_TYPES.ESTIMATE,
+        type: expensesApi.TYPES.ESTIMATE,
         currency: "CAD",
       }
     },

--- a/web/src/modules/travelForm/views/travel-form-edit/estimate-tab/EstimateCreateDialog.vue
+++ b/web/src/modules/travelForm/views/travel-form-edit/estimate-tab/EstimateCreateDialog.vue
@@ -135,7 +135,7 @@ export default {
     required,
     newEstimate() {
       return {
-        taid: this.formId,
+        formId: this.formId,
         type: EXPENSE_TYPES.ESTIMATE,
         currency: "CAD",
       }


### PR DESCRIPTION
References
- https://github.com/icefoganalytics/travel-authorization/issues/16
- https://github.com/icefoganalytics/travel-authorization/issues/30
- [Modeling, My Travel Requests, 2023-10-13](https://docs.google.com/document/d/1jpW3VokZa3v5Mv-Gf4Kfjve2WwTpK7X4cpep5-EROCE/edit?pli=1#heading=h.epyy9mt07rdp)

# Context

1. Snake case/underscore all `expenses` columns
2. Fix all foreign key references in the table so that they refer to the table name they are referencing (i.e. `taid`).
3. Add `created_at` and `update_at` standard timestamp columns.
4. Migrate Expense#type column so that it references Model names. e.g. Expense or Estimate and update all references to the column so that the references uses these constants.

# Implementation

Update `taid` fake foreign key, and make it a real foreign key to the `forms` table as `form_id`
Start exposing enums through the Model instead of independent export, because I was worried about naming conflicts, and namespacing to the model avoids that problem.
Migrate all code querying the `expenses` table using legacy Knex queries, to using new Sequelize model queries.

# Testing Instructions

1. Boot the db and api services via `dev up`.
2. Boot the web service by `dev up_web`.
3. Check that the app boots correctly.
5. Go to the My Travel Request page.
6. Create a new travel request.
7. Create some to/from travel information and save the draft.
8. Go to the "Estimate" tab and generate an estimate.
9. Check that you can create, edit, and delete estimates.