### PR TITLE
Travel Authorization Details: Accommodation Should Be Left Blank on Final Stop

### DIFF
--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue
@@ -133,6 +133,16 @@ export default {
   },
   methods: {
     required,
+    /*
+      Update trip type selection, setting default stops as needed,
+      or loading stops from cache if cached valued exists.
+
+      Use of a cache permits stops to have a blank accomodation or trip type,
+      against a variety of stop configurations, without wiping stop content on trip type change.
+
+      NOTE: This would probably be made irrelevant by modeling stops differently, such as by
+      using a "trip segment" model, with a departure and arrival location.
+    */
     updateTripType(value) {
       this.stopsCache[this.tripType] = this.currentTravelAuthorization.stops
 

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue
@@ -75,9 +75,9 @@ import { last } from "lodash"
 import { mapState, mapGetters } from "vuex"
 
 import { required } from "@/utils/validators"
-
+import { ACCOMMODATION_TYPES } from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
+import { TRAVEL_METHODS } from "@/modules/travel-authorizations/components/TravelMethodSelect"
 import DatePicker from "@/components/Utils/DatePicker"
-
 import TravelDurationTextField from "./details-form-card/TravelDurationTextField.vue"
 
 const TRIP_TYPES = Object.freeze({
@@ -132,12 +132,26 @@ export default {
       if (value === TRIP_TYPES.ROUND_TRIP) {
         this.currentTravelAuthorization.oneWayTrip = false
         this.currentTravelAuthorization.multiStop = false
+        this.currentTravelAuthorization.stops = [
+          this.newStop(),
+          this.newStop({ accommodationType: null, transport: null }),
+        ]
       } else if (value === TRIP_TYPES.ONE_WAY) {
         this.currentTravelAuthorization.oneWayTrip = true
         this.currentTravelAuthorization.multiStop = false
+        this.currentTravelAuthorization.stops = [
+          this.newStop({ accommodationType: null }),
+          this.newStop({ accommodationType: null, transport: null }),
+        ]
       } else if (value === TRIP_TYPES.MULTI_DESTINATION) {
         this.currentTravelAuthorization.multiStop = true
         this.currentTravelAuthorization.oneWayTrip = false
+        this.currentTravelAuthorization.stops = [
+          this.newStop(),
+          this.newStop(),
+          this.newStop({ accommodationType: null }),
+          this.newStop({ accommodationType: null, transport: null }),
+        ]
       } else {
         throw new Error("Invalid trip type")
       }
@@ -147,6 +161,14 @@ export default {
       this.$nextTick(() => {
         this.$refs.form.resetValidation()
       })
+    },
+    newStop(attributes) {
+      return {
+        travelAuthorizationId: this.currentTravelAuthorizationId,
+        accommodationType: ACCOMMODATION_TYPES.HOTEL,
+        transport: TRAVEL_METHODS.AIRCRAFT,
+        ...attributes,
+      }
     },
   },
 }

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue
@@ -152,7 +152,14 @@ export default {
 
         this.currentTravelAuthorization.stops = this.getStopsFromCacheOrDefault(
           TRIP_TYPES.ROUND_TRIP,
-          [this.newStop(), this.newStop({ accommodationType: null, transport: null })]
+          [
+            this.newStop(),
+            this.newStop({
+              ...this.finalDestination,
+              accommodationType: null,
+              transport: null,
+            }),
+          ]
         )
       } else if (value === TRIP_TYPES.ONE_WAY) {
         this.currentTravelAuthorization.oneWayTrip = true
@@ -162,7 +169,11 @@ export default {
           TRIP_TYPES.ONE_WAY,
           [
             this.newStop({ accommodationType: null }),
-            this.newStop({ accommodationType: null, transport: null }),
+            this.newStop({
+              ...this.finalDestination,
+              accommodationType: null,
+              transport: null,
+            }),
           ]
         )
       } else if (value === TRIP_TYPES.MULTI_DESTINATION) {
@@ -175,7 +186,11 @@ export default {
             this.newStop(),
             this.newStop(),
             this.newStop({ accommodationType: null }),
-            this.newStop({ accommodationType: null, transport: null }),
+            this.newStop({
+              ...this.finalDestination,
+              accommodationType: null,
+              transport: null,
+            }),
           ]
         )
       } else {

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
@@ -238,11 +238,14 @@
         />
         <AccommodationTypeSelect
           v-model="stop3.accommodationType"
-          :rules="[required]"
+          :default-value="null"
+          hint="Optional, set only if neccessary"
+          placeholder="N/A"
           background-color="white"
+          clearable
           dense
           outlined
-          required
+          persistent-hint
         />
       </v-col>
     </v-row>
@@ -294,8 +297,8 @@ export default {
       this.currentTravelAuthorization.stops = [
         this.newStop(),
         this.newStop(),
-        this.newStop(),
-        this.newStop(),
+        this.newStop({ accommodationType: null }),
+        this.newStop({ accommodationType: null }),
       ]
     } else if (this.currentTravelAuthorization.stops.length === 1) {
       this.currentTravelAuthorization.stops.splice(
@@ -322,11 +325,12 @@ export default {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
     required,
     greaterThanOrEqualToDate,
-    newStop() {
+    newStop(attributes) {
       return {
         travelAuthorizationId: this.currentTravelAuthorizationId,
         accommodationType: ACCOMMODATION_TYPES.HOTEL,
         transport: TRAVEL_METHODS.AIRCRAFT,
+        ...attributes,
       }
     },
   },

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/MultiDestinationStopsSection.vue
@@ -254,18 +254,13 @@
 
 <script>
 import { mapActions, mapState, mapGetters } from "vuex"
-import { isEmpty } from "lodash"
 
 import { required, greaterThanOrEqualToDate } from "@/utils/validators"
 
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
-import AccommodationTypeSelect, {
-  ACCOMMODATION_TYPES,
-} from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
-import TravelMethodSelect, {
-  TRAVEL_METHODS,
-} from "@/modules/travel-authorizations/components/TravelMethodSelect"
+import AccommodationTypeSelect from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
+import TravelMethodSelect from "@/modules/travel-authorizations/components/TravelMethodSelect"
 
 export default {
   name: "MultiDestinationStopsSection",
@@ -293,29 +288,6 @@ export default {
   async mounted() {
     await this.loadDestinations()
 
-    if (isEmpty(this.currentTravelAuthorization.stops)) {
-      this.currentTravelAuthorization.stops = [
-        this.newStop(),
-        this.newStop(),
-        this.newStop({ accommodationType: null }),
-        this.newStop({ accommodationType: null }),
-      ]
-    } else if (this.currentTravelAuthorization.stops.length === 1) {
-      this.currentTravelAuthorization.stops.splice(
-        0,
-        0,
-        this.newStop(),
-        this.newStop(),
-        this.newStop()
-      )
-    } else if (this.currentTravelAuthorization.stops.length === 2) {
-      this.currentTravelAuthorization.stops.splice(1, 0, this.newStop(), this.newStop())
-    } else if (this.currentTravelAuthorization.stops.length === 3) {
-      this.currentTravelAuthorization.stops.splice(2, 0, this.newStop())
-    } else if (this.currentTravelAuthorization.stops.length > 4) {
-      this.currentTravelAuthorization.stops = this.currentTravelAuthorization.stops.slice(0, 3)
-    }
-
     this.stop1 = this.currentTravelAuthorization.stops[0]
     this.stop2 = this.currentTravelAuthorization.stops[1]
     this.stop3 = this.currentTravelAuthorization.stops[2]
@@ -325,14 +297,6 @@ export default {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
     required,
     greaterThanOrEqualToDate,
-    newStop(attributes) {
-      return {
-        travelAuthorizationId: this.currentTravelAuthorizationId,
-        accommodationType: ACCOMMODATION_TYPES.HOTEL,
-        transport: TRAVEL_METHODS.AIRCRAFT,
-        ...attributes,
-      }
-    },
   },
 }
 </script>

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -86,16 +86,13 @@
 
 <script>
 import { mapActions, mapState, mapGetters } from "vuex"
-import { isEmpty } from "lodash"
 
 import { required } from "@/utils/validators"
 
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
 import AccommodationTypeSelect from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
-import TravelMethodSelect, {
-  TRAVEL_METHODS,
-} from "@/modules/travel-authorizations/components/TravelMethodSelect"
+import TravelMethodSelect from "@/modules/travel-authorizations/components/TravelMethodSelect"
 
 export default {
   name: "OneWayStopsSection",
@@ -121,29 +118,12 @@ export default {
   async mounted() {
     await this.loadDestinations()
 
-    if (isEmpty(this.currentTravelAuthorization.stops)) {
-      this.currentTravelAuthorization.stops = [this.newStop(), this.newStop({ transport: null })]
-    } else if (this.currentTravelAuthorization.stops.length === 1) {
-      this.currentTravelAuthorization.stops.push(this.newStop({ transport: null }))
-    } else if (this.currentTravelAuthorization.stops.length > 2) {
-      const elementsToRemove = this.currentTravelAuthorization.stops.length - 2
-      this.currentTravelAuthorization.stops.splice(1, elementsToRemove)
-    }
-
     this.originStop = this.currentTravelAuthorization.stops[0]
     this.destinationStop = this.currentTravelAuthorization.stops[1]
   },
   methods: {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
     required,
-    newStop(attributes) {
-      return {
-        travelAuthorizationId: this.currentTravelAuthorizationId,
-        accommodationType: null,
-        transport: TRAVEL_METHODS.AIRCRAFT,
-        ...attributes,
-      }
-    },
   },
 }
 </script>

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/OneWayStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/OneWayStopsSection.vue
@@ -70,11 +70,14 @@
         />
         <AccommodationTypeSelect
           v-model="originStop.accommodationType"
-          :rules="[required]"
+          :default-value="null"
+          hint="Optional, set only if neccessary"
+          placeholder="N/A"
           background-color="white"
+          clearable
           dense
           outlined
-          required
+          persistent-hint
         />
       </v-col>
     </v-row>
@@ -89,9 +92,7 @@ import { required } from "@/utils/validators"
 
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
-import AccommodationTypeSelect, {
-  ACCOMMODATION_TYPES,
-} from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
+import AccommodationTypeSelect from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
 import TravelMethodSelect, {
   TRAVEL_METHODS,
 } from "@/modules/travel-authorizations/components/TravelMethodSelect"
@@ -121,9 +122,9 @@ export default {
     await this.loadDestinations()
 
     if (isEmpty(this.currentTravelAuthorization.stops)) {
-      this.currentTravelAuthorization.stops = [this.newStop(), this.newStop()]
+      this.currentTravelAuthorization.stops = [this.newStop(), this.newStop({ transport: null })]
     } else if (this.currentTravelAuthorization.stops.length === 1) {
-      this.currentTravelAuthorization.stops.push(this.newStop())
+      this.currentTravelAuthorization.stops.push(this.newStop({ transport: null }))
     } else if (this.currentTravelAuthorization.stops.length > 2) {
       const elementsToRemove = this.currentTravelAuthorization.stops.length - 2
       this.currentTravelAuthorization.stops.splice(1, elementsToRemove)
@@ -135,11 +136,12 @@ export default {
   methods: {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
     required,
-    newStop() {
+    newStop(attributes) {
       return {
         travelAuthorizationId: this.currentTravelAuthorizationId,
-        accommodationType: ACCOMMODATION_TYPES.HOTEL,
+        accommodationType: null,
         transport: TRAVEL_METHODS.AIRCRAFT,
+        ...attributes,
       }
     },
   },

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -155,9 +155,9 @@
         <AccommodationTypeSelect
           v-model="destinationStop.accommodationType"
           :default-value="null"
-          background-color="white"
           hint="Optional, set only if neccessary"
           placeholder="N/A"
+          background-color="white"
           clearable
           dense
           outlined

--- a/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/RoundTripStopsSection.vue
+++ b/web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/details-form-card/RoundTripStopsSection.vue
@@ -170,18 +170,13 @@
 
 <script>
 import { mapActions, mapState, mapGetters } from "vuex"
-import { isEmpty } from "lodash"
 
 import { required, greaterThanOrEqualToDate } from "@/utils/validators"
 
 import DatePicker from "@/components/Utils/DatePicker"
 import TimePicker from "@/components/Utils/TimePicker"
-import AccommodationTypeSelect, {
-  ACCOMMODATION_TYPES,
-} from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
-import TravelMethodSelect, {
-  TRAVEL_METHODS,
-} from "@/modules/travel-authorizations/components/TravelMethodSelect"
+import AccommodationTypeSelect from "@/modules/travel-authorizations/components/AccommodationTypeSelect"
+import TravelMethodSelect from "@/modules/travel-authorizations/components/TravelMethodSelect"
 
 export default {
   name: "RoundTripStopsSection",
@@ -207,18 +202,6 @@ export default {
   async mounted() {
     await this.loadDestinations()
 
-    if (isEmpty(this.currentTravelAuthorization.stops)) {
-      this.currentTravelAuthorization.stops = [
-        this.newStop(),
-        this.newStop({ accommodationType: null }),
-      ]
-    } else if (this.currentTravelAuthorization.stops.length === 1) {
-      this.currentTravelAuthorization.stops.push(this.newStop({ accommodationType: null }))
-    } else if (this.currentTravelAuthorization.stops.length > 2) {
-      const elementsToRemove = this.currentTravelAuthorization.stops.length - 2
-      this.currentTravelAuthorization.stops.splice(1, elementsToRemove)
-    }
-
     this.originStop = this.currentTravelAuthorization.stops[0]
     this.destinationStop = this.currentTravelAuthorization.stops[1]
   },
@@ -226,14 +209,6 @@ export default {
     ...mapActions("travelAuthorizations", ["loadDestinations"]),
     greaterThanOrEqualToDate,
     required,
-    newStop(attributes) {
-      return {
-        travelAuthorizationId: this.currentTravelAuthorizationId,
-        accommodationType: ACCOMMODATION_TYPES.HOTEL,
-        transport: TRAVEL_METHODS.AIRCRAFT,
-        ...attributes,
-      }
-    },
   },
 }
 </script>


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/52

# Context

On the final stop the accommodation should be left blank if possible as the traveler will typically be home.

- [x] Make final accommodation type optional for "one way" trip type
- [x] Make final accommodation type optional for "multi-destination" trip type.

See https://github.com/icefoganalytics/travel-authorization/pull/65 for example of how this was accomplished for the "Round Trip" trip type.

# Implementation

Move setting of trip type defaults a higher level, `web/src/modules/travel-authorizations/pages/travel-authorization-edit/details-tab/DetailsFormCard.vue`.
Use stops cache so as to load stops against a given trip type, and allow custom defaults for each trip type.
Propagate the "final stop" to each trip type on initial selection, after that each trip type uses the trip type specific cached version of stops.

# Testing Instructions

1. Boot the app via `dev up`
2. Log in to the app at http://localhost:8080/
3. Go to the My Travel Requests page via the top nav dropdown.
4. Create a new travel travel request.
5. Check that the final "Type of Accommodation" is unset by default.
6. Make some changes and "Save" the draft.
7. Check that the stop information persists after save.
8. Switch the trip type to "One Way".
9. Note that all trip information is wiped except for the "final stop" information.
10. Check that "Multi-destination" trip type works as expected too.
11. Check that switching back to a previous trip type, results in restoring the state that existed in that trip type. This seemed like the least disruptive option?