### PR TITLE
Clicking Generate Estimate Wipes Unsaved Changes On Travel Authorization Edit Page

### DIFF
--- a/web/src/api/travel-authorizations/estimates/generate-api.js
+++ b/web/src/api/travel-authorizations/estimates/generate-api.js
@@ -2,7 +2,9 @@ import http from "@/api/http-client"
 
 export const generateApi = {
   create(travelAuthorizationId) {
-    return http.post(`/api/travel-authorizations/${travelAuthorizationId}/estimates/generate`).then(({ data }) => data)
+    return http
+      .post(`/api/travel-authorizations/${travelAuthorizationId}/estimates/generate`)
+      .then(({ data }) => data)
   },
 }
 

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-details-page/ApprovalsFormCard.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-details-page/ApprovalsFormCard.vue
@@ -102,9 +102,9 @@ import { mapActions, mapState, mapGetters } from "vuex"
 import preApprovedTravelRequestsApi from "@/api/pre-approved-travel-requests-api"
 
 import SearchableUserEmailCombobox from "@/components/SearchableUserEmailCombobox"
-import EstimateGenerateDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-estimate-page/EstimateGenerateDialog"
 
 import EstimatedCostTextField from "@/modules/travel-authorizations/components/EstimatedCostTextField"
+import EstimateGenerateDialog from "./approvals-form-card/EstimateGenerateDialog"
 import SubmitToSupervisorButton from "./approvals-form-card/SubmitToSupervisorButton"
 
 export default {

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-details-page/approvals-form-card/EstimateGenerateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-details-page/approvals-form-card/EstimateGenerateDialog.vue
@@ -1,0 +1,115 @@
+<template>
+  <v-dialog
+    v-model="showDialog"
+    max-width="500px"
+  >
+    <template #activator="{ on, attrs }">
+      <v-btn
+        dark
+        :class="buttonClasses"
+        :color="buttonColor"
+        v-bind="attrs"
+        v-on="on"
+      >
+        Generate Estimate
+      </v-btn>
+    </template>
+    <v-form @submit.prevent="createAndClose">
+      <v-card :loading="loading">
+        <v-card-title class="text-h5"> Generate Estimate? </v-card-title>
+
+        <v-card-text>
+          <p>
+            By proceeding, the travel request will be saved, and initial cost estimates will be
+            pre-populated. You'll have the opportunity to review and modify the estimates afterward.
+          </p>
+          <p>
+            <em>This might take a some time...</em>
+          </p>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            :loading="loading"
+            color="error"
+            @click="close"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            :loading="loading"
+            color="primary"
+            type="submit"
+          >
+            Save & Generate
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script>
+import { mapActions } from "vuex"
+
+import { required } from "@/utils/validators"
+
+import generateApi from "@/api/travel-authorizations/estimates/generate-api"
+
+export default {
+  name: "EstimateGenerateDialog",
+  components: {},
+  props: {
+    formId: {
+      type: Number,
+      required: true,
+    },
+    buttonClasses: {
+      type: [String, Array, Object],
+      default: () => "mb-2",
+    },
+    buttonColor: {
+      type: String,
+      default: "primary",
+    },
+  },
+  data() {
+    return {
+      showDialog: this.$route.query.showGenerate === "true",
+      loading: false,
+    }
+  },
+  watch: {
+    showDialog(value) {
+      if (value) {
+        this.$router.push({ query: { showGenerate: value } })
+      } else {
+        this.$router.push({ query: { showGenerate: undefined } })
+      }
+    },
+  },
+  methods: {
+    required,
+    ...mapActions("current/travelAuthorization", {
+      saveCurrentTravelAuthorizationSilently: "saveSilently",
+    }),
+    close() {
+      this.showDialog = false
+    },
+    async createAndClose() {
+      this.loading = true
+      try {
+        await this.saveCurrentTravelAuthorizationSilently()
+        await generateApi.create(this.formId)
+        this.$emit("created")
+        this.close()
+      } catch (error) {
+        this.$snack(error.message, { color: "error" })
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+}
+</script>

--- a/web/src/store/current/travel-authorization.js
+++ b/web/src/store/current/travel-authorization.js
@@ -86,11 +86,18 @@ const actions = {
       commit("SET_IS_LOADING", false)
     }
   },
-  async save({ commit, state, getters }) {
+  async save({ commit, dispatch }) {
+    commit("SET_IS_LOADING", true)
+    try {
+      return dispatch("saveSilently")
+    } finally {
+      commit("SET_IS_LOADING", false)
+    }
+  },
+  async saveSilently({ commit, state, getters }) {
     const travelAuthorizationId = getters.id
     const attributes = state.attributes
 
-    commit("SET_IS_LOADING", true)
     try {
       const { travelAuthorization } = await travelAuthorizationsApi.update(
         travelAuthorizationId,
@@ -103,8 +110,6 @@ const actions = {
       console.error("Failed to update travel authorization:", error)
       commit("SET_IS_ERRORED", true)
       throw error
-    } finally {
-      commit("SET_IS_LOADING", false)
     }
   },
   newBlankStop({ getters }, attributes) {


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/92

Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/113

# Context

When you are editing a new "draft" Travel Authorization,
and you click the "Generate Estimate",
it refreshes the page,
and wipes any information you have previously entered but not saved.

# Implementation

Make the "Generate Estimate" button perform a silent save of the current travel authorization.

# Screenshots

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/93090318-3f4c-41b8-ad89-84bd15279902)

# Testing Instructions

1. Boot the app via `dev up`
2. Log in to the app at http://localhost:8080
3. Go to the "My Travel Requests" page via the top drop down nav.
4. Create a new travel request via the "+ Travel Authorization" button.
5. Add all the necessary content, until you get to the "Generate Estimate" button, but don't save as draft yet.
6. Click the "Generate Estimate" button.
7. Check that the form is persisted, and the estimates are generated.
