### PR TITLE
Travel Authorization Details: Automate Calculation of # of Days

### DIFF
--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -1,0 +1,3 @@
+export * from "./user"
+
+export default undefined

--- a/web/src/constants/user.js
+++ b/web/src/constants/user.js
@@ -1,0 +1,14 @@
+// Trying to match the back-end format for consistency sake.
+const Roles = Object.freeze({
+  ADMIN: "admin",
+  USER: "user",
+  PAT_ADMIN: "pat_admin",
+  DEPT_ADMIN: "dept_admin",
+  TD_USER: "td_user",
+})
+
+export const User = Object.freeze({
+  Roles,
+})
+
+export default User

--- a/web/src/modules/travel-authorizations/pages/TravelAuthorizationRead.vue
+++ b/web/src/modules/travel-authorizations/pages/TravelAuthorizationRead.vue
@@ -55,6 +55,8 @@
 <script>
 import { mapActions, mapState } from "vuex"
 
+import { User } from "@/constants"
+
 import Breadcrumbs from "@/components/Breadcrumbs"
 import FullScreenLoadingOverlay from "@/components/FullScreenLoadingOverlay"
 import SummaryHeaderPanel from "./travel-authorization-read/SummaryHeaderPanel"
@@ -78,7 +80,7 @@ export default {
   computed: {
     ...mapState("travelAuthorizations", ["currentUser", "loadingCurrentForm", "loadingCurrentUser"]),
     isAdmin() {
-      return this.currentUser?.roles.includes("admin")
+      return this.currentUser?.roles?.includes(User.Roles.ADMIN)
     },
   },
   mounted() {

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-read/details-tab/DetailsCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-read/details-tab/DetailsCard.vue
@@ -71,13 +71,12 @@ import { mapState, mapGetters } from "vuex"
 const TRIP_TYPES = Object.freeze({
   ROUND_TRIP: "Round Trip",
   ONE_WAY: "One Way",
-  MULI_DESTINATION: "Muli-Destination",
+  MULTI_DESTINATION: "Multi-Destination",
 })
 
 export default {
   name: "DetailsCard",
-  components: {
-  },
+  components: {},
   data: () => ({
     tripType: "",
   }),
@@ -90,7 +89,7 @@ export default {
           return () => import("./details-card/RoundTripStopsSection")
         case TRIP_TYPES.ONE_WAY:
           return () => import("./details-card/OneWayStopsSection")
-        case TRIP_TYPES.MULI_DESTINATION:
+        case TRIP_TYPES.MULTI_DESTINATION:
           return () => import("./details-card/MultiDestinationStopsSection")
         default:
           return null
@@ -101,7 +100,7 @@ export default {
     if (this.currentTravelAuthorization.oneWayTrip) {
       this.tripType = TRIP_TYPES.ONE_WAY
     } else if (this.currentTravelAuthorization.multiStop) {
-      this.tripType = TRIP_TYPES.MULI_DESTINATION
+      this.tripType = TRIP_TYPES.MULTI_DESTINATION
     } else {
       this.tripType = TRIP_TYPES.ROUND_TRIP
     }

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/SummaryHeaderForm.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/SummaryHeaderForm.vue
@@ -77,7 +77,9 @@
           :min="initialDestination.departureDate"
           :rules="[
             required,
-            greaterThanOrEqualToDate(initialDestination.departureDate, 'start date'),
+            greaterThanOrEqualToDate(initialDestination.departureDate, {
+              referenceFieldLabel: 'start date',
+            }),
           ]"
           label="End Date"
           required
@@ -91,6 +93,8 @@
 import { first, last } from "lodash"
 import { mapState, mapActions, mapGetters } from "vuex"
 
+import { required, greaterThanOrEqualToDate } from "@/utils/validators"
+
 import DatePicker from "@/components/Utils/DatePicker"
 
 export default {
@@ -101,9 +105,8 @@ export default {
   data: () => ({
     loadingPurposes: false,
     loadingDestinations: false,
-    required: (v) => !!v || "This field is required",
-    greaterThanOrEqualToDate: (b, label) => (a) =>
-      new Date(a) >= new Date(b) || `This field must be greater than or equal to ${b || label}`,
+    required,
+    greaterThanOrEqualToDate,
   }),
   computed: {
     ...mapState("travelAuthorizations", [
@@ -111,18 +114,33 @@ export default {
       "purposes",
       "destinationsByCurrentFormTravelRestriction",
     ]),
-    ...mapGetters("travelAuthorizations", ["currentTravelAuthorizationId", "destinationsByCurrentFormTravelRestriction"]),
+    ...mapGetters("travelAuthorizations", [
+      "currentTravelAuthorizationId",
+      "destinationsByCurrentFormTravelRestriction",
+    ]),
     finalDestination: {
       get() {
-        return last(this.currentTravelAuthorization.stops) || { travelAuthorizationId: this.currentTravelAuthorizationId }
+        return (
+          last(this.currentTravelAuthorization.stops) || {
+            travelAuthorizationId: this.currentTravelAuthorizationId,
+          }
+        )
       },
       set(newValue) {
-        this.$set(this.currentTravelAuthorization.stops, this.currentTravelAuthorization.stops.length - 1, newValue)
+        this.$set(
+          this.currentTravelAuthorization.stops,
+          this.currentTravelAuthorization.stops.length - 1,
+          newValue
+        )
       },
     },
     initialDestination: {
       get() {
-        return first(this.currentTravelAuthorization.stops) || { travelAuthorizationId: this.currentTravelAuthorizationId }
+        return (
+          first(this.currentTravelAuthorization.stops) || {
+            travelAuthorizationId: this.currentTravelAuthorizationId,
+          }
+        )
       },
       set(newValue) {
         this.$set(this.currentTravelAuthorization.stops, 0, newValue)

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/SummaryHeaderForm.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/SummaryHeaderForm.vue
@@ -105,8 +105,6 @@ export default {
   data: () => ({
     loadingPurposes: false,
     loadingDestinations: false,
-    required,
-    greaterThanOrEqualToDate,
   }),
   computed: {
     ...mapState("travelAuthorizations", [
@@ -161,6 +159,8 @@ export default {
   },
   methods: {
     ...mapActions("travelAuthorizations", ["loadPurposes", "loadDestinations"]),
+    required,
+    greaterThanOrEqualToDate,
   },
 }
 </script>

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -98,7 +98,6 @@ export default {
     TRIP_TYPES,
     tripTypes: Object.values(TRIP_TYPES),
     tripType: "",
-    required,
     isNumber: (v) => v == 0 || Number.isInteger(Number(v)) || "This field must be a number",
   }),
   computed: {
@@ -143,6 +142,7 @@ export default {
     this.currentTravelAuthorization.travelDuration = this.travelDuration
   },
   methods: {
+    required,
     updateTripType(value) {
       if (value === TRIP_TYPES.ROUND_TRIP) {
         this.currentTravelAuthorization.oneWayTrip = false

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -76,7 +76,7 @@
 
 <script>
 import { DateTime } from "luxon"
-import { first, isNil, last } from "lodash"
+import { first, isNil, last, max } from "lodash"
 import { mapState, mapGetters } from "vuex"
 
 import { required } from "@/utils/validators"
@@ -170,8 +170,8 @@ export default {
 
       const departureDateOrigin = DateTime.fromISO(originDestination.departureDate)
       const departureDateFinal = DateTime.fromISO(finalDestination.departureDate)
-
-      return departureDateFinal.diff(departureDateOrigin, "days").days
+      const timeDifference = departureDateFinal.diff(departureDateOrigin, "days")
+      return max([0, timeDifference.days])
     },
   },
 }

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -86,7 +86,7 @@ import DatePicker from "@/components/Utils/DatePicker"
 const TRIP_TYPES = Object.freeze({
   ROUND_TRIP: "Round Trip",
   ONE_WAY: "One Way",
-  MULI_DESTINATION: "Muli-Destination",
+  MULTI_DESTINATION: "Multi-Destination",
 })
 
 export default {
@@ -118,7 +118,7 @@ export default {
           return () => import("./details-form-card/RoundTripStopsSection")
         case TRIP_TYPES.ONE_WAY:
           return () => import("./details-form-card/OneWayStopsSection")
-        case TRIP_TYPES.MULI_DESTINATION:
+        case TRIP_TYPES.MULTI_DESTINATION:
           return () => import("./details-form-card/MultiDestinationStopsSection")
         default:
           return null
@@ -134,7 +134,7 @@ export default {
     if (this.currentTravelAuthorization.oneWayTrip) {
       this.tripType = TRIP_TYPES.ONE_WAY
     } else if (this.currentTravelAuthorization.multiStop) {
-      this.tripType = TRIP_TYPES.MULI_DESTINATION
+      this.tripType = TRIP_TYPES.MULTI_DESTINATION
     } else {
       this.tripType = TRIP_TYPES.ROUND_TRIP
     }
@@ -150,7 +150,7 @@ export default {
       } else if (value === TRIP_TYPES.ONE_WAY) {
         this.currentTravelAuthorization.oneWayTrip = true
         this.currentTravelAuthorization.multiStop = false
-      } else if (value === TRIP_TYPES.MULI_DESTINATION) {
+      } else if (value === TRIP_TYPES.MULTI_DESTINATION) {
         this.currentTravelAuthorization.multiStop = true
         this.currentTravelAuthorization.oneWayTrip = false
       } else {

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -27,8 +27,8 @@
         </v-row>
 
         <component
-          v-if="tripTypeComponent"
           :is="tripTypeComponent"
+          v-if="tripTypeComponent"
         />
         <div v-else>Trip type {{ tripType }} not implemented!</div>
         <v-row>

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/DetailsFormCard.vue
@@ -79,6 +79,8 @@ import { DateTime } from "luxon"
 import { first, isNil, last } from "lodash"
 import { mapState, mapGetters } from "vuex"
 
+import { required } from "@/utils/validators"
+
 import DatePicker from "@/components/Utils/DatePicker"
 
 const TRIP_TYPES = Object.freeze({
@@ -96,7 +98,7 @@ export default {
     TRIP_TYPES,
     tripTypes: Object.values(TRIP_TYPES),
     tripType: "",
-    required: (v) => !!v || "This field is required",
+    required,
     isNumber: (v) => v == 0 || Number.isInteger(Number(v)) || "This field must be a number",
   }),
   computed: {

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
@@ -270,15 +270,29 @@ export default {
   },
   computed: {
     ...mapState("travelAuthorizations", ["currentTravelAuthorization"]),
-    ...mapGetters("travelAuthorizations", ["currentTravelAuthorizationId", "destinationsByCurrentFormTravelRestriction"]),
+    ...mapGetters("travelAuthorizations", [
+      "currentTravelAuthorizationId",
+      "destinationsByCurrentFormTravelRestriction",
+    ]),
   },
   async mounted() {
     await this.loadDestinations()
 
     if (isEmpty(this.currentTravelAuthorization.stops)) {
-      this.currentTravelAuthorization.stops = [this.newStop(), this.newStop(), this.newStop(), this.newStop()]
+      this.currentTravelAuthorization.stops = [
+        this.newStop(),
+        this.newStop(),
+        this.newStop(),
+        this.newStop(),
+      ]
     } else if (this.currentTravelAuthorization.stops.length === 1) {
-      this.currentTravelAuthorization.stops.splice(0, 0, this.newStop(), this.newStop(), this.newStop())
+      this.currentTravelAuthorization.stops.splice(
+        0,
+        0,
+        this.newStop(),
+        this.newStop(),
+        this.newStop()
+      )
     } else if (this.currentTravelAuthorization.stops.length === 2) {
       this.currentTravelAuthorization.stops.splice(1, 0, this.newStop(), this.newStop())
     } else if (this.currentTravelAuthorization.stops.length === 3) {

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
@@ -117,7 +117,13 @@
       >
         <DatePicker
           v-model="stop2.departureDate"
-          :rules="[required]"
+          :min="stop1.departureDate"
+          :rules="[
+            required,
+            greaterThanOrEqualToDate(stop1.departureDate, {
+              referenceFieldLabel: 'previous departure date',
+            }),
+          ]"
           label="Date"
           persistent-hint
         />
@@ -195,7 +201,13 @@
       >
         <DatePicker
           v-model="stop3.departureDate"
-          :rules="[required]"
+          :min="stop2.departureDate"
+          :rules="[
+            required,
+            greaterThanOrEqualToDate(stop2.departureDate, {
+              referenceFieldLabel: 'previous departure date',
+            }),
+          ]"
           label="Date"
           persistent-hint
         />
@@ -241,7 +253,7 @@
 import { mapActions, mapState, mapGetters } from "vuex"
 import { isEmpty } from "lodash"
 
-import { required } from "@/utils/validators"
+import { required, greaterThanOrEqualToDate } from "@/utils/validators"
 
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
@@ -309,6 +321,7 @@ export default {
   methods: {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
     required,
+    greaterThanOrEqualToDate,
     newStop() {
       return {
         travelAuthorizationId: this.currentTravelAuthorizationId,

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -112,7 +112,10 @@ export default {
   },
   computed: {
     ...mapState("travelAuthorizations", ["currentTravelAuthorization"]),
-    ...mapGetters("travelAuthorizations", ["currentTravelAuthorizationId", "destinationsByCurrentFormTravelRestriction"]),
+    ...mapGetters("travelAuthorizations", [
+      "currentTravelAuthorizationId",
+      "destinationsByCurrentFormTravelRestriction",
+    ]),
   },
   async mounted() {
     await this.loadDestinations()

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -117,7 +117,13 @@
       >
         <DatePicker
           v-model="destinationStop.departureDate"
-          :rules="[required]"
+          :min="originStop.departureDate"
+          :rules="[
+            required,
+            greaterThanOrEqualToDate(originStop.departureDate, {
+              referenceFieldLabel: 'previous departure date',
+            }),
+          ]"
           label="Date"
           persistent-hint
         />
@@ -166,7 +172,7 @@
 import { mapActions, mapState, mapGetters } from "vuex"
 import { isEmpty } from "lodash"
 
-import { required } from "@/utils/validators"
+import { required, greaterThanOrEqualToDate } from "@/utils/validators"
 
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
@@ -189,17 +195,25 @@ export default {
     return {
       originStop: {},
       destinationStop: {},
+      greaterThanOrEqualToDate,
+      required,
     }
   },
   computed: {
     ...mapState("travelAuthorizations", ["currentTravelAuthorization"]),
-    ...mapGetters("travelAuthorizations", ["currentTravelAuthorizationId", "destinationsByCurrentFormTravelRestriction"]),
+    ...mapGetters("travelAuthorizations", [
+      "currentTravelAuthorizationId",
+      "destinationsByCurrentFormTravelRestriction",
+    ]),
   },
   async mounted() {
     await this.loadDestinations()
 
     if (isEmpty(this.currentTravelAuthorization.stops)) {
-      this.currentTravelAuthorization.stops = [this.newStop(), this.newStop({ accommodationType: null })]
+      this.currentTravelAuthorization.stops = [
+        this.newStop(),
+        this.newStop({ accommodationType: null }),
+      ]
     } else if (this.currentTravelAuthorization.stops.length === 1) {
       this.currentTravelAuthorization.stops.push(this.newStop({ accommodationType: null }))
     } else if (this.currentTravelAuthorization.stops.length > 2) {
@@ -212,7 +226,6 @@ export default {
   },
   methods: {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
-    required,
     newStop(attributes) {
       return {
         travelAuthorizationId: this.currentTravelAuthorizationId,

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -195,8 +195,6 @@ export default {
     return {
       originStop: {},
       destinationStop: {},
-      greaterThanOrEqualToDate,
-      required,
     }
   },
   computed: {
@@ -226,6 +224,8 @@ export default {
   },
   methods: {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
+    greaterThanOrEqualToDate,
+    required,
     newStop(attributes) {
       return {
         travelAuthorizationId: this.currentTravelAuthorizationId,

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/TravelDurationTextField.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/TravelDurationTextField.vue
@@ -62,6 +62,11 @@ export default {
       this.$emit("input", newValue)
     },
   },
+  mounted() {
+    // Backwards compatibility feature, fills missing value not previously set
+    // but all dates are set, you still need to save the form to persist this value
+    this.$emit("input", this.travelDuration)
+  },
   methods: {
     computeTravelDuration(originDestination, finalDestination) {
       if (isNil(originDestination.departureDate) || isNil(finalDestination.departureDate)) {

--- a/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/TravelDurationTextField.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-form-edit/details-tab/details-form-card/TravelDurationTextField.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-tooltip
+    bottom
+    nudge-bottom="20"
+  >
+    <template #activator="{ on, attrs }">
+      <div class="d-flex align-start">
+        <v-text-field
+          :value="value"
+          :style="{ minWidth: '80px' }"
+          label="# Days"
+          dense
+          outlined
+          disabled
+          readonly
+          v-bind="{ ...attrs }"
+          v-on="on"
+        ></v-text-field>
+        <v-icon
+          class="ml-1"
+          small
+          v-bind="attrs"
+          v-on="on"
+        >
+          mdi-help-circle-outline
+        </v-icon>
+      </div>
+    </template>
+    <span>This is computed from the start and end dates of the trip.</span>
+  </v-tooltip>
+</template>
+
+<script>
+import { DateTime } from "luxon"
+import { first, isNil, last, max } from "lodash"
+
+export default {
+  name: "TravelDurationTextField",
+  props: {
+    value: {
+      type: Number,
+      default: () => 0,
+    },
+    stops: {
+      type: Array,
+      required: true,
+    },
+  },
+  computed: {
+    originDestination() {
+      return first(this.stops) || {}
+    },
+    finalDestination() {
+      return last(this.stops) || {}
+    },
+    travelDuration() {
+      return this.computeTravelDuration(this.originDestination, this.finalDestination)
+    },
+  },
+  watch: {
+    travelDuration(newValue) {
+      this.$emit("input", newValue)
+    },
+  },
+  methods: {
+    computeTravelDuration(originDestination, finalDestination) {
+      if (isNil(originDestination.departureDate) || isNil(finalDestination.departureDate)) {
+        return null
+      }
+
+      const departureDateOrigin = DateTime.fromISO(originDestination.departureDate)
+      const departureDateFinal = DateTime.fromISO(finalDestination.departureDate)
+      const timeDifference = departureDateFinal.diff(departureDateOrigin, "days")
+      return max([0, timeDifference.days])
+    },
+  },
+}
+</script>

--- a/web/src/utils/validators.js
+++ b/web/src/utils/validators.js
@@ -2,6 +2,13 @@
 
 export const required = (v) => !!v || "This field is required"
 
+export const greaterThanOrEqualToDate =
+  (b, { referenceFieldLabel }) =>
+  (a) =>
+    new Date(a) >= new Date(b) ||
+    `This field must be greater than or equal to ${b || referenceFieldLabel}`
+
 export default {
+  greaterThanOrEqualToDate,
   required,
 }


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/53

# Context

The # Days should be calculated based on start and end date of the travel.
![image](https://github.com/icefoganalytics/travel-authorization/assets/89539008/cc262b4a-5fe7-4784-be71-80056ab62575)

# Propose Solution

1. Calculate the value in the front-end, and submit it as the "currentTravelAuthorization.travelDuration" value.
2. Add validation/minimums to the date selectors to prevent a negative value for the travel duration calcuation
3. Add (?) tooltip to explain where date comes from.
4. ~Fix form validation so you can't submit and invalid form.~ - deferring this till later, hopefully when I have a test suite.


# Testing Instructions

1. Boot the app with `dev up`
2. Log in at http://localhost:8080.
3. Go to the "My Travel Requests" page via the top dropdown nav.
4. Create a new travel authorization.
5. Check that when you fill in the start and end dates of the trip, the "Details" panel, "# Days" field gets filled in.
6. Check that it changes when you change the dates.
7. Check that the date selectors for the various "Trip Types", limit the selection to be greater than or equal to the previously selected dates.
8. Check that the "# Days" field says filled in after you save as draft.
9. Check that the "# Days" field says filled in after you submit to your supervisor.