### PR TITLE
Fix Bug In Multi-Destination Trip Type End Date Mismatch

### DIFF
--- a/web/src/modules/travel-authorizations/components/SummaryHeaderPanel.vue
+++ b/web/src/modules/travel-authorizations/components/SummaryHeaderPanel.vue
@@ -43,7 +43,7 @@
         md="2"
       >
         <v-text-field
-          :value="finalDestination.departureDate"
+          :value="finalDestinationDepartureDate"
           label="End Date"
           prepend-icon="mdi-calendar"
           dense
@@ -74,6 +74,7 @@ export default {
   computed: {
     ...mapGetters("current/travelAuthorization", {
       currentTravelAuthorization: "attributes",
+      stops: "stops",
       initialDestination: "firstStop",
       finalDestination: "lastStop",
     }),
@@ -86,6 +87,13 @@ export default {
         (p) => p.id === this.currentTravelAuthorization.purposeId
       )
       return purpose?.purpose || ""
+    },
+    finalDestinationDepartureDate() {
+      if (this.currentTravelAuthorization.multiStop) {
+        return this.stops[this.stops.length - 2].departureDate
+      }
+
+      return this.finalDestination.departureDate
     },
   },
   async mounted() {


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/79

# Context

The End Date in the top "SummaryHeaderForm" does not match the final end date in the multi-destionation stops form.

![Image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/2047cb3e-c2fe-4e08-969a-e61f2e74aee3)
![Image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/d0e1d8ac-befd-4a83-925d-c8516b183a41)

This is the result of data description problem. Stops have a "departureDate", which is the time the user leaves the stop, but for multi-destination trips we have 4 stops, but only set the departureDate for 3 of them in the lower form.

# Implementation

This is a UI hack, and alternative would be to make a travel_segments table. See https://github.com/icefoganalytics/travel-authorization/issues/79#issuecomment-1823707588

I did _not_ fix this same bug in the One Way trip type, as I'm not sure what the end date should pull from. Should it just be the start date? Or should it pull from the "Expected Date return to work" field?

# Testing Instructions

1. Boot the app with `dev up`
2. Log in to the app at http://localhost:8080
3. Go to the "My Travel Requests" page via the top dropdown nav.
4. Create a new travel request via the "+ Travel Authorization" button.
5. Fill in the "Final Destination" field in the Purpose field.
6. Check that this propagates to the top summary banner thing.
7. Scroll down to the "Details" section and fill in the second row "date" field.
8. Ignore the form validation warning that triggers because you didn't fill in the first row date field.
9. Swap the "Trip Type" to "Multi-Destination".
10. Note that this clears the date information, but persists the location. This is expected, propagation between trip types is a fine tuning thing, and will take a while to build out fully. Also test will be essential to handle the complexity.
11. Note that this also clears the date information in the top summary banner thing.
12. Set a date in the third row "date" field, and check that it propagates to the top summary banner thing.