### PR TITLE
TA Details: Make It Clear That Time Selection Is 24 Hour

### DIFF
--- a/api/src/controllers/travel-authorizations-controller.ts
+++ b/api/src/controllers/travel-authorizations-controller.ts
@@ -57,7 +57,11 @@ export class TravelAuthorizationsController extends BaseController {
     const permittedAttributes = policy.permitAttributesForCreate(this.request.body)
     return TravelAuthorizationsService.create(permittedAttributes, this.currentUser)
       .then((travelAuthorization) => {
-        return this.response.status(201).json({ travelAuthorization })
+        const serializedTravelAuthorization =
+          TravelAuthorizationsSerializer.asDetailed(travelAuthorization)
+        return this.response
+          .status(201)
+          .json({ travelAuthorization: serializedTravelAuthorization })
       })
       .catch((error) => {
         return this.response
@@ -90,7 +94,10 @@ export class TravelAuthorizationsController extends BaseController {
         return this.response.status(404).json({ message: "TravelAuthorization not found." })
       }
 
-      return this.response.json({ travelAuthorization })
+      const serializedTravelAuthorization =
+        TravelAuthorizationsSerializer.asDetailed(travelAuthorization)
+
+      return this.response.json({ travelAuthorization: serializedTravelAuthorization })
     })
   }
 
