### PR TITLE
Standardize `travelDeskPnrDocuments` table in Database

### DIFF
--- a/api/src/data/migrations/20231018220003_rename-name-in-travel-desk-npr-documents-table.ts
+++ b/api/src/data/migrations/20231018220003_rename-name-in-travel-desk-npr-documents-table.ts
@@ -1,0 +1,51 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("travelDeskPnrDocuments", async (table) => {
+    table.dropPrimary()
+    table.dropForeign(["requestID"])
+  })
+
+  await knex.schema.renameTable(
+    "travelDeskPnrDocuments",
+    "travel_desk_passenger_name_record_documents"
+  )
+
+  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+    table.primary(["documentID"])
+    table
+      .foreign("requestID")
+      .references("requestID")
+      .inTable("travelDeskTravelRequest")
+      .onDelete("CASCADE")
+  })
+
+  await knex.raw(
+    `ALTER SEQUENCE "travelDeskPnrDocuments_documentID_seq" RENAME TO "travel_desk_passenger_name_record_documents_documentID_seq"`
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+    table.dropPrimary()
+    table.dropForeign(["requestID"])
+  })
+
+  await knex.schema.renameTable(
+    "travel_desk_passenger_name_record_documents",
+    "travelDeskPnrDocuments"
+  )
+
+  await knex.schema.table("travelDeskPnrDocuments", async (table) => {
+    table.primary(["documentID"])
+    table
+      .foreign("requestID")
+      .references("requestID")
+      .inTable("travelDeskTravelRequest")
+      .onDelete("CASCADE")
+  })
+
+  await knex.raw(
+    `ALTER SEQUENCE "travel_desk_passenger_name_record_documents_documentID_seq" RENAME TO "travelDeskPnrDocuments_documentID_seq"`
+  )
+}

--- a/api/src/data/migrations/20231018220004_standardize-primary-key-name-in-travel-desk-npr-documents-table.ts
+++ b/api/src/data/migrations/20231018220004_standardize-primary-key-name-in-travel-desk-npr-documents-table.ts
@@ -1,0 +1,24 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+    table.dropPrimary()
+    table.renameColumn("documentID", "id")
+    table.primary(["id"])
+  })
+
+  await knex.raw(
+    'ALTER SEQUENCE "travel_desk_passenger_name_record_documents_documentID_seq" RENAME TO "travel_desk_passenger_name_record_documents_id_seq"'
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+    table.dropPrimary()
+    table.renameColumn("id", "documentID")
+    table.primary(["documentID"])
+  })
+  await knex.raw(
+    'ALTER SEQUENCE "travel_desk_passenger_name_record_documents_id_seq" RENAME TO "travel_desk_passenger_name_record_documents_documentID_seq"'
+  )
+}

--- a/api/src/data/migrations/20231018220005_snake-case-all-travel-desk-pnr-documents-columns.ts
+++ b/api/src/data/migrations/20231018220005_snake-case-all-travel-desk-pnr-documents-columns.ts
@@ -1,0 +1,31 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+    table.dropForeign(["requestID"])
+    table.renameColumn("requestID", "travel_desk_travel_request_id")
+    table
+      .foreign("travel_desk_travel_request_id")
+      .references("requestID")
+      .inTable("travelDeskTravelRequest")
+      .onDelete("CASCADE")
+
+    table.renameColumn("pnrDocument", "pnr_document")
+    table.renameColumn("invoiceNumber", "invoice_number")
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+    table.dropForeign(["travel_desk_travel_request_id"])
+    table.renameColumn("travel_desk_travel_request_id", "requestID")
+    table
+      .foreign("requestID")
+      .references("requestID")
+      .inTable("travelDeskTravelRequest")
+      .onDelete("CASCADE")
+
+    table.renameColumn("pnr_document", "pnrDocument")
+    table.renameColumn("invoice_number", "invoiceNumber")
+  })
+}

