### PR TITLE
Add Read-Only View For My Travel Requests -> Estimates Tab

### DIFF
--- a/web/src/modules/travel-authorizations/pages/TravelAuthorizationRead.vue
+++ b/web/src/modules/travel-authorizations/pages/TravelAuthorizationRead.vue
@@ -20,7 +20,7 @@
       >
         Edit
         <v-tooltip bottom>
-          <template v-slot:activator="{ on, attrs }">
+          <template #activator="{ on, attrs }">
             <v-icon
               small
               class="ml-2"
@@ -42,6 +42,9 @@
     <v-tabs v-model="tab">
       <v-tab :to="{ name: 'TravelAuthorizationRead-DetailsTab', params: { formId } }"
         >Details</v-tab
+      >
+      <v-tab :to="{ name: 'TravelAuthorizationRead-EstimateTab', params: { formId } }"
+        >Estimate</v-tab
       >
       <!-- TODO: add in any tabs that you can normally see in read-only mode -->
     </v-tabs>
@@ -78,7 +81,11 @@ export default {
     tab: null,
   }),
   computed: {
-    ...mapState("travelAuthorizations", ["currentUser", "loadingCurrentForm", "loadingCurrentUser"]),
+    ...mapState("travelAuthorizations", [
+      "currentUser",
+      "loadingCurrentForm",
+      "loadingCurrentUser",
+    ]),
     isAdmin() {
       return this.currentUser?.roles?.includes(User.Roles.ADMIN)
     },

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-read/EstimateTab.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-read/EstimateTab.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="mt-4">
+    <EstimatesTable
+      ref="estimatesTable"
+      :form-id="formIdAsNumber"
+    />
+  </div>
+</template>
+
+<script>
+import EstimatesTable from "./estimate-tab/EstimatesTable"
+
+export default {
+  name: "EstimateTab",
+  components: {
+    EstimatesTable,
+  },
+  props: {
+    formId: {
+      type: [Number, String],
+      required: true,
+    },
+  },
+  data: () => ({}),
+  computed: {
+    formIdAsNumber() {
+      return parseInt(this.formId)
+    },
+  },
+  async mounted() {},
+  methods: {},
+}
+</script>

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-read/estimate-tab/EstimatesTable.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-read/estimate-tab/EstimatesTable.vue
@@ -6,38 +6,11 @@
     :loading="loadingEstimates"
     class="elevation-2"
   >
-    <template #top>
-      <EstimateEditDialog
-        ref="editDialog"
-        @saved="refresh"
-      />
-      <EstimateDeleteDialog
-        ref="deleteDialog"
-        @deleted="refresh"
-      />
-    </template>
     <template #item.date="{ value }">
       {{ formatDate(value) }}
     </template>
     <template #item.cost="{ value }">
       {{ formatCurrency(value) }}
-    </template>
-    <template #item.actions="{ value: actions, item }">
-      <div class="d-flex justify-end">
-        <v-btn
-          v-if="actions.includes('edit')"
-          color="secondary"
-          @click="showEditDialog(item)"
-          >Edit</v-btn
-        >
-        <v-btn
-          v-if="actions.includes('delete')"
-          class="ml-2"
-          color="error"
-          @click="showDeleteDialog(item)"
-          >Delete</v-btn
-        >
-      </div>
     </template>
     <template #foot>
       <tfoot>
@@ -58,15 +31,9 @@ import { sumBy } from "lodash"
 import { mapActions, mapState } from "vuex"
 import { DateTime } from "luxon"
 
-import EstimateDeleteDialog from "./EstimateDeleteDialog"
-import EstimateEditDialog from "./EstimateEditDialog"
-
 export default {
   name: "EstimatesTable",
-  components: {
-    EstimateDeleteDialog,
-    EstimateEditDialog,
-  },
+  components: {},
   props: {
     formId: {
       type: Number,
@@ -79,7 +46,7 @@ export default {
       { test: "Description", value: "description" },
       { text: "Date", value: "date" },
       { text: "Amount", value: "cost" },
-      { text: "", value: "actions" },
+      // { text: "", value: "actions" }, // no actions; read-only
     ],
     totalRowClasses: "text-start font-weight-bold text-uppercase",
   }),
@@ -91,10 +58,7 @@ export default {
     },
   },
   mounted() {
-    return this.loadEstimates({ travelAuthorizationId: this.formId }).then(() => {
-      this.showEditDialogForRouteQuery()
-      this.showDeleteDialogForRouteQuery()
-    })
+    return this.loadEstimates({ travelAuthorizationId: this.formId })
   },
   methods: {
     ...mapActions("travelAuthorizations", ["loadEstimates"]),
@@ -107,33 +71,6 @@ export default {
         currency: "CAD",
       })
       return formatter.format(amount)
-    },
-    refresh() {
-      return this.loadEstimates({ formId: this.formId })
-    },
-    showDeleteDialog(item) {
-      this.$refs.deleteDialog.show(item)
-    },
-    showEditDialog(item) {
-      this.$refs.editDialog.show(item)
-    },
-    showEditDialogForRouteQuery() {
-      const estimateId = parseInt(this.$route.query.showEdit)
-      if (isNaN(estimateId)) return
-
-      const estimate = this.estimates.find((estimate) => estimate.id === estimateId)
-      if (!estimate) return
-
-      this.showEditDialog(estimate)
-    },
-    showDeleteDialogForRouteQuery() {
-      const estimateId = parseInt(this.$route.query.showDelete)
-      if (isNaN(estimateId)) return
-
-      const estimate = this.estimates.find((estimate) => estimate.id === estimateId)
-      if (!estimate) return
-
-      this.showDeleteDialog(estimate)
     },
   },
 }