@@ -114,7 +121,10 @@ export class TravelAuthorizationsController extends BaseController {
     const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
     return TravelAuthorizationsService.update(travelAuthorization, permittedAttributes)
       .then((travelAuthorization) => {
-        this.response.json({ travelAuthorization })
+        const serializedTravelAuthorization =
+          TravelAuthorizationsSerializer.asDetailed(travelAuthorization)
+
+        return this.response.json({ travelAuthorization: serializedTravelAuthorization })
       })
       .catch((error) => {
         return this.response

--- a/api/src/serializers/index.ts
+++ b/api/src/serializers/index.ts
@@ -1,4 +1,5 @@
 export * from './expenses-serializer'
+export * from './stops-serializer'
 export * from './travel-authorizations-serializer'
 export * from './users-serializer'
 

--- a/api/src/serializers/stops-serializer.ts
+++ b/api/src/serializers/stops-serializer.ts
@@ -1,0 +1,28 @@
+import { isNil } from "lodash"
+
+import { Stop } from "@/models"
+
+import BaseSerializer from "./base-serializer"
+
+export class StopsSerializer extends BaseSerializer<Stop> {
+  static asDetailed(stop: Stop): Partial<Stop> {
+    const serializer = new StopsSerializer(stop)
+    return serializer.asDetailed()
+  }
+
+  asDetailed(): Partial<Stop> {
+    return {
+      ...this.record.dataValues,
+      departureTime: this.formatTimeToHHmm(),
+    }
+  }
+
+  formatTimeToHHmm(): string | null {
+    const timeString = this.record.departureTime
+    if (isNil(timeString)) return null
+
+    return timeString.split(":").slice(0, 2).join(":")
+  }
+}
+
+export default StopsSerializer

--- a/api/src/serializers/travel-authorizations-serializer.ts
+++ b/api/src/serializers/travel-authorizations-serializer.ts
@@ -3,6 +3,7 @@ import { isEmpty, isNil, last, first, pick } from "lodash"
 import { Expense, Stop, TravelAuthorization, TravelDeskTravelRequest } from "@/models"
 
 import BaseSerializer from "./base-serializer"
+import StopsSerializer from "./stops-serializer"
 
 export class TravelAuthorizationsSerializer extends BaseSerializer<TravelAuthorization> {
   static asTable(travelAuthorizations: TravelAuthorization[]) {
@@ -10,6 +11,13 @@ export class TravelAuthorizationsSerializer extends BaseSerializer<TravelAuthori
       const serializer = new this(travelAuthorization)
       return serializer.asTableRow()
     })
+  }
+
+  static asDetailed(
+    record: TravelAuthorization
+  ): Omit<Partial<TravelAuthorization>, "stops"> & { stops: Partial<Stop>[] } {
+    const serializer = new this(record)
+    return serializer.asDetailed()
   }
 
   private firstStop: Stop | undefined
@@ -21,6 +29,13 @@ export class TravelAuthorizationsSerializer extends BaseSerializer<TravelAuthori
     this.firstStop = first(this.record.stops)
     this.lastStop = last(this.record.stops)
     this.currentDate = new Date()
+  }
+
+  asDetailed(): Omit<Partial<TravelAuthorization>, "stops"> & { stops: Partial<Stop>[] } {
+    return {
+      ...this.record.dataValues,
+      stops: this.record.stops?.map(StopsSerializer.asDetailed) || [],
+    }
   }
 
   asTableRow() {

--- a/web/src/components/Utils/DatePicker.vue
+++ b/web/src/components/Utils/DatePicker.vue
@@ -30,15 +30,24 @@
 </template>
 
 <script>
-import { isEmpty } from 'lodash'
+import { isEmpty } from "lodash"
 
-import { required } from '@/utils/validators'
+import { required } from "@/utils/validators"
 
 export default {
   inheritAttrs: false,
   props: {
     value: String,
-    text: String, // DEPRECATED: prefer label
+    text: {
+      type: String,
+      default: undefined,
+      validator(value) {
+        if (value !== undefined) {
+          console.warn('The "text" prop is deprecated; prefer using "label" instead.')
+        }
+        return true
+      },
+    },
     label: String,
     rules: {
       type: Array,

--- a/web/src/components/Utils/TimePicker.vue
+++ b/web/src/components/Utils/TimePicker.vue
@@ -11,7 +11,7 @@
       <v-text-field
         dense
         :value="value"
-        :label="text"
+        :label="label || text"
         prepend-icon="mdi-clock"
         background-color="white"
         outlined
@@ -37,7 +37,17 @@
 export default {
   props: {
     value: String,
-    text: String,
+    text: {
+      type: String,
+      default: undefined,
+      validator(value) {
+        if (value !== undefined) {
+          console.warn('The "text" prop is deprecated; prefer using "label" instead.')
+        }
+        return true
+      },
+    },
+    label: String,
     review: {
       type: Boolean,
       default: false,

--- a/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/details-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/details-card/MultiDestinationStopsSection.vue
@@ -123,7 +123,7 @@
       >
         <v-text-field
           :value="stop2.departureTime"
-          text="Time"
+          label="Time (24h)"
           prepend-icon="mdi-clock"
           dense
           outlined
@@ -197,7 +197,7 @@
       >
         <v-text-field
           :value="stop3.departureTime"
-          text="Time"
+          label="Time (24h)"
           prepend-icon="mdi-clock"
           dense
           outlined

--- a/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/details-card/OneWayStopsSection.vue
+++ b/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/details-card/OneWayStopsSection.vue
@@ -47,7 +47,7 @@
       >
         <v-text-field
           :value="originStop.departureTime"
-          label="Time"
+          label="Time (24h)"
           prepend-icon="mdi-clock"
           dense
           outlined

--- a/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/details-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-form/pages/travel-authorization-read/details-tab/details-card/RoundTripStopsSection.vue
@@ -47,7 +47,7 @@
       >
         <v-text-field
           :value="originStop.departureTime"
-          label="Time"
+          label="Time (24h)"
           prepend-icon="mdi-clock"
           dense
           outlined
@@ -123,7 +123,7 @@
       >
         <v-text-field
           :value="destinationStop.departureTime"
-          label="Time"
+          label="Time (24h)"
           prepend-icon="mdi-clock"
           dense
           outlined

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
@@ -51,7 +51,7 @@
         <TimePicker
           v-model="stop1.departureTime"
           :rules="[required]"
-          text="Time"
+          label="Time (24h)"
           persistent-hint
         />
       </v-col>
@@ -129,7 +129,7 @@
         <TimePicker
           v-model="stop2.departureTime"
           :rules="[required]"
-          text="Time"
+          label="Time (24 hour)"
           persistent-hint
         />
       </v-col>
@@ -207,7 +207,7 @@
         <TimePicker
           v-model="stop3.departureTime"
           :rules="[required]"
-          text="Time"
+          label="Time (24 hour)"
           persistent-hint
         />
       </v-col>

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -51,7 +51,7 @@
         <TimePicker
           v-model="originStop.departureTime"
           :rules="[required]"
-          text="Time"
+          label="Time (24h)"
           persistent-hint
         />
       </v-col>

--- a/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-form/views/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -51,7 +51,7 @@
         <TimePicker
           v-model="originStop.departureTime"
           :rules="[required]"
-          text="Time"
+          label="Time (24h)"
           persistent-hint
         />
       </v-col>
@@ -129,7 +129,7 @@
         <TimePicker
           v-model="destinationStop.departureTime"
           :rules="[required]"
-          text="Time"
+          label="Time (24h)"
           persistent-hint
         />
       </v-col>


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/51

# Context

Need the ability to define am or pm as part of the time function.  The clock selector allows a 12 hour clock but no mechanism to select am or pm. 
![image](https://github.com/icefoganalytics/travel-authorization/assets/89539008/226f0e37-ceb5-4177-908e-c9de1e9281ad)

# Solution

Make clock selector 24 hour, and update label to make this clear.
Fix bug where persisted times include seconds, and this displays in the UI after save. The UI value should only show the hours + minutes.

# Screenshots

New - edit mode
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/8910e46a-2c83-44de-81bc-eb2914fe0291)

New - read only mode
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/c9ff34e8-a4a4-42e7-aa58-f8a7f1bbfc79)


# Testing Instructions

1. Boot the app via `dev up`
2. Login at to http://localhost:8080.
3. Go to the "My Travel Requests" page via the top nav.
4. Create a new Travel Authorization.
5. In the Details panel, check that all the time selectors now are in 24 hour format and that their label reflects this.
6. Check that this is true for all "Trip Types".
7. Submit the travel authorization to your supervisor.
8. In the Details panel, check that all the time selectors now are in 24 hour format and that their label reflects this.
9. Create new Travel Authorizations, and check this for each "Trip Type" in the read-only view.