### PR TITLE
Move "In Territory" Selector to Top

### DIFF
--- a/web/src/modules/travel-form/pages/TravelAuthorizationRead.vue
+++ b/web/src/modules/travel-form/pages/TravelAuthorizationRead.vue
@@ -4,7 +4,7 @@
 
     <Breadcrumbs />
 
-    <h1 class="d-flex justify-space-between">
+    <h1 class="d-flex justify-space-between mb-0">
       <span>
         Travel -
         <v-progress-circular
@@ -76,11 +76,7 @@ export default {
     tab: null,
   }),
   computed: {
-    ...mapState("travelForm", [
-      "currentUser",
-      "loadingCurrentForm",
-      "loadingCurrentUser",
-    ]),
+    ...mapState("travelForm", ["currentUser", "loadingCurrentForm", "loadingCurrentUser"]),
     isAdmin() {
       return this.currentUser?.roles.includes("admin")
     },

--- a/web/src/modules/travel-form/pages/travel-authorization-read/SummaryHeaderPanel.vue
+++ b/web/src/modules/travel-form/pages/travel-authorization-read/SummaryHeaderPanel.vue
@@ -7,7 +7,7 @@
       >
         <!-- Depending on in territory flag we will load a different list of destinations -->
         <v-checkbox
-          :value="currentForm.allTravelWithinTerritory"
+          :input-value="currentForm.allTravelWithinTerritory"
           label="In Territory?"
           dense
           outlined

--- a/web/src/modules/travel-form/pages/travel-authorization-read/SummaryHeaderPanel.vue
+++ b/web/src/modules/travel-form/pages/travel-authorization-read/SummaryHeaderPanel.vue
@@ -5,6 +5,22 @@
         cols="12"
         md="2"
       >
+        <!-- Depending on in territory flag we will load a different list of destinations -->
+        <v-checkbox
+          :value="currentForm.allTravelWithinTerritory"
+          label="In Territory?"
+          dense
+          outlined
+          readonly
+        >
+        </v-checkbox>
+      </v-col>
+    </v-row>
+    <v-row dense>
+      <v-col
+        cols="12"
+        md="2"
+      >
         <v-text-field
           :value="purposeText"
           label="Purpose"

--- a/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/DetailsCard.vue
+++ b/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/DetailsCard.vue
@@ -5,20 +5,6 @@
       <v-row>
         <v-col
           cols="12"
-          md="2"
-        >
-          <!-- Depending on in territory flag we will load a different list of destinations -->
-          <v-checkbox
-            :value="currentForm.allTravelWithinTerritory"
-            label="In Territory?"
-            dense
-            outlined
-            readonly
-          >
-          </v-checkbox>
-        </v-col>
-        <v-col
-          cols="12"
           md="3"
         >
           <v-text-field

--- a/web/src/modules/travel-form/views/travel-form-edit/SummaryHeaderForm.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/SummaryHeaderForm.vue
@@ -8,6 +8,21 @@
         cols="12"
         md="2"
       >
+        <!-- Depending on in territory flag we will load a different list of destinations -->
+        <v-checkbox
+          v-model="currentForm.allTravelWithinTerritory"
+          label="In Territory?"
+          dense
+          required
+        >
+        </v-checkbox>
+      </v-col>
+    </v-row>
+    <v-row dense>
+      <v-col
+        cols="12"
+        md="2"
+      >
         <v-select
           v-model="currentForm.purposeId"
           :items="purposes"

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -11,19 +11,6 @@
         <v-row>
           <v-col
             cols="12"
-            md="2"
-          >
-            <!-- Depending on in territory flag we will load a different list of destinations -->
-            <v-checkbox
-              v-model="currentForm.allTravelWithinTerritory"
-              label="In Territory?"
-              dense
-              required
-            >
-            </v-checkbox>
-          </v-col>
-          <v-col
-            cols="12"
             md="3"
           >
             <v-select


### PR DESCRIPTION
# Context

On the TA details screen, move "in territory to top of screen.

![image](https://github.com/icefoganalytics/travel-authorization/assets/89539008/ff3f5156-6905-4cd2-ba02-abd9c9e8b8ca)

# Screenshots

New - read only
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/d270cc2b-2c50-4d97-9cfb-04ca6eb81d4c)

New - edit mode
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/9c27275c-479b-4a95-9453-292d22f67bc9)


# Testing Instructions

1. Boot the app via `dev up`
2. Login at to http://localhost:8080.
3. Go to the "My Travel Requests" page via the top nav.
4. Create a new travel authorizations.
5. Check that the "In Territory" selector is now the first thing you need to select.
6. Check that toggling the selector restricts the various destination selectors.
7. Submit the travel authorization to your supervisor.
8. Check that the "In Territory" selector is now the first thing you see.
9. Check that if it was checked, it's checked on this read-only view as well.