### PR TITLE
Fix Hotel Select Lost on Save Draft

### DIFF
--- a/api/src/controllers/travel-authorizations-controller.ts
+++ b/api/src/controllers/travel-authorizations-controller.ts
@@ -119,7 +119,7 @@ export class TravelAuthorizationsController extends BaseController {
         .json({ message: "You are not authorized to update this travelAuthorization." })
     }
 
-    return TravelAuthorizationsService.update(this.params.travelAuthorizationId, this.request.body)
+    return TravelAuthorizationsService.update(travelAuthorization, this.request.body)
       .then((travelAuthorization) => {
         this.response.json({ travelAuthorization })
       })

--- a/api/src/data/migrations/20231017223028_standardize-expenses-foreign-key-reference-to-travel-authorizations-table.ts
+++ b/api/src/data/migrations/20231017223028_standardize-expenses-foreign-key-reference-to-travel-authorizations-table.ts
@@ -20,6 +20,6 @@ export async function down(knex: Knex): Promise<void> {
 
     table.renameColumn("travel_authorization_id", "form_id")
 
-    table.foreign("form_id").references("id").inTable("forms").onDelete("CASCADE")
+    table.foreign("form_id").references("id").inTable("travel_authorizations").onDelete("CASCADE")
   })
 }

--- a/api/src/services/travel-authorizations-service.ts
+++ b/api/src/services/travel-authorizations-service.ts
@@ -38,18 +38,10 @@ export class TravelAuthorizationsService {
   }
 
   static async update(
-    id: string | number,
+    travelAuthorization: TravelAuthorization,
     { stops = [], expenses = [], ...attributes }: Partial<TravelAuthorization>
   ): Promise<TravelAuthorization> {
-    // TODO: change the function signature, so that you can pass in a travelAuthorization instance.
-    const travelAuthorization = await TravelAuthorization.findByPk(id, {
-      include: ["expenses", "stops", "purpose"],
-    })
-    if (isNull(travelAuthorization)) {
-      throw new Error(`Could not find TravelAuthorization with id: ${id}`)
-    }
-
-    travelAuthorization.update(attributes).catch((error) => {
+    await travelAuthorization.update(attributes).catch((error) => {
       throw new Error(`Could not update TravelAuthorization: ${error}`)
     })
 
@@ -58,17 +50,14 @@ export class TravelAuthorizationsService {
     // If we are using an ORM such as Sequelize, it would then be worth doing.
     const travelAuthorizationId = travelAuthorization.id
     if (!isEmpty(stops)) {
-      travelAuthorization.stops = await StopsService.bulkReplace(travelAuthorizationId, stops)
+      await StopsService.bulkReplace(travelAuthorizationId, stops)
     }
 
     if (!isEmpty(expenses)) {
-      travelAuthorization.expenses = await ExpensesService.bulkReplace(
-        travelAuthorizationId,
-        expenses
-      )
+      await ExpensesService.bulkReplace(travelAuthorizationId, expenses)
     }
 
-    return travelAuthorization
+    return travelAuthorization.reload({ include: ["expenses", "stops", "purpose"] })
   }
 }
 

--- a/web/src/modules/travel-form/components/AccommodationTypeSelect.vue
+++ b/web/src/modules/travel-form/components/AccommodationTypeSelect.vue
@@ -43,23 +43,35 @@ export default {
     },
   },
   data() {
+    const accommodationTypes = Object.values(ACCOMMODATION_TYPES)
+    const accommodationType = this.accommodationTypeFromValue(
+      accommodationTypes,
+      this.value,
+      this.defaultValue
+    )
+    const accommodationTypeOther = this.accommodationTypeOtherFromValue(
+      accommodationTypes,
+      this.value
+    )
+
     return {
       ACCOMMODATION_TYPES,
-      accommodationType: "",
-      accommodationTypeOther: "",
-      accommodationTypes: Object.values(ACCOMMODATION_TYPES),
+      accommodationType,
+      accommodationTypeOther,
+      accommodationTypes,
     }
   },
   watch: {
     value(newValue) {
-      if (isNil(newValue)) {
-        this.accommodationType = this.defaultValue
-      } else if (this.accommodationTypes.includes(newValue)) {
-        this.accommodationType = newValue
-      } else {
-        this.accommodationType = ACCOMMODATION_TYPES.OTHER
-        this.accommodationTypeOther = newValue
-      }
+      this.accommodationType = this.accommodationTypeFromValue(
+        this.accommodationTypes,
+        newValue,
+        this.defaultValue
+      )
+      this.accommodationTypeOther = this.accommodationTypeOtherFromValue(
+        this.accommodationTypes,
+        newValue
+      )
     },
   },
   methods: {
@@ -75,6 +87,24 @@ export default {
     updateAccommodationTypeOther(value) {
       this.$emit("input", value)
       this.accommodationTypeOther = value
+    },
+    accommodationTypeFromValue(accommodationTypes, value, defaultValue) {
+      if (isNil(value)) {
+        return defaultValue
+      }
+
+      if (accommodationTypes.includes(value)) {
+        return value
+      }
+
+      return ACCOMMODATION_TYPES.OTHER
+    },
+    accommodationTypeOtherFromValue(accommodationTypes, value) {
+      if (accommodationTypes.includes(value)) {
+        return ""
+      }
+
+      return value
     },
   },
 }

--- a/web/src/modules/travel-form/components/AccommodationTypeSelect.vue
+++ b/web/src/modules/travel-form/components/AccommodationTypeSelect.vue
@@ -50,15 +50,17 @@ export default {
       accommodationTypes: Object.values(ACCOMMODATION_TYPES),
     }
   },