--- a/api/src/data/migrations/20231018233031_add-timestamp-columns-to-travel-desk-passenger-name-record-document-table.ts
+++ b/api/src/data/migrations/20231018233031_add-timestamp-columns-to-travel-desk-passenger-name-record-document-table.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+    table.timestamps(true, true)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+    table.dropColumn("created_at")
+    table.dropColumn("updated_at")
+  })
+}

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -85,8 +85,8 @@ Expense.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: "travel_authorizations", // using table name here, instead of Model class
-        key: "id",
+        model: "travel_authorizations", // using real table name here
+        key: "id", // using real column name here
       },
     },
     description: {

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -3,20 +3,23 @@ import db from "@/db/db-client"
 import Stop from "./stop"
 import Expense from "./expense"
 import TravelAuthorization from "./travel-authorization"
+import TravelDeskPnrDocument from "./travel-desk-pnr-document"
 
 Stop.establishAssociations()
 Expense.establishAssociations()
 TravelAuthorization.establishAssociations()
+TravelDeskPnrDocument.establishAssociations()
 
 export * from "./auth"
 export * from "./distance-matrix"
 export * from "./expense"
-export * from "./travel-authorization"
 export * from "./location"
 export * from "./per-diem"
 export * from "./preapproved-traveler"
 export * from "./preapproved"
 export * from "./stop"
+export * from "./travel-authorization"
+export * from "./travel-desk-pnr-document"
 export * from "./travel-purpose"
 export * from "./user"
 

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -3,12 +3,12 @@ import db from "@/db/db-client"
 import Stop from "./stop"
 import Expense from "./expense"
 import TravelAuthorization from "./travel-authorization"
-import TravelDeskPnrDocument from "./travel-desk-pnr-document"
+import TravelDeskPassengerNameRecordDocument from "./travel-desk-passenger-name-record-document"
 
 Stop.establishAssociations()
 Expense.establishAssociations()
 TravelAuthorization.establishAssociations()
-TravelDeskPnrDocument.establishAssociations()
+TravelDeskPassengerNameRecordDocument.establishAssociations()
 
 export * from "./auth"
 export * from "./distance-matrix"
@@ -19,7 +19,7 @@ export * from "./preapproved-traveler"
 export * from "./preapproved"
 export * from "./stop"
 export * from "./travel-authorization"
-export * from "./travel-desk-pnr-document"
+export * from "./travel-desk-passenger-name-record-document"
 export * from "./travel-purpose"
 export * from "./user"
 

--- a/api/src/models/stop.ts
+++ b/api/src/models/stop.ts
@@ -112,16 +112,16 @@ Stop.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: "travel_authorizations", // using table name here, instead of Model class
-        key: "id",
+        model: "travel_authorizations", // using real table name here
+        key: "id", // using real column name here
       },
     },
     locationId: {
       type: DataTypes.INTEGER,
       allowNull: true,
       references: {
-        model: "locations", // using table name here, instead of Model class
-        key: "id",
+        model: "locations", // using real table name here
+        key: "id", // using real column name here
       },
     },
     departureDate: {

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -165,16 +165,16 @@ TravelAuthorization.init(
       type: DataTypes.INTEGER,
       allowNull: true,
       references: {
-        model: "travelPurpose", // using table name here, instead of Model class
-        key: "id",
+        model: "travelPurpose", // using real table name here
+        key: "id", // using real column name here
       },
     },
     userId: {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: "users", // using table name here, instead of Model class
-        key: "id",
+        model: "users", // using real table name here
+        key: "id", // using real column name here
       },
     },
     firstName: {

--- a/api/src/models/travel-desk-passenger-name-record-document.ts
+++ b/api/src/models/travel-desk-passenger-name-record-document.ts
@@ -63,7 +63,7 @@ TravelDeskPassengerNameRecordDocument.init(
       allowNull: false,
       references: {
         model: "travelDeskTravelRequest", // using real table name here
-        key: "travel_desk_travel_request_id", // using real key name here
+        key: "requestID", // using real column name here
       },
       onDelete: "CASCADE",
     },

--- a/api/src/models/travel-desk-passenger-name-record-document.ts
+++ b/api/src/models/travel-desk-passenger-name-record-document.ts
@@ -42,10 +42,11 @@ export class TravelDeskPassengerNameRecordDocument extends Model<
   }
 
   static establishAssociations() {
-    this.belongsTo(TravelDeskTravelRequest, {
-      as: "travelDeskTravelRequest",
-      foreignKey: "requestID",
-    })
+    // TODO: enable this once TravelDeskTravelRequest model is set up
+    // this.belongsTo(TravelDeskTravelRequest, {
+    //   as: "travelDeskTravelRequest",
+    //   foreignKey: "requestID",
+    // })
   }
 }
 

