### PR TITLE
Fixup: Fix TypesScript Complile Errors In Migrations

### DIFF
--- a/api/src/data/migrations/20231019153339_enforce-one-to-one-relationship-on-travel-desk-travel-request-id-in-travel-desk-passenger-name-record-documents-table.ts
+++ b/api/src/data/migrations/20231019153339_enforce-one-to-one-relationship-on-travel-desk-travel-request-id-in-travel-desk-passenger-name-record-documents-table.ts
@@ -16,7 +16,7 @@ export async function up(knex: Knex): Promise<void> {
       .inTable("travelDeskTravelRequest")
       .onDelete("CASCADE")
 
-    table.unique("travel_desk_travel_request_id", {
+    table.unique(["travel_desk_travel_request_id"], {
       indexName: "travel_desk_pnr_documents_travel_desk_travel_request_id_unique",
     })
   })

--- a/api/src/data/migrations/20231019181549_enforce-one-to-one-relationship-on-travel-authorization-id-in-travel-desk-travel-request.ts
+++ b/api/src/data/migrations/20231019181549_enforce-one-to-one-relationship-on-travel-authorization-id-in-travel-desk-travel-request.ts
@@ -2,7 +2,7 @@ import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable("travel_desk_travel_requests", (table) => {
-    table.unique("travel_authorization_id")
+    table.unique(["travel_authorization_id"])
   })
 }
 


### PR DESCRIPTION
# Context

Build is failing https://github.com/icefoganalytics/travel-authorization/actions/runs/6580551620/job/17879396109

<details><summary>Log Details</summary>

```
#22 10.97 src/data/migrations/20231019153339_enforce-one-to-one-relationship-on-travel-desk-travel-request-id-in-travel-desk-passenger-name-record-documents-table.ts(19,18): error TS2769: No overload matches this call.
#22 10.97   Overload 1 of 2, '(columnNames: readonly (string | Raw<any>)[], options?: Readonly<{ indexName?: string | undefined; storageEngineIndexType?: string | undefined; deferrable?: deferrableType | undefined; useConstraint?: boolean | undefined; }> | undefined): TableBuilder', gave the following error.
#22 10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
#22 10.97   Overload 2 of 2, '(columnNames: readonly (string | Raw<any>)[], indexName?: string | undefined): TableBuilder', gave the following error.
#22 10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
#22 10.97 src/data/migrations/20231019181549_enforce-one-to-one-relationship-on-travel-authorization-id-in-travel-desk-travel-request.ts(5,18): error TS2769: No overload matches this call.
#22 10.97   Overload 1 of 2, '(columnNames: readonly (string | Raw<any>)[], options?: Readonly<{ indexName?: string | undefined; storageEngineIndexType?: string | undefined; deferrable?: deferrableType | undefined; useConstraint?: boolean | undefined; }> | undefined): TableBuilder', gave the following error.
#22 10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
#22 10.97   Overload 2 of 2, '(columnNames: readonly (string | Raw<any>)[], indexName?: string | undefined): TableBuilder', gave the following error.
#22 10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
#22 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 2
------
 > [17/18] RUN npm run build:
10.97 src/data/migrations/20231019153339_enforce-one-to-one-relationship-on-travel-desk-travel-request-id-in-travel-desk-passenger-name-record-documents-table.ts(19,18): error TS2769: No overload matches this call.
10.97   Overload 1 of 2, '(columnNames: readonly (string | Raw<any>)[], options?: Readonly<{ indexName?: string | undefined; storageEngineIndexType?: string | undefined; deferrable?: deferrableType | undefined; useConstraint?: boolean | undefined; }> | undefined): TableBuilder', gave the following error.
10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
10.97   Overload 2 of 2, '(columnNames: readonly (string | Raw<any>)[], indexName?: string | undefined): TableBuilder', gave the following error.
10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
10.97 src/data/migrations/20231019181549_enforce-one-to-one-relationship-on-travel-authorization-id-in-travel-desk-travel-request.ts(5,18): error TS2769: No overload matches this call.
10.97   Overload 1 of 2, '(columnNames: readonly (string | Raw<any>)[], options?: Readonly<{ indexName?: string | undefined; storageEngineIndexType?: string | undefined; deferrable?: deferrableType | undefined; useConstraint?: boolean | undefined; }> | undefined): TableBuilder', gave the following error.
10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
10.97   Overload 2 of 2, '(columnNames: readonly (string | Raw<any>)[], indexName?: string | undefined): TableBuilder', gave the following error.
10.97     Argument of type 'string' is not assignable to parameter of type 'readonly (string | Raw<any>)[]'.
------
``` 

</details> 

# Solution

Wrap unique definition in an array.
I'm not getting an error locally, but I'm getting an error in the docker build environment.
There must be something different between the typing system in production? Even with a local production build, I don't get this error.