-  mounted() {
-    if (isNil(this.value)) {
-      this.accommodationType = this.defaultValue
-    } else if (this.accommodationTypes.includes(this.value)) {
-      this.accommodationType = this.value
-    } else {
-      this.accommodationType = ACCOMMODATION_TYPES.OTHER
-      this.accommodationTypeOther = this.value
-    }
+  watch: {
+    value(newValue) {
+      if (isNil(newValue)) {
+        this.accommodationType = this.defaultValue
+      } else if (this.accommodationTypes.includes(newValue)) {
+        this.accommodationType = newValue
+      } else {
+        this.accommodationType = ACCOMMODATION_TYPES.OTHER
+        this.accommodationTypeOther = newValue
+      }
+    },
   },
   methods: {
     updateAccommodationType(value) {

--- a/web/src/modules/travel-form/components/TravelMethodSelect.vue
+++ b/web/src/modules/travel-form/components/TravelMethodSelect.vue
@@ -43,20 +43,22 @@ export default {
     },
   },
   data() {
+    const travelMethods = Object.values(TRAVEL_METHODS)
+    const travelMethod = this.travelMethodFromValue(travelMethods, this.value)
+    const travelMethodOther = this.travelMethodOtherFromValue(travelMethods, this.value)
+
     return {
       TRAVEL_METHODS,
-      travelMethods: Object.values(TRAVEL_METHODS),
-      travelMethod: "",
-      travelMethodOther: "",
+      travelMethods,
+      travelMethod,
+      travelMethodOther,
     }
   },
-  mounted() {
-    if (this.travelMethods.includes(this.value)) {
-      this.travelMethod = this.value
-    } else {
-      this.travelMethod = TRAVEL_METHODS.OTHER
-      this.travelMethodOther = this.value
-    }
+  watch: {
+    value (newValue) {
+      this.travelMethod = this.travelMethodFromValue(this.travelMethods, newValue)
+      this.travelMethodOther = this.travelMethodOtherFromValue(this.travelMethods, newValue)
+    },
   },
   methods: {
     updateFromTravelMethod(value) {
@@ -71,6 +73,20 @@ export default {
     updateFromTravelMethodOther(value) {
       this.$emit("input", value)
       this.travelMethodOther = value
+    },
+    travelMethodFromValue(travelMethods, value) {
+      if (travelMethods.includes(value)) {
+        return value
+      }
+
+      return TRAVEL_METHODS.OTHER
+    },
+    travelMethodOtherFromValue(travelMethods, value) {
+      if (travelMethods.includes(value)) {
+        return ""
+      }
+
+      return value
     },
   },
 }

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -41,11 +41,11 @@
           </v-col>
         </v-row>
 
-        <RoundTripStopsSection v-if="tripType === TRIP_TYPES.ROUND_TRIP" />
-        <OneWayStopsSection v-else-if="tripType === TRIP_TYPES.ONE_WAY" />
-        <MultiDestinationStopsSection v-else-if="tripType === TRIP_TYPES.MULI_DESTINATION" />
+        <component
+          v-if="tripTypeComponent"
+          :is="tripTypeComponent"
+        />
         <div v-else>Trip type {{ tripType }} not implemented!</div>
-
         <v-row>
           <v-col
             cols="12"
@@ -98,9 +98,6 @@ import { mapState, mapGetters } from "vuex"
 import { last } from "lodash"
 
 import DatePicker from "@/components/Utils/DatePicker"
-import MultiDestinationStopsSection from "./details-form-card/MultiDestinationStopsSection"
-import OneWayStopsSection from "./details-form-card/OneWayStopsSection"
-import RoundTripStopsSection from "./details-form-card/RoundTripStopsSection"
 
 const TRIP_TYPES = Object.freeze({
   ROUND_TRIP: "Round Trip",
@@ -112,9 +109,6 @@ export default {
   name: "DetailsFormCard",
   components: {
     DatePicker,
-    MultiDestinationStopsSection,
-    OneWayStopsSection,
-    RoundTripStopsSection,
   },
   data: () => ({
     TRIP_TYPES,
@@ -128,6 +122,18 @@ export default {
     ...mapGetters("travelForm", ["currentFormId"]),
     finalDestination() {
       return last(this.currentForm.stops) || { travelAuthorizationId: this.currentFormId }
+    },
+    tripTypeComponent() {
+      switch (this.tripType) {
+        case TRIP_TYPES.ROUND_TRIP:
+          return () => import("./details-form-card/RoundTripStopsSection")
+        case TRIP_TYPES.ONE_WAY:
+          return () => import("./details-form-card/OneWayStopsSection")
+        case TRIP_TYPES.MULI_DESTINATION:
+          return () => import("./details-form-card/MultiDestinationStopsSection")
+        default:
+          return null
+      }
     },
   },
   mounted() {

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -43,7 +43,7 @@
 
         <RoundTripStopsSection v-if="tripType === TRIP_TYPES.ROUND_TRIP" />
         <OneWayStopsSection v-else-if="tripType === TRIP_TYPES.ONE_WAY" />
-        <MuliDestinationStopsSection v-else-if="tripType === TRIP_TYPES.MULI_DESTINATION" />
+        <MultiDestinationStopsSection v-else-if="tripType === TRIP_TYPES.MULI_DESTINATION" />
         <div v-else>Trip type {{ tripType }} not implemented!</div>
 
         <v-row>
@@ -98,7 +98,7 @@ import { mapState, mapGetters } from "vuex"
 import { last } from "lodash"
 
 import DatePicker from "@/components/Utils/DatePicker"
-import MuliDestinationStopsSection from "./details-form-card/MuliDestinationStopsSection"
+import MultiDestinationStopsSection from "./details-form-card/MultiDestinationStopsSection"
 import OneWayStopsSection from "./details-form-card/OneWayStopsSection"
 import RoundTripStopsSection from "./details-form-card/RoundTripStopsSection"
 
@@ -112,7 +112,7 @@ export default {
   name: "DetailsFormCard",
   components: {
     DatePicker,
-    MuliDestinationStopsSection,
+    MultiDestinationStopsSection,
     OneWayStopsSection,
     RoundTripStopsSection,
   },

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/MuliDestinationStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/MuliDestinationStopsSection.vue
@@ -239,7 +239,7 @@
 
 <script>
 import { mapActions, mapState, mapGetters } from "vuex"
-import { isArray, isEmpty } from "lodash"
+import { isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
@@ -260,41 +260,17 @@ export default {
     TimePicker,
     TravelMethodSelect,
   },
+  data() {
+    return {
+      stop1: {},
+      stop2: {},
+      stop3: {},
+      stop4: {},
+    }
+  },
   computed: {
     ...mapState("travelForm", ["currentForm"]),
     ...mapGetters("travelForm", ["currentFormId", "destinationsByCurrentFormTravelRestriction"]),
-    stop1() {
-      if (isEmpty(this.currentForm?.stops)) return this.newStop()
-
-      return this.currentForm.stops[0]
-    },
-    stop2() {
-      if (
-        isEmpty(this.currentForm?.stops) ||
-        (isArray(this.currentForm?.stops) && this.currentForm.stops.length < 2)
-      )
-        return this.newStop()
-
-      return this.currentForm.stops[1]
-    },
-    stop3() {
-      if (
-        isEmpty(this.currentForm?.stops) ||
-        (isArray(this.currentForm?.stops) && this.currentForm.stops.length < 3)
-      )
-        return this.newStop()
-
-      return this.currentForm.stops[2]
-    },
-    stop4() {
-      if (
-        isEmpty(this.currentForm?.stops) ||
-        (isArray(this.currentForm?.stops) && this.currentForm.stops.length < 4)
-      )
-        return this.newStop()
-
-      return this.currentForm.stops[3]
-    },
   },
   async mounted() {
     await this.loadDestinations()
@@ -310,6 +286,11 @@ export default {
     } else if (this.currentForm.stops.length > 4) {
       this.currentForm.stops = this.currentForm.stops.slice(0, 3)
     }
+
+    this.stop1 = this.currentForm.stops[0]
+    this.stop2 = this.currentForm.stops[1]
+    this.stop3 = this.currentForm.stops[2]
+    this.stop4 = this.currentForm.stops[3]
   },
   methods: {
     ...mapActions("travelForm", ["loadDestinations"]),

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
@@ -253,7 +253,7 @@ import TravelMethodSelect, {
 } from "@/modules/travel-form/components/TravelMethodSelect"
 
 export default {
-  name: "MuliDestinationStopsSection",
+  name: "MultiDestinationStopsSection",
   components: {
     AccommodationTypeSelect,
     DatePicker,

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -6,7 +6,7 @@
         md="2"
       >
         <v-autocomplete
-          v-model="from.locationId"
+          v-model="originStop.locationId"
           :items="destinationsByCurrentFormTravelRestriction"
           :rules="[required]"
           label="From"
@@ -22,7 +22,7 @@
         md="2"
       >
         <v-autocomplete
-          v-model="to.locationId"
+          v-model="destinationStop.locationId"
           :items="destinationsByCurrentFormTravelRestriction"
           :rules="[required]"
           label="To"
@@ -38,7 +38,7 @@
         md="2"
       >
         <DatePicker
-          v-model="from.departureDate"
+          v-model="originStop.departureDate"
           :rules="[required]"
           text="Date"
           persistent-hint
@@ -49,7 +49,7 @@
         md="2"
       >
         <TimePicker
-          v-model="from.departureTime"
+          v-model="originStop.departureTime"
           :rules="[required]"
           text="Time"
           persistent-hint
@@ -60,7 +60,7 @@
         md="4"
       >
         <TravelMethodSelect
-          v-model="from.transport"
+          v-model="originStop.transport"
           :rules="[required]"
           background-color="white"
           dense
@@ -69,7 +69,7 @@
           outlined
         />
         <AccommodationTypeSelect
-          v-model="from.accommodationType"
+          v-model="originStop.accommodationType"
           :rules="[required]"
           background-color="white"
           dense
@@ -83,7 +83,7 @@
 
 <script>
 import { mapActions, mapState, mapGetters } from "vuex"
-import { isArray, isEmpty } from "lodash"
+import { isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
@@ -104,23 +104,15 @@ export default {
     TimePicker,
     TravelMethodSelect,
   },
+  data() {
+    return {
+      originStop: {},
+      destinationStop: {},
+    }
+  },
   computed: {
     ...mapState("travelForm", ["currentForm"]),
     ...mapGetters("travelForm", ["currentFormId", "destinationsByCurrentFormTravelRestriction"]),
-    from() {
-      if (isEmpty(this.currentForm?.stops)) return this.newStop()
-
-      return this.currentForm.stops[0]
-    },
-    to() {
-      if (
-        isEmpty(this.currentForm?.stops) ||
-        (isArray(this.currentForm?.stops) && this.currentForm.stops.length < 2)
-      )
-        return this.newStop()
-
-      return this.currentForm.stops[1]
-    },
   },
   async mounted() {
     await this.loadDestinations()
@@ -133,6 +125,9 @@ export default {
       const elementsToRemove = this.currentForm.stops.length - 2
       this.currentForm.stops.splice(1, elementsToRemove)
     }
+
+    this.originStop = this.currentForm.stops[0]
+    this.destinationStop = this.currentForm.stops[1]
   },
   methods: {
     ...mapActions("travelForm", ["loadDestinations"]),

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -69,7 +69,7 @@
           outlined
         />
         <AccommodationTypeSelect
-          v-model="destinationStop.accommodationType"
+          v-model="originStop.accommodationType"
           :rules="[required]"
           background-color="white"
           dense
@@ -147,7 +147,7 @@
           outlined
         />
         <AccommodationTypeSelect
-          v-model="originStop.accommodationType"
+          v-model="destinationStop.accommodationType"
           :default-value="null"
           background-color="white"
           hint="Optional, set only if neccessary"

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -164,7 +164,7 @@
 
 <script>
 import { mapActions, mapState, mapGetters } from "vuex"
-import { isArray, isEmpty } from "lodash"
+import { isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
@@ -185,23 +185,15 @@ export default {
     TimePicker,
     TravelMethodSelect,
   },
+  data() {
+    return {
+      originStop: {},
+      destinationStop: {},
+    }
+  },
   computed: {
     ...mapState("travelForm", ["currentForm"]),
     ...mapGetters("travelForm", ["currentFormId", "destinationsByCurrentFormTravelRestriction"]),
-    originStop() {
-      if (isEmpty(this.currentForm?.stops)) return this.newStop()
-
-      return this.currentForm.stops[0]
-    },
-    destinationStop() {
-      if (
-        isEmpty(this.currentForm?.stops) ||
-        (isArray(this.currentForm?.stops) && this.currentForm.stops.length < 2)
-      )
-        return this.newStop()
-
-      return this.currentForm.stops[1]
-    },
   },
   async mounted() {
     await this.loadDestinations()
@@ -214,6 +206,9 @@ export default {
       const elementsToRemove = this.currentForm.stops.length - 2
       this.currentForm.stops.splice(1, elementsToRemove)
     }
+
+    this.originStop = this.currentForm.stops[0]
+    this.destinationStop = this.currentForm.stops[1]
   },
   methods: {
     ...mapActions("travelForm", ["loadDestinations"]),


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/61

# Context

When filling out the travel authorization form, in the "Details" panel, the accommodation type is auto-selected as "hotel". However, upon saving the draft, the accommodation type in the first row gets deleted. If this deletion goes unnoticed and the user proceeds to generate estimates, the missing accommodation type results in inaccurate estimates.

## Expected Behavior
The accommodation type should remain as "hotel" after saving the draft and should be accurately captured when generating estimates.

## Actual Behavior
The accommodation type in the first row gets deleted upon saving the draft, leading to inaccuracies in generated estimates.

# Testing Instructions

1. Boot the database and api services via `dev up`
2. Boot the web service via `dev up_web`.
3. Log in to the app at http://localhost:8080/
4. Go to the "My Travel Requests" page via the top nav.
5. Create a new travel request via the "+ Travel Authorization" button.
6. Fill out stops in the "Details" panel.
7. Notice that the final accommodation type is _no longer_ auto-selected as "hotel".
8. Save the as Draft.
9. Observe that the accommodation type in the first row is now persisted.
10. Go to the "Estimate" tab and check that the generated estimate now references the correct accommodation type.
11. Go back to the "Details" tab, and in the "Details" section, add a final accommodation type.
12. Save as Draft, and check that the value persists.
13. Go to the "Estimate" tab and check that the generated estimate now references the correct accommodation type for the last day.