--- a/api/src/models/travel-desk-passenger-name-record-document.ts
+++ b/api/src/models/travel-desk-passenger-name-record-document.ts
@@ -16,9 +16,9 @@ import { TravelDeskTravelRequest } from "./travel-desk-travel-request"
 
 import sequelize from "@/db/db-client"
 
-export class TravelDeskPnrDocument extends Model<
-  InferAttributes<TravelDeskPnrDocument>,
-  InferCreationAttributes<TravelDeskPnrDocument>
+export class TravelDeskPassengerNameRecordDocument extends Model<
+  InferAttributes<TravelDeskPassengerNameRecordDocument>,
+  InferCreationAttributes<TravelDeskPassengerNameRecordDocument>
 > {
   declare documentID: CreationOptional<number>
   declare requestID: ForeignKey<TravelDeskTravelRequest["requestID"]>
@@ -35,7 +35,10 @@ export class TravelDeskPnrDocument extends Model<
   declare travelDeskTravelRequest?: NonAttribute<TravelDeskTravelRequest>
 
   declare static associations: {
-    travelDeskTravelRequest: Association<TravelDeskPnrDocument, TravelDeskTravelRequest>
+    travelDeskTravelRequest: Association<
+      TravelDeskPassengerNameRecordDocument,
+      TravelDeskTravelRequest
+    >
   }
 
   static establishAssociations() {
@@ -46,7 +49,7 @@ export class TravelDeskPnrDocument extends Model<
   }
 }
 