--- a/web/src/modules/travel-authorizations/router.js
+++ b/web/src/modules/travel-authorizations/router.js
@@ -23,10 +23,17 @@ const routes = [
           {
             path: "details",
             name: "TravelAuthorizationRead-DetailsTab",
-            component: () => import("@/modules/travel-authorizations/pages/travel-authorization-read/DetailsTab"),
+            component: () =>
+              import("@/modules/travel-authorizations/pages/travel-authorization-read/DetailsTab"),
             props: true,
           },
-          // TODO: add read only estimates tab
+          {
+            path: "estimate",
+            name: "TravelAuthorizationRead-EstimateTab",
+            component: () =>
+              import("@/modules/travel-authorizations/pages/travel-authorization-read/EstimateTab"),
+            props: true,
+          },
         ],
       },
       {
@@ -41,13 +48,15 @@ const routes = [
           {
             path: "details",
             name: "TravelFormEdit-DetailsTab",
-            component: () => import("@/modules/travel-authorizations/pages/travel-form-edit/DetailsTab"),
+            component: () =>
+              import("@/modules/travel-authorizations/pages/travel-form-edit/DetailsTab"),
             props: true,
           },
           {
             path: "estimate",
             name: "TravelFormEdit-EstimateTab",
-            component: () => import("@/modules/travel-authorizations/pages/travel-form-edit/EstimateTab"),
+            component: () =>
+              import("@/modules/travel-authorizations/pages/travel-form-edit/EstimateTab"),
             props: true,
           },
         ],


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/76

Relates to:
- https://github.com/icefoganalytics/travel-authorization/pull/71

# Context

Q. Can a User edit Estimates for a  "submitted" travel authorization?

> A. No they can't once it is submitted it should be locked.

# Screenshots

Note the "edit" button that only shows up for admins
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/6cd59db7-4b7d-4d36-affd-390e5beeab4a)

# Testing Instructions

1. Boot the app via `dev up`
2. Log in to the app at http://localhost:8080.
3. Go to the "My Travel Requests" page via the top nav dropdown.
4. Create a new "Travel Authorization" via the "+ Travel Authorization" button in the top right.
5. Go to the Details section of the "Details" tab and add some travel information of a trip from Whitehorse to Vancouver.
6. Scroll down to the Approvals section and click the "Generate Estimates" button. Confirm your choice.
7. Submit the travel authorization to your supervisor to be redirected to the "read-only" view of the page.
8. Click the "new" Estimate tab, and check that the tab shows your estimates, and everything is read-only; that there aren't any create/update/delete buttons.
 