### PR TITLE
Add Pull Request and Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Fixes xxxx
+
+Relates to:
+
+- yyyy
+
+# Context
+
+aaaa
+
+# Implementation
+
+bbbb
+
+# Screenshots
+
+cccc
+
+# Testing Instructions
+
+1. Boot the app via `dev up`
+2. Log in to the app at http://localhost:8080
+3.


### PR DESCRIPTION
# Context

Add pull request template to make writing pull request a bit easier.
Add GitHub's default issue templates to make the process of filing bugs and creating issues a bit more formalized.

Pull request template should be:
context
implementation
screenshots
testing instructions
1. Boot the app via `dev up`
2. Log in to the app at http://localhost:8080
3. 

Issue template should be
context
and if bug, maybe steps to reproduce

# Testing Instructions

1. Merge this PR.
2. Try to create a Pull Request in this repo, and see if the template gets loaded.
3. Try to create an Issue in this repo, and see if you are asked to pick from two templates.