-TravelDeskPnrDocument.init(
+TravelDeskPassengerNameRecordDocument.init(
   {
     documentID: {
       type: DataTypes.INTEGER,
@@ -74,11 +77,11 @@ TravelDeskPnrDocument.init(
   },
   {
     sequelize,
-    modelName: "TravelDeskPnrDocument",
-    tableName: "travelDeskPnrDocuments",
+    modelName: "TravelDeskPassengerNameRecordDocument",
+    tableName: "travel_desk_passenger_name_record_documents",
     underscored: false,
     timestamps: false,
   }
 )
 
-export default TravelDeskPnrDocument
+export default TravelDeskPassengerNameRecordDocument

--- a/api/src/models/travel-desk-passenger-name-record-document.ts
+++ b/api/src/models/travel-desk-passenger-name-record-document.ts
@@ -21,7 +21,7 @@ export class TravelDeskPassengerNameRecordDocument extends Model<
   InferCreationAttributes<TravelDeskPassengerNameRecordDocument>
 > {
   declare id: CreationOptional<number>
-  declare requestID: ForeignKey<TravelDeskTravelRequest["requestID"]>
+  declare travelDeskTravelRequestId: ForeignKey<TravelDeskTravelRequest["requestID"]>
   declare pnrDocument: Buffer | null
   declare invoiceNumber: string | null
 
@@ -45,7 +45,7 @@ export class TravelDeskPassengerNameRecordDocument extends Model<
     // TODO: enable this once TravelDeskTravelRequest model is set up
     // this.belongsTo(TravelDeskTravelRequest, {
     //   as: "travelDeskTravelRequest",
-    //   foreignKey: "requestID",
+    //   foreignKey: "travelDeskTravelRequestId",
     // })
   }
 }
@@ -58,12 +58,12 @@ TravelDeskPassengerNameRecordDocument.init(
       primaryKey: true,
       autoIncrement: true,
     },
-    requestID: {
+    travelDeskTravelRequestId: {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: "travelDeskTravelRequest", // using table name here, instead of Model class
-        key: "requestID",
+        model: "travelDeskTravelRequest", // using real table name here
+        key: "travel_desk_travel_request_id", // using real key name here
       },
       onDelete: "CASCADE",
     },
@@ -80,7 +80,6 @@ TravelDeskPassengerNameRecordDocument.init(
     sequelize,
     modelName: "TravelDeskPassengerNameRecordDocument",
     tableName: "travel_desk_passenger_name_record_documents",
-    underscored: false,
     timestamps: false,
   }
 )

--- a/api/src/models/travel-desk-passenger-name-record-document.ts
+++ b/api/src/models/travel-desk-passenger-name-record-document.ts
@@ -20,7 +20,7 @@ export class TravelDeskPassengerNameRecordDocument extends Model<
   InferAttributes<TravelDeskPassengerNameRecordDocument>,
   InferCreationAttributes<TravelDeskPassengerNameRecordDocument>
 > {
-  declare documentID: CreationOptional<number>
+  declare id: CreationOptional<number>
   declare requestID: ForeignKey<TravelDeskTravelRequest["requestID"]>
   declare pnrDocument: Buffer | null
   declare invoiceNumber: string | null
@@ -52,7 +52,7 @@ export class TravelDeskPassengerNameRecordDocument extends Model<
 
 TravelDeskPassengerNameRecordDocument.init(
   {
-    documentID: {
+    id: {
       type: DataTypes.INTEGER,
       allowNull: false,
       primaryKey: true,

--- a/api/src/models/travel-desk-passenger-name-record-document.ts
+++ b/api/src/models/travel-desk-passenger-name-record-document.ts
@@ -24,6 +24,8 @@ export class TravelDeskPassengerNameRecordDocument extends Model<
   declare travelDeskTravelRequestId: ForeignKey<TravelDeskTravelRequest["requestID"]>
   declare pnrDocument: Buffer | null
   declare invoiceNumber: string | null
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   declare getTravelDeskTravelRequest: BelongsToGetAssociationMixin<TravelDeskTravelRequest>
   declare setTravelDeskTravelRequest: BelongsToSetAssociationMixin<
@@ -75,12 +77,21 @@ TravelDeskPassengerNameRecordDocument.init(
       type: DataTypes.STRING(255),
       allowNull: true,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     modelName: "TravelDeskPassengerNameRecordDocument",
     tableName: "travel_desk_passenger_name_record_documents",
-    timestamps: false,
   }
 )
 

--- a/api/src/models/travel-desk-pnr-document.ts
+++ b/api/src/models/travel-desk-pnr-document.ts
@@ -1,0 +1,84 @@
+import {
+  Association,
+  BelongsToCreateAssociationMixin,
+  BelongsToGetAssociationMixin,
+  BelongsToSetAssociationMixin,
+  CreationOptional,
+  DataTypes,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  NonAttribute,
+} from "sequelize"
+
+import { TravelDeskTravelRequest } from "./travel-desk-travel-request"
+
+import sequelize from "@/db/db-client"
+
+export class TravelDeskPnrDocument extends Model<
+  InferAttributes<TravelDeskPnrDocument>,
+  InferCreationAttributes<TravelDeskPnrDocument>
+> {
+  declare documentID: CreationOptional<number>
+  declare requestID: ForeignKey<TravelDeskTravelRequest["requestID"]>
+  declare pnrDocument: Buffer | null
+  declare invoiceNumber: string | null
+
+  declare getTravelDeskTravelRequest: BelongsToGetAssociationMixin<TravelDeskTravelRequest>
+  declare setTravelDeskTravelRequest: BelongsToSetAssociationMixin<
+    TravelDeskTravelRequest,
+    TravelDeskTravelRequest["requestID"]
+  >
+  declare createTravelDeskTravelRequest: BelongsToCreateAssociationMixin<TravelDeskTravelRequest>
+
+  declare travelDeskTravelRequest?: NonAttribute<TravelDeskTravelRequest>
+
+  declare static associations: {
+    travelDeskTravelRequest: Association<TravelDeskPnrDocument, TravelDeskTravelRequest>
+  }
+
+  static establishAssociations() {
+    this.belongsTo(TravelDeskTravelRequest, {
+      as: "travelDeskTravelRequest",
+      foreignKey: "requestID",
+    })
+  }
+}
+
+TravelDeskPnrDocument.init(
+  {
+    documentID: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    requestID: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "travelDeskTravelRequest", // using table name here, instead of Model class
+        key: "requestID",
+      },
+      onDelete: "CASCADE",
+    },
+    pnrDocument: {
+      type: DataTypes.BLOB,
+      allowNull: true,
+    },
+    invoiceNumber: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    modelName: "TravelDeskPnrDocument",
+    tableName: "travelDeskPnrDocuments",
+    underscored: false,
+    timestamps: false,
+  }
+)
+
+export default TravelDeskPnrDocument

--- a/api/src/models/travel-desk-travel-request.ts
+++ b/api/src/models/travel-desk-travel-request.ts
@@ -1,0 +1,14 @@
+import { CreationOptional, InferAttributes, InferCreationAttributes, Model } from "sequelize"
+
+export class TravelDeskTravelRequest extends Model<
+  InferAttributes<TravelDeskTravelRequest>,
+  InferCreationAttributes<TravelDeskTravelRequest>
+> {
+  declare requestID: CreationOptional<number>
+
+  // TODO: add other fields
+
+  // TODO: add associations
+}
+
+// TODO: add model initialization

--- a/api/src/routes/traveldesk-router.ts
+++ b/api/src/routes/traveldesk-router.ts
@@ -9,7 +9,7 @@ import {
   RequiresRoleTdUserOrAdmin,
 } from "@/middleware"
 import { UserService } from "@/services"
-import { TravelAuthorization, TravelDeskPnrDocument } from "@/models"
+import { TravelAuthorization, TravelDeskPassengerNameRecordDocument } from "@/models"
 
 import dbLegacy from "@/db/db-client-legacy"
 
@@ -55,7 +55,7 @@ travelDeskRouter.get("/", RequiresAuth, async function (req: Request, res: Respo
     }
     travelRequest.questions = questions
 
-    const travelDeskPnrDocument = await TravelDeskPnrDocument.findOne({
+    const travelDeskPnrDocument = await TravelDeskPassengerNameRecordDocument.findOne({
       attributes: ["invoiceNumber"],
       where: { requestID },
     })
@@ -103,7 +103,7 @@ travelDeskRouter.get(
         // @ts-ignore - isn't worth fixing at this time
         const requestID = form.travelRequest?.requestID
         if (requestID) {
-          const travelDeskPnrDocument = await TravelDeskPnrDocument.findOne({
+          const travelDeskPnrDocument = await TravelDeskPassengerNameRecordDocument.findOne({
             attributes: ["invoiceNumber"],
             where: { requestID },
           })
@@ -442,7 +442,7 @@ travelDeskRouter.get(
       }
       travelRequest.questions = questions
 
-      const travelDeskPnrDocument = await TravelDeskPnrDocument.findOne({
+      const travelDeskPnrDocument = await TravelDeskPassengerNameRecordDocument.findOne({
         attributes: ["invoiceNumber"],
         where: { requestID },
       })
@@ -674,7 +674,7 @@ travelDeskRouter.post(
     try {
       await dbLegacy.transaction(async (trx) => {
         // TODO: re-add to transaction once travelDeskTravelRequest is in Sequelize
-        await TravelDeskPnrDocument.upsert({
+        await TravelDeskPassengerNameRecordDocument.upsert({
           requestID,
           invoiceNumber: data.invoiceNumber,
           pnrDocument: file,
@@ -704,7 +704,7 @@ travelDeskRouter.get(
   async function (req, res) {
     try {
       const requestID = req.params.requestID
-      const doc = await TravelDeskPnrDocument.findOne({
+      const doc = await TravelDeskPassengerNameRecordDocument.findOne({
         where: { requestID },
       })
 

--- a/api/src/routes/traveldesk-router.ts
+++ b/api/src/routes/traveldesk-router.ts
@@ -57,7 +57,7 @@ travelDeskRouter.get("/", RequiresAuth, async function (req: Request, res: Respo
 
     const travelDeskPnrDocument = await TravelDeskPassengerNameRecordDocument.findOne({
       attributes: ["invoiceNumber"],
-      where: { requestID },
+      where: { travelDeskTravelRequestId: requestID },
     })
     travelRequest.invoiceNumber = travelDeskPnrDocument?.invoiceNumber || ""
   }
@@ -105,7 +105,7 @@ travelDeskRouter.get(
         if (requestID) {
           const travelDeskPnrDocument = await TravelDeskPassengerNameRecordDocument.findOne({
             attributes: ["invoiceNumber"],
-            where: { requestID },
+            where: { travelDeskTravelRequestId: requestID },
           })
 
           // @ts-ignore - isn't worth fixing at this time
@@ -444,7 +444,7 @@ travelDeskRouter.get(
 
       const travelDeskPnrDocument = await TravelDeskPassengerNameRecordDocument.findOne({
         attributes: ["invoiceNumber"],
-        where: { requestID },
+        where: { travelDeskTravelRequestId: requestID },
       })
       travelRequest.invoiceNumber = travelDeskPnrDocument?.invoiceNumber || ""
     }
@@ -675,7 +675,7 @@ travelDeskRouter.post(
       await dbLegacy.transaction(async (trx) => {
         // TODO: re-add to transaction once travelDeskTravelRequest is in Sequelize
         await TravelDeskPassengerNameRecordDocument.upsert({
-          requestID,
+          travelDeskTravelRequestId: requestID,
           invoiceNumber: data.invoiceNumber,
           pnrDocument: file,
         })
@@ -705,7 +705,7 @@ travelDeskRouter.get(
     try {
       const requestID = req.params.requestID
       const doc = await TravelDeskPassengerNameRecordDocument.findOne({
-        where: { requestID },
+        where: { travelDeskTravelRequestId: requestID },
       })
 
       if (isNull(doc)) {


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/45

References
- https://github.com/icefoganalytics/travel-authorization/issues/16
- https://github.com/icefoganalytics/travel-authorization/issues/30
- [Modeling, My Travel Requests, 2023-10-13](https://docs.google.com/document/d/1jpW3VokZa3v5Mv-Gf4Kfjve2WwTpK7X4cpep5-EROCE/edit?pli=1#heading=h.epyy9mt07rdp)

# Context

1. Replace all legacy "travelDeskPnrDocuments" queries with Sequelize TravelDeskPnrDocuments model queries, must add model.
2. Snake case/underscore all columns.
3. Fix primary key name, `documentID` should become `id`.
4. Fix all foreign key references in the table so that they refer to the table name they are referencing (i.e. `requestID` should become `travelDeskTravelRequestId`).
5. Add `created_at` and `update_at` standard timestamp columns.
6. Rename table and model to `travel_desk_passenger_name_record_documents` and `TravelDeskPassengerNameRecordDocuments` respectively.

# Implementation

Found out that I need to rename sequences and "constraints" for a full table/key rename. I've definitely missed this in the past, but hasn't caused any problems yet.

# Testing Instructions

1. Boot the db and api services via `dev up`.
2. Boot the web service by `dev up_web`.
3. Check that the app boots correctly.
4. Not sure how to test this for real through the UI, but the changes are minimal so hopefully its ok ...