### PR TITLE
Make Departure Times Optional In Travel Authorization Form And Various Other Locations

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+Relates to:
+- TODO
+
+# Context
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ TODO
 
 # Testing Instructions
 
-1. Boot the app via `dev up`
-2. Log in to the app at http://localhost:8080
-3.
+1. Run the test suite via `dev test` (or `dev test_api`)
+2. Boot the app via `dev up`
+3. Log in to the app at http://localhost:8080
+4.

--- a/api/src/controllers/travel-authorizations/estimates/generate-controller.ts
+++ b/api/src/controllers/travel-authorizations/estimates/generate-controller.ts
@@ -21,7 +21,8 @@ export class GenerateController extends BaseController {
         .json({ message: "You are not authorized to create this expense." })
     }
 
-    return BulkGenerateService.perform(travelAuthorization.id)
+    const travelSegments = travelAuthorization.travelSegments || []
+    return BulkGenerateService.perform(travelAuthorization.id, travelSegments)
       .then((estimates) => {
         return this.response.status(201).json({
           estimates,
@@ -36,7 +37,15 @@ export class GenerateController extends BaseController {
   }
 
   private async loadTravelAuthorization() {
-    return TravelAuthorization.findByPk(this.params.travelAuthorizationId)
+    return TravelAuthorization.findByPk(this.params.travelAuthorizationId, {
+      include: [
+        {
+          association: "travelSegments",
+          include: ["departureLocation", "arrivalLocation"],
+        },
+      ],
+      order: [["travelSegments", "segmentNumber", "ASC"]],
+    })
   }
 
   private async buildExpense(travelAuthorization: TravelAuthorization) {

--- a/api/src/controllers/travel-authorizations/estimates/generate-controller.ts
+++ b/api/src/controllers/travel-authorizations/estimates/generate-controller.ts
@@ -4,7 +4,7 @@ import BaseController from "@/controllers/base-controller"
 
 import { Expense, TravelAuthorization } from "@/models"
 import { ExpensesPolicy } from "@/policies"
-import { BulkGenerate } from "@/services/estimates"
+import { BulkGenerateService } from "@/services/estimates"
 
 export class GenerateController extends BaseController {
   async create() {
@@ -21,7 +21,7 @@ export class GenerateController extends BaseController {
         .json({ message: "You are not authorized to create this expense." })
     }
 
-    return BulkGenerate.perform(travelAuthorization.id)
+    return BulkGenerateService.perform(travelAuthorization.id)
       .then((estimates) => {
         return this.response.status(201).json({
           estimates,

--- a/api/src/data/migrations/20231128201914_create-travel-segments-table.ts
+++ b/api/src/data/migrations/20231128201914_create-travel-segments-table.ts
@@ -1,0 +1,40 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("travel_segments", (table) => {
+    table.increments("id").primary()
+    table
+      .integer("travel_authorization_id")
+      .notNullable()
+      .references("id")
+      .inTable("travel_authorizations")
+      .onDelete("CASCADE")
+    table
+      .integer("departure_location_id")
+      .nullable()
+      .references("id")
+      .inTable("locations")
+      .onDelete("RESTRICT")
+    table
+      .integer("arrival_location_id")
+      .nullable()
+      .references("id")
+      .inTable("locations")
+      .onDelete("RESTRICT")
+    table.integer("segment_number").notNullable()
+
+    // See https://github.com/thoughtbot/guides/blob/4ab5599a6fd30b0854d566843015b33fc6fc4bc5/rails/README.md
+    table.date("departure_on").nullable()
+    table.time("departure_time").nullable()
+
+    table.string("mode_of_transport", 255).notNullable()
+    table.string("mode_of_transport_other", 255).nullable()
+    table.string("accommodation_type", 255).nullable()
+    table.string("accommodation_type_other", 255).nullable()
+    table.timestamps(true, true)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable("travel_segments")
+}

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -7,6 +7,7 @@ import TravelAuthorizationActionLog from "./travel-authorization-action-log"
 import TravelDeskPassengerNameRecordDocument from "./travel-desk-passenger-name-record-document"
 import TravelDeskTravelRequest from "./travel-desk-travel-request"
 import User from "./user"
+import TravelSegment from "./travel-segment"
 
 // Order matters here, though may be somewhat flexible
 Stop.establishAssociations()
@@ -16,6 +17,7 @@ TravelDeskPassengerNameRecordDocument.establishAssociations()
 TravelDeskTravelRequest.establishAssociations()
 User.establishAssociations()
 TravelAuthorizationActionLog.establishAssociations()
+TravelSegment.establishAssociations()
 
 // Alphabetically - order does not matter
 export * from "./distance-matrix"
@@ -25,12 +27,13 @@ export * from "./per-diem"
 export * from "./preapproved-traveler"
 export * from "./preapproved"
 export * from "./stop"
-export * from "./travel-authorization"
 export * from "./travel-authorization-action-log"
+export * from "./travel-authorization"
 export * from "./travel-desk-passenger-name-record-document"
 export * from "./travel-desk-travel-agent"
 export * from "./travel-desk-travel-request"
 export * from "./travel-purpose"
+export * from "./travel-segment"
 export * from "./user"
 
 // special db instance that has access to all models.

--- a/api/src/models/per-diem.ts
+++ b/api/src/models/per-diem.ts
@@ -31,6 +31,10 @@ export enum CurrencyTypes {
 }
 
 export class PerDiem extends Model<InferAttributes<PerDiem>, InferCreationAttributes<PerDiem>> {
+  static ClaimTypes = ClaimTypes
+  static LocationTypes = LocationTypes
+  static CurrencyTypes = CurrencyTypes
+
   declare id: CreationOptional<number>
   declare claim: ClaimTypes | null
   declare location: LocationTypes | null

--- a/api/src/models/stop.ts
+++ b/api/src/models/stop.ts
@@ -28,8 +28,8 @@ so we're doing it piecemeal.
 export class Stop extends Model<InferAttributes<Stop>, InferCreationAttributes<Stop>> {
   static TravelMethods = TravelSegment.TravelMethods
   static AccommodationTypes = TravelSegment.AccommodationTypes
-  static BEGINNING_OF_DAY = TravelSegment.BEGINNING_OF_DAY
-  static END_OF_DAY = TravelSegment.END_OF_DAY
+  static BEGINNING_OF_DAY = TravelSegment.FallbackTimes.BEGINNING_OF_DAY
+  static END_OF_DAY = TravelSegment.FallbackTimes.END_OF_DAY
 
   declare id: CreationOptional<number>
   declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>

--- a/api/src/models/stop.ts
+++ b/api/src/models/stop.ts
@@ -17,31 +17,7 @@ import sequelize from "@/db/db-client"
 
 import Location from "./location"
 import TravelAuthorization from "./travel-authorization"
-
-const BEGINNING_OF_DAY = "00:00:00"
-
-// Keep in sync with web/src/modules/travel-authorizations/components/TravelMethodSelect.vue
-// Until both are using a shared location
-// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
-enum TravelMethods {
-  AIRCRAFT = "Aircraft",
-  POOL_VEHICLE = "Pool Vehicle",
-  PERSONAL_VEHICLE = "Personal Vehicle",
-  RENTAL_VEHICLE = "Rental Vehicle",
-  BUS = "Bus",
-  // TODO: replace other type with specific values
-  // OTHER = "Other:"
-}
-
-// Keep in sync with web/src/modules/travel-authorizations/components/AccommodationTypeSelect.vue
-// Until both are using a shared location
-// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
-enum AccommodationTypes {
-  HOTEL = "Hotel",
-  PRIVATE = "Private",
-  // TODO: replace other type with specific values
-  // OTHER = "Other:",
-}
+import TravelSegment from "./travel-segment"
 
 /*
 DEPRECATED: Whenever you use this model, try and figure out how to migrate
@@ -50,9 +26,10 @@ It was too large a project to migrate to the TravelSegment model all at once,
 so we're doing it piecemeal.
 */
 export class Stop extends Model<InferAttributes<Stop>, InferCreationAttributes<Stop>> {
-  static TravelMethods = TravelMethods
-  static AccommodationTypes = AccommodationTypes
-  static BEGINNING_OF_DAY = BEGINNING_OF_DAY
+  static TravelMethods = TravelSegment.TravelMethods
+  static AccommodationTypes = TravelSegment.AccommodationTypes
+  static BEGINNING_OF_DAY = TravelSegment.BEGINNING_OF_DAY
+  static END_OF_DAY = TravelSegment.END_OF_DAY
 
   declare id: CreationOptional<number>
   declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>
@@ -101,7 +78,7 @@ export class Stop extends Model<InferAttributes<Stop>, InferCreationAttributes<S
     const departureDate = this.departureDate
     if (isNil(departureDate)) return null
 
-    const timePart = this.departureTime || BEGINNING_OF_DAY
+    const timePart = this.departureTime || Stop.BEGINNING_OF_DAY
     const departureDateTime = new Date(`${departureDate}T${timePart}`)
     return departureDateTime
   }

--- a/api/src/models/stop.ts
+++ b/api/src/models/stop.ts
@@ -43,6 +43,12 @@ enum AccommodationTypes {
   // OTHER = "Other:",
 }
 
+/*
+DEPRECATED: Whenever you use this model, try and figure out how to migrate
+the functionality to the TravelSegment model instead.
+It was too large a project to migrate to the TravelSegment model all at once,
+so we're doing it piecemeal.
+*/
 export class Stop extends Model<InferAttributes<Stop>, InferCreationAttributes<Stop>> {
   static TravelMethods = TravelMethods
   static AccommodationTypes = AccommodationTypes

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -29,6 +29,7 @@ import Preapproved from "./preapproved"
 import Stop from "./stop"
 import TravelDeskTravelRequest from "./travel-desk-travel-request"
 import TravelPurpose from "./travel-purpose"
+import TravelSegment from "./travel-segment"
 import User from "./user"
 
 // TODO: state management is going to be a bit deal for this project
@@ -167,6 +168,48 @@ export class TravelAuthorization extends Model<
       sourceKey: "id",
       foreignKey: "travelAuthorizationId",
     })
+  }
+
+  // Shim until Stop model is fully removed
+  buildTravelSegmentsFromStops(): TravelSegment[] {
+    if (this.stops === undefined || this.stops.length < 2) {
+      throw new Error("Must have at least 2 stops to build a travel segments")
+    }
+
+    if (this.multiStop === true && this.stops.length < 4) {
+      throw new Error("Must have at least 4 stops to build a multi-stop travel segments")
+    }
+
+    const isRoundTrip = this.oneWayTrip !== true && this.multiStop !== true
+    if (isRoundTrip) {
+      return this.stops.reduce((travelSegments: TravelSegment[], stop, index, stops) => {
+        const isLastStop = index === stops.length - 1
+        const arrivalStop = isLastStop ? stops[0] : stops[index + 1]
+
+        const travelSegment = TravelSegment.buildFromStops({
+          travelAuthorizationId: this.id,
+          departureStop: stop,
+          arrivalStop,
+          segmentNumber: index,
+        })
+        travelSegments.push(travelSegment)
+        return travelSegments
+      }, [])
+    }
+
+    return this.stops.reduce((travelSegments: TravelSegment[], stop, index, stops) => {
+      const isLastStop = index === stops.length - 1
+      if (isLastStop) return travelSegments
+
+      const travelSegment = TravelSegment.buildFromStops({
+        travelAuthorizationId: this.id,
+        departureStop: stop,
+        arrivalStop: stops[index + 1],
+        segmentNumber: index,
+      })
+      travelSegments.push(travelSegment)
+      return travelSegments
+    }, [])
   }
 
   get estimates(): NonAttribute<Expense[] | undefined> {

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -344,6 +344,13 @@ TravelAuthorization.init(
     sequelize,
     tableName: "travel_authorizations",
     modelName: "TravelAuthorization",
+    validate: {
+      tripTypeConsistency() {
+        if (this.oneWayTrip === true && this.multiStop === true) {
+          throw new Error("oneWayTrip and multiStop cannot both be true")
+        }
+      },
+    },
   }
 )
 

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -342,8 +342,6 @@ TravelAuthorization.init(
   },
   {
     sequelize,
-    tableName: "travel_authorizations",
-    modelName: "TravelAuthorization",
     validate: {
       tripTypeConsistency() {
         if (this.oneWayTrip === true && this.multiStop === true) {

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -130,17 +130,51 @@ export class TravelAuthorization extends Model<
   declare countStops: HasManyCountAssociationsMixin
   declare createStop: HasManyCreateAssociationMixin<Stop>
 
+  declare getTravelSegments: HasManyGetAssociationsMixin<TravelSegment>
+  declare setTravelSegments: HasManySetAssociationsMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare hasTravelSegment: HasManyHasAssociationMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare hasTravelSegments: HasManyHasAssociationsMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare addTravelSegment: HasManyAddAssociationMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare addTravelSegments: HasManyAddAssociationsMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare removeTravelSegment: HasManyRemoveAssociationMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare removeTravelSegments: HasManyRemoveAssociationsMixin<
+    TravelSegment,
+    TravelSegment["travelAuthorizationId"]
+  >
+  declare countTravelSegments: HasManyCountAssociationsMixin
+  declare createTravelSegment: HasManyCreateAssociationMixin<TravelSegment>
+
   declare purpose?: NonAttribute<TravelPurpose>
   declare travelDeskTravelRequest?: NonAttribute<TravelDeskTravelRequest>
   declare user: NonAttribute<User>
   declare expenses?: NonAttribute<Expense[]>
   declare stops?: NonAttribute<Stop[]>
+  declare travelSegments?: NonAttribute<TravelSegment[]>
 
   declare static associations: {
     expenses: Association<TravelAuthorization, Expense>
     purpose: Association<TravelAuthorization, TravelPurpose>
     stops: Association<TravelAuthorization, Stop>
     travelDeskTravelRequest: Association<TravelAuthorization, TravelDeskTravelRequest>
+    travelSegments: Association<TravelAuthorization, TravelSegment>
     user: Association<TravelAuthorization, User>
   }
 
@@ -153,11 +187,6 @@ export class TravelAuthorization extends Model<
       as: "user",
       foreignKey: "userId",
     })
-    this.hasMany(Stop, {
-      as: "stops",
-      sourceKey: "id",
-      foreignKey: "travelAuthorizationId",
-    })
     this.hasOne(TravelDeskTravelRequest, {
       as: "travelDeskTravelRequest",
       sourceKey: "id",
@@ -165,6 +194,16 @@ export class TravelAuthorization extends Model<
     })
     this.hasMany(Expense, {
       as: "expenses",
+      sourceKey: "id",
+      foreignKey: "travelAuthorizationId",
+    })
+    this.hasMany(Stop, {
+      as: "stops",
+      sourceKey: "id",
+      foreignKey: "travelAuthorizationId",
+    })
+    this.hasMany(TravelSegment, {
+      as: "travelSegments",
       sourceKey: "id",
       foreignKey: "travelAuthorizationId",
     })

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -23,6 +23,7 @@ const END_OF_DAY = "23:59:59"
 // Keep in sync with web/src/api/stops-api.js
 // Until both are using a shared location
 // Avoid exporting here, and instead expose via the model to avoid naming conflicts
+// TODO: normalize casing of these to snake_case, and add UI localization
 enum TravelMethods {
   AIRCRAFT = "Aircraft",
   POOL_VEHICLE = "Pool Vehicle",
@@ -35,6 +36,7 @@ enum TravelMethods {
 // Keep in sync with web/src/api/stops-api.js
 // Until both are using a shared location
 // Avoid exporting here, and instead expose via the model to avoid naming conflicts
+// TODO: normalize casing of these to snake_case, and add UI localization
 enum AccommodationTypes {
   HOTEL = "Hotel",
   PRIVATE = "Private",

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -17,10 +17,41 @@ import sequelize from "@/db/db-client"
 import Location from "./location"
 import TravelAuthorization from "./travel-authorization"
 
+const BEGINNING_OF_DAY = "00:00:00"
+const END_OF_DAY = "23:59:59"
+
+// Keep in sync with web/src/api/stops-api.js
+// Until both are using a shared location
+// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
+enum TravelMethods {
+  AIRCRAFT = "Aircraft",
+  POOL_VEHICLE = "Pool Vehicle",
+  PERSONAL_VEHICLE = "Personal Vehicle",
+  RENTAL_VEHICLE = "Rental Vehicle",
+  BUS = "Bus",
+  // TODO: replace other type with specific values
+  // OTHER = "Other:"
+}
+
+// Keep in sync with web/src/api/stops-api.js
+// Until both are using a shared location
+// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
+enum AccommodationTypes {
+  HOTEL = "Hotel",
+  PRIVATE = "Private",
+  // TODO: replace other type with specific values
+  // OTHER = "Other:",
+}
+
 export class TravelSegment extends Model<
   InferAttributes<TravelSegment>,
   InferCreationAttributes<TravelSegment>
 > {
+  static TravelMethods = TravelMethods
+  static AccommodationTypes = AccommodationTypes
+  static BEGINNING_OF_DAY = BEGINNING_OF_DAY
+  static END_OF_DAY = END_OF_DAY
+
   declare id: CreationOptional<number>
   declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>
   declare departureLocationId: ForeignKey<Location["id"]> | null

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -19,8 +19,10 @@ import Location from "./location"
 import Stop from "./stop"
 import TravelAuthorization from "./travel-authorization"
 
-const BEGINNING_OF_DAY = "00:00:00"
-const END_OF_DAY = "23:59:59"
+enum FallbackTimes {
+  BEGINNING_OF_DAY = "00:00:00",
+  END_OF_DAY = "23:59:59",
+}
 
 // Keep in sync with web/src/api/stops-api.js
 // Until both are using a shared location
@@ -51,8 +53,7 @@ export class TravelSegment extends Model<
 > {
   static TravelMethods = TravelMethods
   static AccommodationTypes = AccommodationTypes
-  static BEGINNING_OF_DAY = BEGINNING_OF_DAY
-  static END_OF_DAY = END_OF_DAY
+  static FallbackTimes = FallbackTimes
 
   declare id: CreationOptional<number>
   declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>
@@ -161,10 +162,16 @@ export class TravelSegment extends Model<
   }
 
   get departureAt(): NonAttribute<Date | null> {
+    return this.departureAtWithTimeFallback(FallbackTimes.BEGINNING_OF_DAY)
+  }
+
+  departureAtWithTimeFallback(
+    fallbackTime: FallbackTimes
+  ): NonAttribute<Date | null> {
     const departureOn = this.departureOn
     if (isNil(departureOn)) return null
 
-    const timePart = this.departureTime || BEGINNING_OF_DAY
+    const timePart = this.departureTime || fallbackTime
     return new Date(`${departureOn}T${timePart}`)
   }
 }

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -11,6 +11,7 @@ import {
   Model,
   NonAttribute,
 } from "sequelize"
+import { isNil } from "lodash"
 
 import sequelize from "@/db/db-client"
 
@@ -110,6 +111,14 @@ export class TravelSegment extends Model<
       foreignKey: "arrivalLocationId",
       onDelete: "RESTRICT",
     })
+  }
+
+  get departureAt(): NonAttribute<Date | null> {
+    const departureOn = this.departureOn
+    if (isNil(departureOn)) return null
+
+    const timePart = this.departureTime || BEGINNING_OF_DAY
+    return new Date(`${departureOn}T${timePart}`)
   }
 }
 

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -131,18 +131,18 @@ export class TravelSegment extends Model<
     }
 
     const modeOfTransport = (Object.values(TravelMethods) as string[]).includes(
-      departureStop.transport as any
+      departureStop.transport
     )
       ? departureStop.transport
       : TravelMethods.OTHER
     const modeOfTransportOther =
       modeOfTransport === TravelMethods.OTHER ? departureStop.transport : null
 
-    const accommodationType = (Object.values(AccommodationTypes) as string[]).includes(
-      departureStop.accommodationType as any
-    )
-      ? departureStop.accommodationType
-      : AccommodationTypes.OTHER
+    const accommodationType =
+      isNil(departureStop.accommodationType) ||
+      (Object.values(AccommodationTypes) as string[]).includes(departureStop.accommodationType)
+        ? departureStop.accommodationType
+        : AccommodationTypes.OTHER
     const accommodationTypeOther =
       accommodationType === AccommodationTypes.OTHER ? departureStop.accommodationType : null
 

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -1,0 +1,149 @@
+import {
+  Association,
+  BelongsToCreateAssociationMixin,
+  BelongsToGetAssociationMixin,
+  BelongsToSetAssociationMixin,
+  CreationOptional,
+  DataTypes,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  NonAttribute,
+} from "sequelize"
+
+import sequelize from "@/db/db-client"
+
+import Location from "./location"
+import TravelAuthorization from "./travel-authorization"
+
+export class TravelSegment extends Model<
+  InferAttributes<TravelSegment>,
+  InferCreationAttributes<TravelSegment>
+> {
+  declare id: CreationOptional<number>
+  declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>
+  declare departureLocationId: ForeignKey<Location["id"]> | null
+  declare arrivalLocationId: ForeignKey<Location["id"]> | null
+  declare segmentNumber: number
+  declare departureOn: Date | null
+  declare departureTime: string | null
+  declare modeOfTransport: string
+  declare modeOfTransportOther: string | null
+  declare accommodationType: string | null
+  declare accommodationTypeOther: string | null
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
+
+  // https://sequelize.org/docs/v6/other-topics/typescript/#usage
+  // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
+  // https://sequelize.org/api/v7/types/_sequelize_core.index.belongstocreateassociationmixin
+  declare getTravelAuthorization: BelongsToGetAssociationMixin<TravelAuthorization>
+  declare setTravelAuthorization: BelongsToSetAssociationMixin<
+    TravelAuthorization,
+    TravelAuthorization["id"]
+  >
+  declare createTravelAuthorization: BelongsToCreateAssociationMixin<TravelAuthorization>
+
+  declare getDepartureLocation: BelongsToGetAssociationMixin<Location>
+  declare setDepartureLocation: BelongsToSetAssociationMixin<Location, Location["id"]>
+  declare createDepartureLocation: BelongsToCreateAssociationMixin<Location>
+
+  declare getArrivalLocation: BelongsToGetAssociationMixin<Location>
+  declare setArrivalLocation: BelongsToSetAssociationMixin<Location, Location["id"]>
+  declare createArrivalLocation: BelongsToCreateAssociationMixin<Location>
+
+  declare travelAuthorization?: NonAttribute<TravelAuthorization>
+  declare departureLocation?: NonAttribute<Location>
+  declare arrivalLocation?: NonAttribute<Location>
+
+  declare static associations: {
+    travelAuthorization: Association<TravelSegment, TravelAuthorization>
+    departureLocation: Association<TravelSegment, Location>
+    arrivalLocation: Association<TravelSegment, Location>
+  }
+
+  static establishAssociations() {
+    this.belongsTo(TravelAuthorization, {
+      as: "travelAuthorization",
+      foreignKey: "travelAuthorizationId",
+      onDelete: "CASCADE",
+    })
+    this.belongsTo(Location, {
+      as: "departureLocation",
+      foreignKey: "departureLocationId",
+      onDelete: "RESTRICT",
+    })
+    this.belongsTo(Location, {
+      as: "arrivalLocation",
+      foreignKey: "arrivalLocationId",
+      onDelete: "RESTRICT",
+    })
+  }
+}
+
+TravelSegment.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    travelAuthorizationId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    departureLocationId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    arrivalLocationId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    segmentNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    departureOn: {
+      type: DataTypes.DATEONLY,
+      allowNull: true,
+    },
+    departureTime: {
+      type: DataTypes.TIME,
+      allowNull: true,
+    },
+    modeOfTransport: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    modeOfTransportOther: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    accommodationType: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    accommodationTypeOther: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+  }
+)
+
+export default TravelSegment

--- a/api/src/services/estimates/bulk-generate-service.ts
+++ b/api/src/services/estimates/bulk-generate-service.ts
@@ -10,6 +10,7 @@ import {
   PerDiem,
   Stop,
   TravelAuthorization,
+  TravelSegment,
 } from "@/models"
 
 import BaseService from "@/services/base-service"
@@ -105,7 +106,9 @@ export class BulkGenerateService extends BaseService {
       }
 
       if (!isNil(nextTravelSegment)) {
-        const departureAt = nextTravelSegment.departureAt
+        const departureAt = nextTravelSegment.departureAtWithTimeFallback(
+          TravelSegment.FallbackTimes.END_OF_DAY
+        )
         if (isNil(departureAt)) {
           throw new Error(`Missing departure date on Stop#${nextTravelSegment.id}`)
         }

--- a/api/src/services/estimates/bulk-generate-service.ts
+++ b/api/src/services/estimates/bulk-generate-service.ts
@@ -207,6 +207,9 @@ export class BulkGenerateService extends BaseService {
       const claims = this.determineClaimTypes(stayedAt, departureAt)
       const description = claims.join("/")
       const cost = await this.determinePerDiemCost(province, claims)
+      if (isNil(cost)) {
+        throw new Error(`Missing per diem cost for province=${province} and claims=${claims}`)
+      }
 
       estimates.push({
         type: Expense.Types.ESTIMATE,

--- a/api/src/services/estimates/bulk-generate-service.ts
+++ b/api/src/services/estimates/bulk-generate-service.ts
@@ -14,6 +14,7 @@ import {
 
 import BaseService from "@/services/base-service"
 import { TravelSegments } from "@/services"
+import { BulkGenerate } from "@/services/estimates"
 
 const MAXIUM_AIRCRAFT_ALLOWANCE = 1000
 const AIRCRAFT_ALLOWANCE_PER_SEGMENT = 350
@@ -162,7 +163,7 @@ export class BulkGenerateService extends BaseService {
     const city = location.city
     const description = `${accommodationType} in ${city}`
 
-    const numberOfNights = this.calculateNumberOfNights(arrivalAt, departureAt)
+    const numberOfNights = BulkGenerate.calculateNumberOfNights(arrivalAt, departureAt)
     return times(numberOfNights, (index) => {
       let stayedAt = clone(arrivalAt)
       stayedAt.setDate(arrivalAt.getDate() + index)
@@ -189,10 +190,10 @@ export class BulkGenerateService extends BaseService {
     arrivalAt: Date
     departureAt: Date
   }): Promise<CreationAttributes<Expense>[]> {
-    const numberOfNights = this.calculateNumberOfNights(arrivalAt, departureAt)
+    const numberOfDays = BulkGenerate.calculateNumberOfDays(arrivalAt, departureAt)
 
     let estimates = []
-    for (let index = 0; index < numberOfNights; index += 1) {
+    for (let index = 0; index < numberOfDays; index += 1) {
       let stayedAtStartOfDay = clone(arrivalAt)
       stayedAtStartOfDay.setDate(arrivalAt.getDate() + index)
       stayedAtStartOfDay.setHours(0, 0, 0, 0)
@@ -271,14 +272,6 @@ export class BulkGenerateService extends BaseService {
       default:
         return 0
     }
-  }
-
-  private calculateNumberOfNights(checkInAt: Date, checkOutAt: Date): number {
-    const differenceInMs = checkOutAt.getTime() - checkInAt.getTime()
-    const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
-    const differenceInDays = Math.floor(differenceInDaysAsFloat)
-
-    return max([0, differenceInDays]) as number
   }
 
   // Assuming a meal every 4 hours

--- a/api/src/services/estimates/bulk-generate-service.ts
+++ b/api/src/services/estimates/bulk-generate-service.ts
@@ -21,7 +21,7 @@ const DISTANCE_ALLOWANCE_PER_KILOMETER = 0.605
 const HOTEL_ALLOWANCE_PER_NIGHT = 250
 const PRIVATE_ACCOMMODATION_ALLOWANCE_PER_NIGHT = 50
 
-export class BulkGenerate extends BaseService {
+export class BulkGenerateService extends BaseService {
   private travelAuthorizationId: number
   private aircraftAllowanceRemaining: number
 
@@ -342,4 +342,4 @@ export class BulkGenerate extends BaseService {
   }
 }
 
-export default BulkGenerate
+export default BulkGenerateService

--- a/api/src/services/estimates/bulk-generate.ts
+++ b/api/src/services/estimates/bulk-generate.ts
@@ -53,7 +53,14 @@ export class BulkGenerate extends BaseService {
     const travelSegmentsAttributes = travelAuthorization
       .buildTravelSegmentsFromStops()
       .map((t) => t.dataValues)
-    const travelSegments = await TravelSegments.BulkReplaceService.perform(this.travelAuthorizationId, travelSegmentsAttributes)
+    await TravelSegments.BulkReplaceService.perform(
+      this.travelAuthorizationId,
+      travelSegmentsAttributes
+    )
+    const travelSegments = await travelAuthorization.getTravelSegments({
+      include: ["departureLocation", "arrivalLocation"],
+      order: [["segmentNumber", "ASC"]],
+    })
 
     const estimates: CreationAttributes<Expense>[] = []
     let index = 0
@@ -71,7 +78,6 @@ export class BulkGenerate extends BaseService {
         throw new Error(`Missing departure date on TravelSegment#${travelSegment.id}`)
       }
 
-      // TODO: debug location assertions so they don't trigger error below
       const travelMethodEstimate = await this.buildTravelMethodEstimate({
         modeOfTransport: travelSegment.modeOfTransport,
         departureCity: travelSegment.departureLocation.city,

--- a/api/src/services/estimates/bulk-generate.ts
+++ b/api/src/services/estimates/bulk-generate.ts
@@ -80,33 +80,31 @@ export class BulkGenerate extends BaseService {
       })
       estimates.push(travelMethodEstimate)
 
-      const accommodationType = fromStop.accommodationType
-      const nextSegment = travelSegments[index + 1]
-      if (!isNil(accommodationType) && !isNil(nextSegment)) {
-        const [nextFromStop, _] = nextSegment
-        const accommodationDepartureAt = nextFromStop.departureAt
+      const accommodationType = travelSegment.accommodationType
+      const nextTravelSegment = travelSegments[index + 1]
+      if (!isNil(accommodationType) && !isNil(nextTravelSegment)) {
+        const accommodationDepartureAt = nextTravelSegment.departureAt
         if (isNil(accommodationDepartureAt)) {
-          throw new Error(`Missing departure date on Stop#${nextFromStop.id}`)
+          throw new Error(`Missing departure date on Stop#${nextTravelSegment.id}`)
         }
 
         const accommodationEstimates = this.buildAccommodationEstimates({
-          location: toLocation,
+          location: travelSegment.arrivalLocation,
           accommodationType,
-          arrivalAt: fromDepartureAt,
+          arrivalAt: travelSegment.departureAt,
           departureAt: accommodationDepartureAt,
         })
         estimates.push(...accommodationEstimates)
       }
 
-      if (!isNil(nextSegment)) {
-        const [nextFromStop, _] = nextSegment
-        const departureAt = nextFromStop.departureAt
+      if (!isNil(nextTravelSegment)) {
+        const departureAt = nextTravelSegment.departureAt
         if (isNil(departureAt)) {
-          throw new Error(`Missing departure date on Stop#${nextFromStop.id}`)
+          throw new Error(`Missing departure date on Stop#${nextTravelSegment.id}`)
         }
         const mealsAndIncidentalsEstimates = await this.buildMealsAndIncidentalsEstimates({
-          location: toLocation,
-          arrivalAt: fromDepartureAt,
+          location: travelSegment.arrivalLocation,
+          arrivalAt: travelSegment.departureAt,
           departureAt,
         })
         estimates.push(...mealsAndIncidentalsEstimates)

--- a/api/src/services/estimates/bulk-generate.ts
+++ b/api/src/services/estimates/bulk-generate.ts
@@ -10,9 +10,10 @@ import {
   PerDiem,
   Stop,
   TravelAuthorization,
-  TravelSegment,
 } from "@/models"
+
 import BaseService from "@/services/base-service"
+import { TravelSegments } from "@/services"
 
 const MAXIUM_AIRCRAFT_ALLOWANCE = 1000
 const AIRCRAFT_ALLOWANCE_PER_SEGMENT = 350
@@ -49,9 +50,10 @@ export class BulkGenerate extends BaseService {
       throw new Error(`TravelAuthorization not found for id=${this.travelAuthorizationId}`)
     }
 
-    // TODO: I think I might need to make this an ensure/findOrCreate action?
-    // It'll be easier to debug if I'm persisting the travel segments.
-    const travelSegments = travelAuthorization.buildTravelSegmentsFromStops()
+    const travelSegmentsAttributes = travelAuthorization
+      .buildTravelSegmentsFromStops()
+      .map((t) => t.dataValues)
+    const travelSegments = await TravelSegments.BulkReplaceService.perform(this.travelAuthorizationId, travelSegmentsAttributes)
 
     const estimates: CreationAttributes<Expense>[] = []
     let index = 0

--- a/api/src/services/estimates/bulk-generate/README.md
+++ b/api/src/services/estimates/bulk-generate/README.md
@@ -1,0 +1,4 @@
+# Bulk Generate
+
+This module has various helper functions for the estimate bulk generation service.
+It exists to make the specific computations easier to test and debug.

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
@@ -1,0 +1,11 @@
+import { max } from "lodash"
+
+export function calculateNumberOfDays(arrivalAt: Date, departureAt: Date): number {
+  const differenceInMs = departureAt.getTime() - arrivalAt.getTime()
+  const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
+  const differenceInDays = Math.ceil(differenceInDaysAsFloat)
+
+  return max([0, differenceInDays]) as number
+}
+
+export default calculateNumberOfDays

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
@@ -1,18 +1,20 @@
-import { clone, max } from "lodash"
-
 // This calculates the number of days you would need to request per-diems for
 // as a result the function can't use the time difference alone
 export function calculateNumberOfDays(arrivalAt: Date, departureAt: Date): number {
-  const arrivalAtStartOfDay = clone(arrivalAt)
+  if (arrivalAt.getTime() > departureAt.getTime()) {
+    throw new Error("arrivalAt must be less than or equal to departureAt")
+  }
+
+  const arrivalAtStartOfDay = new Date(arrivalAt)
   arrivalAtStartOfDay.setHours(0, 0, 0, 0)
-  const departureAtEndOfDay = clone(departureAt)
+  const departureAtEndOfDay = new Date(departureAt)
   departureAtEndOfDay.setHours(23, 59, 59, 999)
 
   const differenceInMs = departureAtEndOfDay.getTime() - arrivalAtStartOfDay.getTime()
   const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
   const differenceInDays = Math.ceil(differenceInDaysAsFloat)
 
-  return max([0, differenceInDays]) as number
+  return differenceInDays
 }
 
 export default calculateNumberOfDays

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
@@ -1,5 +1,7 @@
 import { clone, max } from "lodash"
 
+// This calculates the number of days you would need to request per-diems for
+// as a result the function can't use the time difference alone
 export function calculateNumberOfDays(arrivalAt: Date, departureAt: Date): number {
   const arrivalAtStartOfDay = clone(arrivalAt)
   arrivalAtStartOfDay.setHours(0, 0, 0, 0)

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-days.ts
@@ -1,7 +1,12 @@
-import { max } from "lodash"
+import { clone, max } from "lodash"
 
 export function calculateNumberOfDays(arrivalAt: Date, departureAt: Date): number {
-  const differenceInMs = departureAt.getTime() - arrivalAt.getTime()
+  const arrivalAtStartOfDay = clone(arrivalAt)
+  arrivalAtStartOfDay.setHours(0, 0, 0, 0)
+  const departureAtEndOfDay = clone(departureAt)
+  departureAtEndOfDay.setHours(23, 59, 59, 999)
+
+  const differenceInMs = departureAtEndOfDay.getTime() - arrivalAtStartOfDay.getTime()
   const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
   const differenceInDays = Math.ceil(differenceInDaysAsFloat)
 

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
@@ -1,5 +1,7 @@
 import { clone, max } from "lodash"
 
+// This calculates the number of nights you would need to book a hotel for
+// as a result the function can't use the time difference alone
 export function calculateNumberOfNights(arrivalAt: Date, departureAt: Date): number {
   const arrivalAtStartOfDay = clone(arrivalAt)
   arrivalAtStartOfDay.setHours(0, 0, 0, 0)

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
@@ -1,0 +1,11 @@
+import { max } from "lodash"
+
+export function calculateNumberOfNights(arrivalAt: Date, departureAt: Date): number {
+  const differenceInMs = departureAt.getTime() - arrivalAt.getTime()
+  const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
+  const differenceInNights = Math.floor(differenceInDaysAsFloat)
+
+  return max([0, differenceInNights]) as number
+}
+
+export default calculateNumberOfNights

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
@@ -1,7 +1,12 @@
-import { max } from "lodash"
+import { clone, max } from "lodash"
 
 export function calculateNumberOfNights(arrivalAt: Date, departureAt: Date): number {
-  const differenceInMs = departureAt.getTime() - arrivalAt.getTime()
+  const arrivalAtStartOfDay = clone(arrivalAt)
+  arrivalAtStartOfDay.setHours(0, 0, 0, 0)
+  const departureAtStartOfDay = clone(departureAt)
+  departureAtStartOfDay.setHours(0, 0, 0, 0)
+
+  const differenceInMs = departureAtStartOfDay.getTime() - arrivalAtStartOfDay.getTime()
   const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
   const differenceInNights = Math.floor(differenceInDaysAsFloat)
 

--- a/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
+++ b/api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
@@ -1,18 +1,20 @@
-import { clone, max } from "lodash"
-
 // This calculates the number of nights you would need to book a hotel for
 // as a result the function can't use the time difference alone
 export function calculateNumberOfNights(arrivalAt: Date, departureAt: Date): number {
-  const arrivalAtStartOfDay = clone(arrivalAt)
+  if (arrivalAt.getTime() > departureAt.getTime()) {
+    throw new Error("arrivalAt must be less than or equal to departureAt")
+  }
+
+  const arrivalAtStartOfDay = new Date(arrivalAt)
   arrivalAtStartOfDay.setHours(0, 0, 0, 0)
-  const departureAtStartOfDay = clone(departureAt)
+  const departureAtStartOfDay = new Date(departureAt)
   departureAtStartOfDay.setHours(0, 0, 0, 0)
 
   const differenceInMs = departureAtStartOfDay.getTime() - arrivalAtStartOfDay.getTime()
   const differenceInDaysAsFloat = differenceInMs / (1000 * 3600 * 24)
   const differenceInNights = Math.floor(differenceInDaysAsFloat)
 
-  return max([0, differenceInNights]) as number
+  return differenceInNights
 }
 
 export default calculateNumberOfNights

--- a/api/src/services/estimates/bulk-generate/index.ts
+++ b/api/src/services/estimates/bulk-generate/index.ts
@@ -1,0 +1,4 @@
+export * from "./calculate-number-of-days"
+export * from "./calculate-number-of-nights"
+
+export default undefined

--- a/api/src/services/estimates/index.ts
+++ b/api/src/services/estimates/index.ts
@@ -1,3 +1,3 @@
-export * from './bulk-generate'
+export * from './bulk-generate-service'
 
 export default undefined

--- a/api/src/services/estimates/index.ts
+++ b/api/src/services/estimates/index.ts
@@ -1,3 +1,8 @@
 export * from './bulk-generate-service'
 
+// Namespaced exports
+import * as BulkGenerate from './bulk-generate'
+
+export { BulkGenerate }
+
 export default undefined

--- a/api/src/services/estimates/index.ts
+++ b/api/src/services/estimates/index.ts
@@ -1,7 +1,7 @@
-export * from './bulk-generate-service'
+export * from "./bulk-generate-service"
 
 // Namespaced exports
-import * as BulkGenerate from './bulk-generate'
+import * as BulkGenerate from "./bulk-generate"
 
 export { BulkGenerate }
 

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -10,8 +10,9 @@ import * as Estimates from "./estimates"
 import * as Qa from "./qa"
 import * as TravelAuthorizations from "./travel-authorizations"
 import * as TravelSegments from "./travel-segments"
+import * as Stops from "./stops"
 
-export { Estimates, Qa, TravelAuthorizations, TravelSegments }
+export { Estimates, Qa, TravelAuthorizations, TravelSegments, Stops }
 
 // TODO: move these to their own files, or deprecate and remove them completely
 export interface QueryStatement {

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -9,8 +9,9 @@ export * from "./yk-government-directory-sync-service"
 import * as Estimates from "./estimates"
 import * as Qa from "./qa"
 import * as TravelAuthorizations from "./travel-authorizations"
+import * as TravelSegments from "./travel-segments"
 
-export { Estimates, Qa, TravelAuthorizations }
+export { Estimates, Qa, TravelAuthorizations, TravelSegments }
 
 // TODO: move these to their own files, or deprecate and remove them completely
 export interface QueryStatement {

--- a/api/src/services/stops/bulk-convert-stops-to-travel-segments-service.ts
+++ b/api/src/services/stops/bulk-convert-stops-to-travel-segments-service.ts
@@ -1,0 +1,48 @@
+import BaseService from "@/services/base-service"
+import { TravelSegments } from "@/services"
+
+import { TravelAuthorization } from "@/models"
+
+export class BulkConvertStopsToTravelSegmentsService extends BaseService {
+  private travelAuthorization: TravelAuthorization
+
+  constructor(travelAuthorization: TravelAuthorization) {
+    super()
+    this.travelAuthorization = travelAuthorization
+  }
+
+  async perform(): Promise<TravelAuthorization> {
+    await this.travelAuthorization.reload({
+      include: [
+        {
+          association: "stops",
+          include: ["location"],
+        },
+      ],
+      order: [
+        ["stops", "departureDate", "ASC"],
+        ["stops", "departureTime", "ASC"],
+      ],
+    })
+
+    const travelSegmentsAttributes = this.travelAuthorization
+      .buildTravelSegmentsFromStops()
+      .map((t) => t.dataValues)
+
+    await TravelSegments.BulkReplaceService.perform(
+      this.travelAuthorization.id,
+      travelSegmentsAttributes
+    )
+    return this.travelAuthorization.reload({
+      include: [
+        {
+          association: "travelSegments",
+          include: ["departureLocation", "arrivalLocation"],
+        },
+      ],
+      order: [["travelSegments", "segmentNumber", "ASC"]],
+    })
+  }
+}
+
+export default BulkConvertStopsToTravelSegmentsService

--- a/api/src/services/stops/index.ts
+++ b/api/src/services/stops/index.ts
@@ -1,0 +1,3 @@
+export * from "./bulk-convert-stops-to-travel-segments-service"
+
+export default undefined

--- a/api/src/services/travel-authorizations/update-service.ts
+++ b/api/src/services/travel-authorizations/update-service.ts
@@ -5,7 +5,7 @@ import db from "@/db/db-client"
 import BaseService from "@/services/base-service"
 
 import { Expense, Stop, TravelAuthorization, TravelAuthorizationActionLog, User } from "@/models"
-import { StopsService, ExpensesService } from "@/services"
+import { StopsService, ExpensesService, Stops } from "@/services"
 
 type StopsCreationAttributes = CreationAttributes<Stop>[]
 
@@ -42,6 +42,8 @@ export class UpdateService extends BaseService {
       const travelAuthorizationId = this.travelAuthorization.id
       if (!isEmpty(this.stops)) {
         await StopsService.bulkReplace(travelAuthorizationId, this.stops)
+        // TODO: remove this once travel segments fully replace stops
+        await Stops.BulkConvertStopsToTravelSegmentsService.perform(this.travelAuthorization)
       }
 
       if (!isEmpty(this.expenses)) {

--- a/api/src/services/travel-segments/bulk-replace-service.ts
+++ b/api/src/services/travel-segments/bulk-replace-service.ts
@@ -1,0 +1,38 @@
+import { CreationAttributes } from "sequelize"
+
+import db from "@/db/db-client"
+import BaseService from "@/services/base-service"
+
+import { TravelSegment } from "@/models"
+
+export class BulkReplaceService extends BaseService {
+  private travelAuthorizationId: number
+  private travelSegmentsAttributes: CreationAttributes<TravelSegment>[]
+
+  constructor(
+    travelAuthorizationId: number,
+    travelSegmentsAttributes: CreationAttributes<TravelSegment>[]
+  ) {
+    super()
+    this.travelAuthorizationId = travelAuthorizationId
+    this.travelSegmentsAttributes = travelSegmentsAttributes
+  }
+
+  async perform(): Promise<TravelSegment[]> {
+    if (
+      !this.travelSegmentsAttributes.every(
+        (travelSegmentAttributes) =>
+          travelSegmentAttributes.travelAuthorizationId === this.travelAuthorizationId
+      )
+    ) {
+      throw new Error("All travelSegments must belong to the same form.")
+    }
+
+    return db.transaction(async () => {
+      await TravelSegment.destroy({ where: { travelAuthorizationId: this.travelAuthorizationId } })
+      return TravelSegment.bulkCreate(this.travelSegmentsAttributes)
+    })
+  }
+}
+
+export default BulkReplaceService

--- a/api/src/services/travel-segments/index.ts
+++ b/api/src/services/travel-segments/index.ts
@@ -1,0 +1,3 @@
+export * from "./bulk-replace-service"
+
+export default undefined

--- a/api/tests/controllers/travel-authorizations/estimates/generate-controller.test.ts
+++ b/api/tests/controllers/travel-authorizations/estimates/generate-controller.test.ts
@@ -2,7 +2,7 @@ import request from "supertest"
 import { Request, Response, NextFunction } from "express"
 
 import app from "@/app"
-import { BulkGenerate } from "@/services/estimates"
+import { BulkGenerateService } from "@/services/estimates"
 import { checkJwt, loadUser } from "@/middleware/authz.middleware"
 import { TravelAuthorization, User } from "@/models"
 import { travelAuthorizationFactory, userFactory } from "@/factories"
@@ -12,11 +12,11 @@ jest.mock("@/middleware/authz.middleware", () => ({
   checkJwt: jest.fn(),
   loadUser: jest.fn(),
 }))
-jest.mock("@/services/estimates", () => ({ BulkGenerate: { perform: jest.fn() } }))
+jest.mock("@/services/estimates", () => ({ BulkGenerateService: { perform: jest.fn() } }))
 
 const mockedCheckJwt = checkJwt as unknown as jest.Mock
 const mockedLoadUser = loadUser as unknown as jest.Mock
-const mockedBulkGeneratePerform = BulkGenerate.perform as unknown as jest.Mock
+const mockedBulkGenerateServicePerform = BulkGenerateService.perform as unknown as jest.Mock
 
 describe("api/src/controllers/travel-authorizations/estimates/generate-controller.ts", () => {
   let user: User
@@ -42,15 +42,15 @@ describe("api/src/controllers/travel-authorizations/estimates/generate-controlle
         { associations: { user } }
       )
 
-      const mockBulkGeneratePerformResponse = "mock bulk generate response"
-      mockedBulkGeneratePerform.mockImplementation(() => {
-        return Promise.resolve(mockBulkGeneratePerformResponse)
+      const mockBulkGenerateServicePerformResponse = "mock bulk generate response"
+      mockedBulkGenerateServicePerform.mockImplementation(() => {
+        return Promise.resolve(mockBulkGenerateServicePerformResponse)
       })
 
       return request(app)
         .post(`/api/travel-authorizations/${travelAuthorization.id}/estimates/generate`)
         .expect("Content-Type", /json/)
-        .expect(201, { estimates: mockBulkGeneratePerformResponse, message: "Generated estimates" })
+        .expect(201, { estimates: mockBulkGenerateServicePerformResponse, message: "Generated estimates" })
     })
 
     test("when authorized and bulk generation not is successful", async () => {
@@ -61,15 +61,15 @@ describe("api/src/controllers/travel-authorizations/estimates/generate-controlle
         { associations: { user } }
       )
 
-      const mockBulkGeneratePerformResponse = "mock bulk generate response"
-      mockedBulkGeneratePerform.mockImplementation(() => {
-        return Promise.reject(mockBulkGeneratePerformResponse)
+      const mockBulkGenerateServicePerformResponse = "mock bulk generate response"
+      mockedBulkGenerateServicePerform.mockImplementation(() => {
+        return Promise.reject(mockBulkGenerateServicePerformResponse)
       })
 
       return request(app)
         .post(`/api/travel-authorizations/${travelAuthorization.id}/estimates/generate`)
         .expect("Content-Type", /json/)
-        .expect(422, { message: `Failed to generate estimate: ${mockBulkGeneratePerformResponse}` })
+        .expect(422, { message: `Failed to generate estimate: ${mockBulkGenerateServicePerformResponse}` })
     })
 
     test("when not authorized", async () => {

--- a/api/tests/factories/helpers.ts
+++ b/api/tests/factories/helpers.ts
@@ -3,8 +3,8 @@ import { faker } from "@faker-js/faker"
 export const POSTGRES_INT_4_MAX = 2147483647
 
 export function anytime() {
-  const hours = faker.number.int({ min: 0, max: 23 })
-  const minutes = faker.number.int({ min: 0, max: 59 })
+  const hours = faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')
+  const minutes = faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')
   const seconds = "00" // currently we aren't tracking time to the second
 
   return `${hours}:${minutes}:${seconds}`

--- a/api/tests/factories/helpers.ts
+++ b/api/tests/factories/helpers.ts
@@ -9,3 +9,7 @@ export function anytime() {
 
   return `${hours}:${minutes}:${seconds}`
 }
+
+export function presence<T>(value: T | undefined, defaultValue: T): T {
+  return value === undefined ? defaultValue : value
+}

--- a/api/tests/factories/index.ts
+++ b/api/tests/factories/index.ts
@@ -2,6 +2,7 @@ export * from "./helpers"
 
 // Factories
 export * from "./location-factory"
+export * from "./per-diem-factory"
 export * from "./stop-factory"
 export * from "./travel-authorization-factory"
 export * from "./travel-purpose-factory"

--- a/api/tests/factories/index.ts
+++ b/api/tests/factories/index.ts
@@ -5,6 +5,7 @@ export * from "./location-factory"
 export * from "./stop-factory"
 export * from "./travel-authorization-factory"
 export * from "./travel-purpose-factory"
+export * from "./travel-segment-factory"
 export * from "./user-factory"
 
 export default undefined

--- a/api/tests/factories/location-factory.ts
+++ b/api/tests/factories/location-factory.ts
@@ -3,11 +3,10 @@ import { faker } from "@faker-js/faker/locale/en_CA"
 
 import { Location } from "@/models"
 
-export const locationFactory = Factory.define<Location>(({ sequence, onCreate }) => {
+export const locationFactory = Factory.define<Location>(({ onCreate }) => {
   onCreate((location) => location.save())
 
   return Location.build({
-    id: sequence,
     province: faker.location.state(),
     city: faker.location.city(),
   })

--- a/api/tests/factories/per-diem-factory.ts
+++ b/api/tests/factories/per-diem-factory.ts
@@ -1,0 +1,17 @@
+import { Factory } from "fishery"
+import { faker } from "@faker-js/faker/locale/en_CA"
+
+import { PerDiem } from "@/models"
+
+export const perDiemFactory = Factory.define<PerDiem>(({ onCreate }) => {
+  onCreate((perDiem) => perDiem.save())
+
+  return PerDiem.build({
+    claim: faker.helpers.enumValue(PerDiem.ClaimTypes),
+    location: faker.helpers.enumValue(PerDiem.LocationTypes),
+    amount: parseFloat(faker.finance.amount({ min: 50, max: 200 })),
+    currency: faker.helpers.enumValue(PerDiem.CurrencyTypes),
+  })
+})
+
+export default perDiemFactory

--- a/api/tests/factories/stop-factory.ts
+++ b/api/tests/factories/stop-factory.ts
@@ -5,7 +5,7 @@ import { isNil } from "lodash"
 import { Stop } from "@/models"
 import { anytime, locationFactory, travelAuthorizationFactory } from "@/factories"
 
-export const stopFactory = Factory.define<Stop>(({ sequence, associations, onCreate }) => {
+export const stopFactory = Factory.define<Stop>(({ associations, onCreate }) => {
   onCreate(async (stop) => {
     if (isNil(stop.travelAuthorizationId)) {
       const travelAuthorization =
@@ -24,7 +24,6 @@ export const stopFactory = Factory.define<Stop>(({ sequence, associations, onCre
   })
 
   return Stop.build({
-    id: sequence,
     departureDate: faker.date.soon(),
     departureTime: anytime(),
     transport: faker.helpers.arrayElement(Object.values(Stop.TravelMethods)),

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -3,7 +3,7 @@ import { faker } from "@faker-js/faker"
 import { isNil } from "lodash"
 
 import { TravelAuthorization } from "@/models"
-import { travelPurposeFactory, POSTGRES_INT_4_MAX, userFactory } from "@/factories"
+import { travelPurposeFactory, POSTGRES_INT_4_MAX, userFactory, presence } from "@/factories"
 
 export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
   ({ associations, params, transientParams, onCreate }) => {
@@ -23,10 +23,8 @@ export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
       return travelAuthorization.save()
     })
 
-    let oneWayTrip =
-      "oneWayTrip" in params ? params.oneWayTrip : !params.multiStop && faker.datatype.boolean()
-    let multiStop =
-      "multiStop" in params ? params.multiStop : !oneWayTrip && faker.datatype.boolean()
+    let oneWayTrip = presence(params.oneWayTrip, !params.multiStop && faker.datatype.boolean())
+    let multiStop = presence(params.multiStop, !oneWayTrip && faker.datatype.boolean())
     if (transientParams.roundTrip === true) {
       if (params.oneWayTrip === true) {
         throw new Error("roundTrip transient param conflicts with oneWayTrip param")

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -20,12 +20,13 @@ export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
         travelAuthorization.userId = user.id
       }
 
-
       return travelAuthorization.save()
     })
 
-    let oneWayTrip = faker.datatype.boolean()
-    let multiStop = !oneWayTrip
+    let oneWayTrip =
+      "oneWayTrip" in params ? params.oneWayTrip : !params.multiStop && faker.datatype.boolean()
+    let multiStop =
+      "multiStop" in params ? params.multiStop : !oneWayTrip && faker.datatype.boolean()
     if (transientParams.roundTrip === true) {
       if (params.oneWayTrip === true) {
         throw new Error("roundTrip transient param conflicts with oneWayTrip param")

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -6,7 +6,7 @@ import { TravelAuthorization } from "@/models"
 import { travelPurposeFactory, POSTGRES_INT_4_MAX, userFactory } from "@/factories"
 
 export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
-  ({ sequence, associations, params, transientParams, onCreate }) => {
+  ({ associations, params, transientParams, onCreate }) => {
     onCreate(async (travelAuthorization) => {
       if (isNil(travelAuthorization.purposeId)) {
         const purpose = associations.purpose || travelPurposeFactory.build()
@@ -38,7 +38,6 @@ export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
     }
 
     return TravelAuthorization.build({
-      id: sequence,
       slug: faker.string.uuid(),
       preappId: faker.number.int({ min: 1, max: POSTGRES_INT_4_MAX }), // TODO: add factories once foreign key constraint exists
       firstName: faker.person.firstName(),

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -25,7 +25,7 @@ export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
     })
 
     let oneWayTrip = faker.datatype.boolean()
-    let multiStop = faker.datatype.boolean()
+    let multiStop = !oneWayTrip
     if (transientParams.roundTrip === true) {
       if (params.oneWayTrip === true) {
         throw new Error("roundTrip transient param conflicts with oneWayTrip param")

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -6,7 +6,7 @@ import { TravelAuthorization } from "@/models"
 import { travelPurposeFactory, POSTGRES_INT_4_MAX, userFactory } from "@/factories"
 
 export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
-  ({ sequence, associations, onCreate }) => {
+  ({ sequence, associations, params, transientParams, onCreate }) => {
     onCreate(async (travelAuthorization) => {
       if (isNil(travelAuthorization.purposeId)) {
         const purpose = associations.purpose || travelPurposeFactory.build()
@@ -23,6 +23,19 @@ export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
 
       return travelAuthorization.save()
     })
+
+    let oneWayTrip = faker.datatype.boolean()
+    let multiStop = faker.datatype.boolean()
+    if (transientParams.roundTrip === true) {
+      if (params.oneWayTrip === true) {
+        throw new Error("roundTrip transient param conflicts with oneWayTrip param")
+      } else if (params.multiStop === true) {
+        throw new Error("roundTrip transient param conflicts with multiStop param")
+      }
+
+      oneWayTrip = false
+      multiStop = false
+    }
 
     return TravelAuthorization.build({
       id: sequence,
@@ -47,8 +60,8 @@ export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
       supervisorEmail: `supervisor-${faker.internet.exampleEmail()}`, // TODO: add factories once foreign key constraint exists
       requestChange: faker.lorem.sentence(),
       denialReason: faker.lorem.sentence(),
-      oneWayTrip: faker.datatype.boolean(),
-      multiStop: faker.datatype.boolean(),
+      oneWayTrip,
+      multiStop,
       createdBy: faker.number.int({ min: 1, max: POSTGRES_INT_4_MAX }),
       travelAdvanceInCents: faker.number.int({ min: 0, max: 3000 * 100 }), // TODO: add factories once foreign key constraint exists
       allTravelWithinTerritory: faker.datatype.boolean(),

--- a/api/tests/factories/travel-purpose-factory.ts
+++ b/api/tests/factories/travel-purpose-factory.ts
@@ -7,7 +7,6 @@ export const travelPurposeFactory = Factory.define<TravelPurpose>(({ sequence, o
   onCreate((travelPurpose) => travelPurpose.save())
 
   return TravelPurpose.build({
-    id: sequence,
     purpose: `${faker.lorem.words(2)}-${sequence}`,
   })
 })

--- a/api/tests/factories/travel-segment-factory.ts
+++ b/api/tests/factories/travel-segment-factory.ts
@@ -5,7 +5,7 @@ import { TravelSegment } from "@/models"
 import { anytime, locationFactory, travelAuthorizationFactory } from "@/factories"
 
 export const travelSegmentFactory = Factory.define<TravelSegment>(
-  ({ sequence, associations, onCreate }) => {
+  ({ associations, onCreate }) => {
     onCreate(async (travelSegment) => {
       if (travelSegment.travelAuthorizationId === undefined) {
         const travelAuthorization =
@@ -33,7 +33,6 @@ export const travelSegmentFactory = Factory.define<TravelSegment>(
     const accommodationType = faker.helpers.enumValue(TravelSegment.AccommodationTypes)
 
     return TravelSegment.build({
-      id: sequence,
       segmentNumber: faker.number.int({ min: 0, max: 3 }),
       departureOn: faker.date.soon(),
       departureTime: anytime(),

--- a/api/tests/factories/travel-segment-factory.ts
+++ b/api/tests/factories/travel-segment-factory.ts
@@ -2,10 +2,10 @@ import { Factory } from "fishery"
 import { faker } from "@faker-js/faker"
 
 import { TravelSegment } from "@/models"
-import { anytime, locationFactory, travelAuthorizationFactory } from "@/factories"
+import { anytime, locationFactory, presence, travelAuthorizationFactory } from "@/factories"
 
 export const travelSegmentFactory = Factory.define<TravelSegment>(
-  ({ associations, onCreate }) => {
+  ({ associations, params, onCreate }) => {
     onCreate(async (travelSegment) => {
       if (travelSegment.travelAuthorizationId === undefined) {
         const travelAuthorization =
@@ -29,8 +29,14 @@ export const travelSegmentFactory = Factory.define<TravelSegment>(
       return travelSegment.save()
     })
 
-    const modeOfTransport = faker.helpers.enumValue(TravelSegment.TravelMethods)
-    const accommodationType = faker.helpers.enumValue(TravelSegment.AccommodationTypes)
+    const modeOfTransport = presence(
+      params.modeOfTransport,
+      faker.helpers.enumValue(TravelSegment.TravelMethods)
+    )
+    const accommodationType = presence(
+      params.accommodationType,
+      faker.helpers.enumValue(TravelSegment.AccommodationTypes)
+    )
 
     return TravelSegment.build({
       segmentNumber: faker.number.int({ min: 0, max: 3 }),

--- a/api/tests/factories/travel-segment-factory.ts
+++ b/api/tests/factories/travel-segment-factory.ts
@@ -1,0 +1,52 @@
+import { Factory } from "fishery"
+import { faker } from "@faker-js/faker"
+
+import { TravelSegment } from "@/models"
+import { anytime, locationFactory, travelAuthorizationFactory } from "@/factories"
+
+export const travelSegmentFactory = Factory.define<TravelSegment>(
+  ({ sequence, associations, onCreate }) => {
+    onCreate(async (travelSegment) => {
+      if (travelSegment.travelAuthorizationId === undefined) {
+        const travelAuthorization =
+          associations.travelAuthorization || travelAuthorizationFactory.build()
+        await travelAuthorization.save()
+        travelSegment.travelAuthorizationId = travelAuthorization.id
+      }
+
+      if (travelSegment.departureLocationId === undefined) {
+        const departureLocation = associations.departureLocation || locationFactory.build()
+        await departureLocation.save()
+        travelSegment.departureLocationId = departureLocation.id
+      }
+
+      if (travelSegment.arrivalLocationId === undefined) {
+        const arrivalLocation = associations.arrivalLocation || locationFactory.build()
+        await arrivalLocation.save()
+        travelSegment.arrivalLocationId = arrivalLocation.id
+      }
+
+      return travelSegment.save()
+    })
+
+    const modeOfTransport = faker.helpers.enumValue(TravelSegment.TravelMethods)
+    const accommodationType = faker.helpers.enumValue(TravelSegment.AccommodationTypes)
+
+    return TravelSegment.build({
+      id: sequence,
+      segmentNumber: faker.number.int({ min: 0, max: 3 }),
+      departureOn: faker.date.soon(),
+      departureTime: anytime(),
+      modeOfTransport,
+      modeOfTransportOther:
+        modeOfTransport === TravelSegment.TravelMethods.OTHER ? faker.hacker.ingverb() : null,
+      accommodationType,
+      accommodationTypeOther:
+        accommodationType === TravelSegment.AccommodationTypes.OTHER
+          ? faker.company.buzzAdjective()
+          : null,
+    })
+  }
+)
+
+export default travelSegmentFactory

--- a/api/tests/factories/user-factory.ts
+++ b/api/tests/factories/user-factory.ts
@@ -3,7 +3,7 @@ import { faker } from "@faker-js/faker/locale/en_CA"
 
 import { User } from "@/models"
 
-export const userFactory = Factory.define<User>(({ sequence, params, onCreate }) => {
+export const userFactory = Factory.define<User>(({ params, onCreate }) => {
   onCreate((user) => user.save())
 
   const generateMailCode = () => {
@@ -16,7 +16,6 @@ export const userFactory = Factory.define<User>(({ sequence, params, onCreate })
   const lastName = params.lastName || faker.person.lastName()
 
   return User.build({
-    id: sequence,
     sub: `auth0|${faker.string.uuid()}`,
     email: faker.internet.email({ firstName, lastName }),
     status: User.Statuses.ACTIVE,

--- a/api/tests/global-setup.ts
+++ b/api/tests/global-setup.ts
@@ -6,5 +6,6 @@ import "tsconfig-paths/register"
 import { importAndExecuteInitializers } from "@/initializers"
 
 export default async function globalSetup() {
+  // TODO: exclude seeding, or at least separate development and test seeding
   await importAndExecuteInitializers()
 }

--- a/api/tests/models/travel-authorization.test.ts
+++ b/api/tests/models/travel-authorization.test.ts
@@ -47,6 +47,7 @@ describe("api/src/models/travel-authorization.ts", () => {
       test("when has 2 stops, and is a one-way trip, builds the correct travel segment", async () => {
         const travelAuthorization = await travelAuthorizationFactory.create({
           oneWayTrip: true,
+          multiStop: false,
         })
         const stop1 = await stopFactory.create({
           travelAuthorizationId: travelAuthorization.id,

--- a/api/tests/models/travel-authorization.test.ts
+++ b/api/tests/models/travel-authorization.test.ts
@@ -1,0 +1,205 @@
+import { stopFactory, travelAuthorizationFactory } from "@/factories"
+import { TravelSegment } from "@/models"
+
+describe("api/src/models/travel-authorization.ts", () => {
+  describe("TravelAuthorization", () => {
+    describe("#buildTravelSegmentsFromStops", () => {
+      test("when has 2 stops, and is a round trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          { transient: { roundTrip: true } }
+        )
+        const stop1 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const stop2 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+
+        await travelAuthorization.reload({ include: ["stops"] })
+
+        expect(travelAuthorization.buildTravelSegmentsFromStops()).toEqual([
+          expect.objectContaining({
+            departureLocationId: stop1.locationId,
+            arrivalLocationId: stop2.locationId,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: stop2.locationId,
+            arrivalLocationId: stop1.locationId,
+            segmentNumber: 1,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop2.departureDate,
+            departureTime: stop2.departureTime,
+          }),
+        ])
+      })
+
+      test("when has 2 stops, and is a one-way trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          oneWayTrip: true,
+        })
+        const stop1 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+        const stop2 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: null,
+          accommodationType: null,
+        })
+
+        await travelAuthorization.reload({ include: ["stops"] })
+
+        expect(travelAuthorization.buildTravelSegmentsFromStops()).toEqual([
+          expect.objectContaining({
+            departureLocationId: stop1.locationId,
+            arrivalLocationId: stop2.locationId,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+        ])
+      })
+
+      test("when has 4 stops, and is a multi-stop trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          multiStop: true,
+          oneWayTrip: false,
+        })
+        const stop1 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const stop2 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const stop3 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+        const stop4 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: null,
+          accommodationType: null,
+        })
+
+        await travelAuthorization.reload({ include: ["stops"] })
+
+        expect(travelAuthorization.buildTravelSegmentsFromStops()).toEqual([
+          expect.objectContaining({
+            departureLocationId: stop1.locationId,
+            arrivalLocationId: stop2.locationId,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: stop2.locationId,
+            arrivalLocationId: stop3.locationId,
+            segmentNumber: 1,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop2.departureDate,
+            departureTime: stop2.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: stop3.locationId,
+            arrivalLocationId: stop4.locationId,
+            segmentNumber: 2,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop3.departureDate,
+            departureTime: stop3.departureTime,
+          }),
+        ])
+      })
+
+      test("when stops length is less than 2 for round trip type, errors informatively", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          {
+            transient: {
+              roundTrip: true,
+            },
+          }
+        )
+       await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+
+        await travelAuthorization.reload({ include: ["stops"] })
+
+        expect(() => travelAuthorization.buildTravelSegmentsFromStops()).toThrow(
+          "Must have at least 2 stops to build a travel segments"
+        )
+      })
+
+      test("when stops length is less than 2 for one-way trip type, errors informatively", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          oneWayTrip: true,
+          multiStop: false,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+
+        await travelAuthorization.reload({ include: ["stops"] })
+
+        expect(() => travelAuthorization.buildTravelSegmentsFromStops()).toThrow(
+          "Must have at least 2 stops to build a travel segments"
+        )
+      })
+
+      test("when stops length is less than 4, for multi-stop trip type, errors informatively", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          multiStop: true,
+          oneWayTrip: false,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+
+        await travelAuthorization.reload({ include: ["stops"] })
+
+        expect(() => travelAuthorization.buildTravelSegmentsFromStops()).toThrow(
+          "Must have at least 4 stops to build a multi-stop travel segments"
+        )
+      })
+    })
+  })
+})

--- a/api/tests/models/travel-segment.test.ts
+++ b/api/tests/models/travel-segment.test.ts
@@ -4,24 +4,6 @@ import { fa, faker } from "@faker-js/faker"
 
 describe("api/src/models/travel-segment.ts", () => {
   describe("TravelSegment", () => {
-    describe("#departureAt", () => {
-      test("when the departureOn is null, departureAt is null", () => {
-        const travelSegment = travelSegmentFactory.build({ departureOn: null })
-
-        expect(travelSegment.departureAt).toBeNull()
-      })
-
-      test("when the departure time is null, time defaults to the beginning of the day", () => {
-        const travelSegment = travelSegmentFactory.build({
-          departureOn: new Date("2021-01-01"),
-          departureTime: null,
-          segmentNumber: 0,
-        })
-
-        expect(travelSegment.departureAt).toEqual(new Date("2021-01-01T00:00:00"))
-      })
-    })
-
     describe(".buildFromStops", () => {
       test("when the params are valid, builds the correct travel segment", async () => {
         const travelAuthorization = await travelAuthorizationFactory.create()
@@ -153,6 +135,24 @@ describe("api/src/models/travel-segment.ts", () => {
             accommodationTypeOther: null,
           })
         )
+      })
+    })
+
+    describe("#departureAt", () => {
+      test("when the departureOn is null, departureAt is null", () => {
+        const travelSegment = travelSegmentFactory.build({ departureOn: null })
+
+        expect(travelSegment.departureAt).toBeNull()
+      })
+
+      test("when the departure time is null, time defaults to the beginning of the day", () => {
+        const travelSegment = travelSegmentFactory.build({
+          departureOn: new Date("2021-01-01"),
+          departureTime: null,
+          segmentNumber: 0,
+        })
+
+        expect(travelSegment.departureAt).toEqual(new Date("2021-01-01T00:00:00"))
       })
     })
   })

--- a/api/tests/models/travel-segment.test.ts
+++ b/api/tests/models/travel-segment.test.ts
@@ -1,4 +1,6 @@
-import { travelSegmentFactory } from "@/factories"
+import { stopFactory, travelAuthorizationFactory, travelSegmentFactory } from "@/factories"
+import { TravelSegment } from "@/models"
+import { fa, faker } from "@faker-js/faker"
 
 describe("api/src/models/travel-segment.ts", () => {
   describe("TravelSegment", () => {
@@ -13,10 +15,118 @@ describe("api/src/models/travel-segment.ts", () => {
         const travelSegment = travelSegmentFactory.build({
           departureOn: new Date("2021-01-01"),
           departureTime: null,
-          segmentNumber: 0
+          segmentNumber: 0,
         })
 
         expect(travelSegment.departureAt).toEqual(new Date("2021-01-01T00:00:00"))
+      })
+    })
+
+    describe(".buildFromStops", () => {
+      test("when the params are valid, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create()
+        const departureStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const arrivalStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+        })
+        const segmentNumber = faker.number.int({ min: 0, max: 10 })
+
+        const travelSegment = TravelSegment.buildFromStops({
+          travelAuthorizationId: travelAuthorization.id,
+          segmentNumber,
+          departureStop,
+          arrivalStop,
+        })
+
+        expect(travelSegment).toEqual(
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            departureLocationId: departureStop.locationId,
+            arrivalLocationId: arrivalStop.locationId,
+            segmentNumber,
+            departureOn: departureStop.departureDate,
+            departureTime: departureStop.departureTime,
+            modeOfTransport: departureStop.transport,
+            accommodationType: departureStop.accommodationType,
+          })
+        )
+      })
+
+      test("when the departure stop is missing a transport, throws an error", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create()
+        const departureStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: null,
+        })
+        const arrivalStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+        })
+        const segmentNumber = faker.number.int({ min: 0, max: 10 })
+
+        expect(() =>
+          TravelSegment.buildFromStops({
+            travelAuthorizationId: travelAuthorization.id,
+            segmentNumber,
+            departureStop,
+            arrivalStop,
+          })
+        ).toThrow(`Missing transport on Stop#${departureStop.id}`)
+      })
+
+      test("when the departure stop has a transport that is not non-standard, sets modeOfTransportOther", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create()
+        const departureStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: "Running",
+        })
+        const arrivalStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+        })
+        const segmentNumber = faker.number.int({ min: 0, max: 10 })
+
+        const travelSegment = TravelSegment.buildFromStops({
+          travelAuthorizationId: travelAuthorization.id,
+          segmentNumber,
+          departureStop,
+          arrivalStop,
+        })
+
+        expect(travelSegment).toEqual(
+          expect.objectContaining({
+            modeOfTransport: TravelSegment.TravelMethods.OTHER,
+            modeOfTransportOther: "Running",
+          })
+        )
+      })
+
+      test("when the departure stop has an accommodation type that is not non-standard, sets accommodationTypeOther", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create()
+        const departureStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          accommodationType: "Camping",
+        })
+        const arrivalStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+        })
+        const segmentNumber = faker.number.int({ min: 0, max: 10 })
+
+        const travelSegment = TravelSegment.buildFromStops({
+          travelAuthorizationId: travelAuthorization.id,
+          segmentNumber,
+          departureStop,
+          arrivalStop,
+        })
+
+        expect(travelSegment).toEqual(
+          expect.objectContaining({
+            accommodationType: TravelSegment.AccommodationTypes.OTHER,
+            accommodationTypeOther: "Camping",
+          })
+        )
       })
     })
   })

--- a/api/tests/models/travel-segment.test.ts
+++ b/api/tests/models/travel-segment.test.ts
@@ -149,11 +149,40 @@ describe("api/src/models/travel-segment.ts", () => {
         const travelSegment = travelSegmentFactory.build({
           departureOn: new Date("2021-01-01"),
           departureTime: null,
-          segmentNumber: 0,
         })
 
         expect(travelSegment.departureAt).toEqual(new Date("2021-01-01T00:00:00"))
       })
+    })
+  })
+
+  describe("#departureAtWithTimeFallback", () => {
+    test("when the departureOn is null, departureAt is null", () => {
+      const travelSegment = travelSegmentFactory.build({ departureOn: null })
+
+      expect(travelSegment.departureAtWithTimeFallback(TravelSegment.FallbackTimes.BEGINNING_OF_DAY)).toBeNull()
+    })
+
+    test("when the departure time is null, time falls back to the beginning of the day", () => {
+      const travelSegment = travelSegmentFactory.build({
+        departureOn: new Date("2021-01-01"),
+        departureTime: null,
+      })
+
+      expect(travelSegment.departureAtWithTimeFallback(TravelSegment.FallbackTimes.BEGINNING_OF_DAY)).toEqual(
+        new Date("2021-01-01T00:00:00")
+      )
+    })
+
+    test("when the departure time is null, time falls back to the end of the day", () => {
+      const travelSegment = travelSegmentFactory.build({
+        departureOn: new Date("2021-01-01"),
+        departureTime: null,
+      })
+
+      expect(travelSegment.departureAtWithTimeFallback(TravelSegment.FallbackTimes.END_OF_DAY)).toEqual(
+        new Date("2021-01-01T23:59:59")
+      )
     })
   })
 })

--- a/api/tests/models/travel-segment.test.ts
+++ b/api/tests/models/travel-segment.test.ts
@@ -128,6 +128,32 @@ describe("api/src/models/travel-segment.ts", () => {
           })
         )
       })
+
+      test("when accommodation type is null, sets accommodationType and accommodationTypeOther correctly", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create()
+        const departureStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          accommodationType: null,
+        })
+        const arrivalStop = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+        })
+        const segmentNumber = faker.number.int({ min: 0, max: 10 })
+
+        const travelSegment = TravelSegment.buildFromStops({
+          travelAuthorizationId: travelAuthorization.id,
+          segmentNumber,
+          departureStop,
+          arrivalStop,
+        })
+
+        expect(travelSegment).toEqual(
+          expect.objectContaining({
+            accommodationType: null,
+            accommodationTypeOther: null,
+          })
+        )
+      })
     })
   })
 })

--- a/api/tests/models/travel-segment.test.ts
+++ b/api/tests/models/travel-segment.test.ts
@@ -1,0 +1,23 @@
+import { travelSegmentFactory } from "@/factories"
+
+describe("api/src/models/travel-segment.ts", () => {
+  describe("TravelSegment", () => {
+    describe("#departureAt", () => {
+      test("when the departureOn is null, departureAt is null", () => {
+        const travelSegment = travelSegmentFactory.build({ departureOn: null })
+
+        expect(travelSegment.departureAt).toBeNull()
+      })
+
+      test("when the departure time is null, time defaults to the beginning of the day", () => {
+        const travelSegment = travelSegmentFactory.build({
+          departureOn: new Date("2021-01-01"),
+          departureTime: null,
+          segmentNumber: 0
+        })
+
+        expect(travelSegment.departureAt).toEqual(new Date("2021-01-01T00:00:00"))
+      })
+    })
+  })
+})

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -6,7 +6,8 @@ import {
   stopFactory,
   travelAuthorizationFactory,
 } from "@/factories"
-import { PerDiem, Stop } from "@/models"
+import { PerDiem, Stop, TravelSegment } from "@/models"
+import { TravelSegments } from "@/services"
 
 describe("api/src/services/estimates/bulk-generate-service.ts", () => {
   describe("BulkGenerateService", () => {
@@ -66,8 +67,10 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           },
           { associations: { travelAuthorization, location: vancouver } }
         )
+        // TODO: replace stops code above with travel segment code
+        const travelSegments: TravelSegment[] = []
 
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id).catch(
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id, travelSegments).catch(
           (error) => {
             console.error(error)
             throw error
@@ -169,8 +172,10 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           },
           { associations: { travelAuthorization, location: vancouver } }
         )
+        // TODO: replace stops code above with travel segment code
+        const travelSegments: TravelSegment[] = []
 
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id).catch(
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id, travelSegments).catch(
           (error) => {
             console.error(error)
             throw error

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -1,7 +1,12 @@
 import { BulkGenerateService } from "@/services/estimates"
 
-import { travelAuthorizationFactory, stopFactory, locationFactory } from "@/factories"
-import { Expense, Stop } from "@/models"
+import {
+  locationFactory,
+  perDiemFactory,
+  stopFactory,
+  travelAuthorizationFactory,
+} from "@/factories"
+import { Expense, PerDiem, Stop } from "@/models"
 
 describe("api/src/services/estimates/bulk-generate-service.ts", () => {
   describe("BulkGenerateService", () => {
@@ -36,6 +41,12 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           },
           { associations: { travelAuthorization, location: vancouver } }
         )
+        await perDiemFactory.create({
+          claim: PerDiem.ClaimTypes.MAXIMUM_DAILY,
+          location: PerDiem.LocationTypes.CANADA,
+          amount: 123.4,
+          currency: PerDiem.CurrencyTypes.CAD,
+        })
 
         expect(await Expense.count()).toBe(0)
         const expenses = await BulkGenerateService.perform(travelAuthorization.id)

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -5,9 +5,9 @@ import {
   perDiemFactory,
   stopFactory,
   travelAuthorizationFactory,
+  travelSegmentFactory,
 } from "@/factories"
 import { PerDiem, Stop, TravelSegment } from "@/models"
-import { TravelSegments } from "@/services"
 
 describe("api/src/services/estimates/bulk-generate-service.ts", () => {
   describe("BulkGenerateService", () => {
@@ -47,35 +47,42 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           }
         )
         const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
-        await stopFactory.create(
+        const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
+        const travelSegment1 = await travelSegmentFactory.create(
           {
-            departureDate: new Date("2022-06-05"),
+            departureOn: new Date("2022-06-05"),
             departureTime: Stop.BEGINNING_OF_DAY,
-            transport: Stop.TravelMethods.AIRCRAFT,
+            modeOfTransport: Stop.TravelMethods.AIRCRAFT,
             accommodationType: Stop.AccommodationTypes.HOTEL,
           },
-          { associations: { travelAuthorization, location: whitehorse } }
-        )
-        const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
-        await stopFactory.create(
           {
-            travelAuthorizationId: travelAuthorization.id,
-            departureDate: new Date("2022-06-07"),
-            departureTime: "12:00:00",
-            transport: Stop.TravelMethods.AIRCRAFT,
-            accommodationType: null,
-          },
-          { associations: { travelAuthorization, location: vancouver } }
-        )
-        // TODO: replace stops code above with travel segment code
-        const travelSegments: TravelSegment[] = []
-
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id, travelSegments).catch(
-          (error) => {
-            console.error(error)
-            throw error
+            associations: {
+              travelAuthorization,
+              departureLocation: whitehorse,
+              arrivalLocation: vancouver,
+            },
           }
         )
+        const travelSegment2 = await travelSegmentFactory.create(
+          {
+            departureOn: new Date("2022-06-07"),
+            departureTime: "12:00:00",
+            modeOfTransport: Stop.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+          },
+          {
+            associations: {
+              travelAuthorization,
+              departureLocation: vancouver,
+              arrivalLocation: whitehorse,
+            },
+          }
+        )
+
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id, [
+          travelSegment1,
+          travelSegment2,
+        ])
 
         expect(expenses).toEqual([
           expect.objectContaining({
@@ -152,35 +159,42 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           }
         )
         const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
-        await stopFactory.create(
+        const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
+        const travelSegment1 = await travelSegmentFactory.create(
           {
-            departureDate: new Date("2022-06-05"),
+            departureOn: new Date("2022-06-05"),
             departureTime: null,
-            transport: Stop.TravelMethods.AIRCRAFT,
+            modeOfTransport: Stop.TravelMethods.AIRCRAFT,
             accommodationType: Stop.AccommodationTypes.HOTEL,
           },
-          { associations: { travelAuthorization, location: whitehorse } }
-        )
-        const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
-        await stopFactory.create(
           {
-            travelAuthorizationId: travelAuthorization.id,
-            departureDate: new Date("2022-06-07"),
-            departureTime: null,
-            transport: Stop.TravelMethods.AIRCRAFT,
-            accommodationType: null,
-          },
-          { associations: { travelAuthorization, location: vancouver } }
-        )
-        // TODO: replace stops code above with travel segment code
-        const travelSegments: TravelSegment[] = []
-
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id, travelSegments).catch(
-          (error) => {
-            console.error(error)
-            throw error
+            associations: {
+              travelAuthorization,
+              departureLocation: whitehorse,
+              arrivalLocation: vancouver,
+            },
           }
         )
+        const travelSegment2 = await travelSegmentFactory.create(
+          {
+            departureOn: new Date("2022-06-07"),
+            departureTime: null,
+            modeOfTransport: Stop.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+          },
+          {
+            associations: {
+              travelAuthorization,
+              departureLocation: vancouver,
+              arrivalLocation: whitehorse,
+            },
+          }
+        )
+
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id, [
+          travelSegment1,
+          travelSegment2,
+        ])
 
         expect(expenses).toEqual([
           expect.objectContaining({

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -1,10 +1,10 @@
-import { BulkGenerate } from "@/services/estimates"
+import { BulkGenerateService } from "@/services/estimates"
 
 import { travelAuthorizationFactory, stopFactory, locationFactory } from "@/factories"
 import { Expense, Stop } from "@/models"
 
-describe("api/src/services/estimates/bulk-generate.ts", () => {
-  describe("BulkGenerate", () => {
+describe("api/src/services/estimates/bulk-generate-service.ts", () => {
+  describe("BulkGenerateService", () => {
     describe(".perform", () => {
       test("creates some new estimates against the travel authorization", async () => {
         const travelAuthorization = await travelAuthorizationFactory.create(
@@ -38,7 +38,7 @@ describe("api/src/services/estimates/bulk-generate.ts", () => {
         )
 
         expect(await Expense.count()).toBe(0)
-        const expenses = await BulkGenerate.perform(travelAuthorization.id)
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id)
         // TODO: fix bulk generation so it builds the correct number of estimates
         expect(await Expense.count()).toBe(7)
 

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -114,9 +114,9 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           }),
           expect.objectContaining({
             travelAuthorizationId: travelAuthorization.id,
-            description: "Breakfast/Lunch",
+            description: "Maximum Daily", // in future will be "Breakfast/Lunch" see https://github.com/icefoganalytics/travel-authorization/issues/121
             date: "2022-06-07",
-            cost: 46.7,
+            cost: 123.4, //  in future will be 46.7 see https://github.com/icefoganalytics/travel-authorization/issues/121
             currency: "CAD",
             type: "Estimate",
             expenseType: "Meals & Incidentals",

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -6,7 +6,7 @@ import {
   stopFactory,
   travelAuthorizationFactory,
 } from "@/factories"
-import { Expense, PerDiem, Stop } from "@/models"
+import { PerDiem, Stop } from "@/models"
 
 describe("api/src/services/estimates/bulk-generate-service.ts", () => {
   describe("BulkGenerateService", () => {
@@ -47,12 +47,25 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           amount: 123.4,
           currency: PerDiem.CurrencyTypes.CAD,
         })
+        await perDiemFactory.create({
+          claim: PerDiem.ClaimTypes.BREAKFAST,
+          location: PerDiem.LocationTypes.CANADA,
+          amount: 23.6,
+          currency: PerDiem.CurrencyTypes.CAD,
+        })
+        await perDiemFactory.create({
+          claim: PerDiem.ClaimTypes.LUNCH,
+          location: PerDiem.LocationTypes.CANADA,
+          amount: 23.9,
+          currency: PerDiem.CurrencyTypes.CAD,
+        })
 
-        expect(await Expense.count()).toBe(0)
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id)
-        // TODO: fix bulk generation so it builds the correct number of estimates
-        expect(await Expense.count()).toBe(7)
-
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id).catch(
+          (error) => {
+            console.error(error)
+            throw error
+          }
+        )
         expect(expenses).toEqual([
           expect.objectContaining({
             travelAuthorizationId: travelAuthorization.id,
@@ -101,21 +114,21 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           }),
           expect.objectContaining({
             travelAuthorizationId: travelAuthorization.id,
-            description: "Aircraft from Vancouver to Whitehorse",
-            date: "2022-06-07",
-            cost: 350.0,
-            currency: "CAD",
-            type: "Estimate",
-            expenseType: "Transportation",
-          }),
-          expect.objectContaining({
-            travelAuthorizationId: travelAuthorization.id,
             description: "Breakfast/Lunch",
             date: "2022-06-07",
             cost: 46.7,
             currency: "CAD",
             type: "Estimate",
             expenseType: "Meals & Incidentals",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Aircraft from Vancouver to Whitehorse",
+            date: "2022-06-07",
+            cost: 350.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Transportation",
           }),
         ])
       })

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -10,6 +10,33 @@ import { PerDiem, Stop } from "@/models"
 
 describe("api/src/services/estimates/bulk-generate-service.ts", () => {
   describe("BulkGenerateService", () => {
+    beforeEach(async () => {
+      await perDiemFactory.create({
+        claim: PerDiem.ClaimTypes.MAXIMUM_DAILY,
+        location: PerDiem.LocationTypes.CANADA,
+        amount: 123.4,
+        currency: PerDiem.CurrencyTypes.CAD,
+      })
+      await perDiemFactory.create({
+        claim: PerDiem.ClaimTypes.BREAKFAST,
+        location: PerDiem.LocationTypes.CANADA,
+        amount: 23.6,
+        currency: PerDiem.CurrencyTypes.CAD,
+      })
+      await perDiemFactory.create({
+        claim: PerDiem.ClaimTypes.LUNCH,
+        location: PerDiem.LocationTypes.CANADA,
+        amount: 23.9,
+        currency: PerDiem.CurrencyTypes.CAD,
+      })
+      await perDiemFactory.create({
+        claim: PerDiem.ClaimTypes.DINNER,
+        location: PerDiem.LocationTypes.CANADA,
+        amount: 58.6,
+        currency: PerDiem.CurrencyTypes.CAD,
+      })
+    })
+
     describe(".perform", () => {
       test("creates some new estimates against the travel authorization", async () => {
         const travelAuthorization = await travelAuthorizationFactory.create(
@@ -18,7 +45,6 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
             transient: { roundTrip: true },
           }
         )
-
         const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
         await stopFactory.create(
           {
@@ -29,7 +55,6 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           },
           { associations: { travelAuthorization, location: whitehorse } }
         )
-
         const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
         await stopFactory.create(
           {
@@ -41,24 +66,6 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           },
           { associations: { travelAuthorization, location: vancouver } }
         )
-        await perDiemFactory.create({
-          claim: PerDiem.ClaimTypes.MAXIMUM_DAILY,
-          location: PerDiem.LocationTypes.CANADA,
-          amount: 123.4,
-          currency: PerDiem.CurrencyTypes.CAD,
-        })
-        await perDiemFactory.create({
-          claim: PerDiem.ClaimTypes.BREAKFAST,
-          location: PerDiem.LocationTypes.CANADA,
-          amount: 23.6,
-          currency: PerDiem.CurrencyTypes.CAD,
-        })
-        await perDiemFactory.create({
-          claim: PerDiem.ClaimTypes.LUNCH,
-          location: PerDiem.LocationTypes.CANADA,
-          amount: 23.9,
-          currency: PerDiem.CurrencyTypes.CAD,
-        })
 
         const expenses = await BulkGenerateService.perform(travelAuthorization.id).catch(
           (error) => {
@@ -66,6 +73,110 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
             throw error
           }
         )
+
+        expect(expenses).toEqual([
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Aircraft from Whitehorse to Vancouver",
+            date: "2022-06-05",
+            cost: 350.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Transportation",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Hotel in Vancouver",
+            date: "2022-06-05",
+            cost: 250.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Accomodations",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Hotel in Vancouver",
+            date: "2022-06-06",
+            cost: 250.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Accomodations",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Maximum Daily",
+            date: "2022-06-05",
+            cost: 123.4,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Meals & Incidentals",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Maximum Daily",
+            date: "2022-06-06",
+            cost: 123.4,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Meals & Incidentals",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Maximum Daily", // in future will be "Breakfast/Lunch" see https://github.com/icefoganalytics/travel-authorization/issues/121
+            date: "2022-06-07",
+            cost: 123.4, //  in future will be 46.7 see https://github.com/icefoganalytics/travel-authorization/issues/121
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Meals & Incidentals",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Aircraft from Vancouver to Whitehorse",
+            date: "2022-06-07",
+            cost: 350.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Transportation",
+          }),
+        ])
+      })
+
+      test("when times are not specified, defaults to full day times", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          {
+            transient: { roundTrip: true },
+          }
+        )
+        const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
+        await stopFactory.create(
+          {
+            departureDate: new Date("2022-06-05"),
+            departureTime: null,
+            transport: Stop.TravelMethods.AIRCRAFT,
+            accommodationType: Stop.AccommodationTypes.HOTEL,
+          },
+          { associations: { travelAuthorization, location: whitehorse } }
+        )
+        const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
+        await stopFactory.create(
+          {
+            travelAuthorizationId: travelAuthorization.id,
+            departureDate: new Date("2022-06-07"),
+            departureTime: null,
+            transport: Stop.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+          },
+          { associations: { travelAuthorization, location: vancouver } }
+        )
+
+        const expenses = await BulkGenerateService.perform(travelAuthorization.id).catch(
+          (error) => {
+            console.error(error)
+            throw error
+          }
+        )
+
         expect(expenses).toEqual([
           expect.objectContaining({
             travelAuthorizationId: travelAuthorization.id,

--- a/api/tests/services/estimates/bulk-generate.test.ts
+++ b/api/tests/services/estimates/bulk-generate.test.ts
@@ -7,11 +7,12 @@ describe("api/src/services/estimates/bulk-generate.ts", () => {
   describe("BulkGenerate", () => {
     describe(".perform", () => {
       test("creates some new estimates against the travel authorization", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create({
-          // round trip
-          oneWayTrip: false,
-          multiStop: false,
-        })
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          {
+            transient: { roundTrip: true },
+          }
+        )
 
         const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
         await stopFactory.create(

--- a/api/tests/services/estimates/bulk-generate/calculate-number-of-days.test.ts
+++ b/api/tests/services/estimates/bulk-generate/calculate-number-of-days.test.ts
@@ -1,0 +1,18 @@
+import { BulkGenerate } from "@/services/estimates"
+
+describe("api/src/services/estimates/bulk-generate/calculate-number-of-days.ts", () => {
+  describe(".calculateNumberOfDays", () => {
+    test.each([
+      {
+        arrivalAt: new Date("2022-06-05 00:00:00"),
+        departureAt: new Date("2022-06-07 12:00:00"),
+        expected: 3,
+      },
+    ])(
+      "calculateNumberOfDays($arrivalAt, $departureAt)",
+      ({ arrivalAt, departureAt, expected }) => {
+        expect(BulkGenerate.calculateNumberOfDays(arrivalAt, departureAt)).toBe(expected)
+      }
+    )
+  })
+})

--- a/api/tests/services/estimates/bulk-generate/calculate-number-of-days.test.ts
+++ b/api/tests/services/estimates/bulk-generate/calculate-number-of-days.test.ts
@@ -1,4 +1,4 @@
-import { BulkGenerate } from "@/services/estimates"
+import { calculateNumberOfDays } from "@/services/estimates/bulk-generate"
 
 describe("api/src/services/estimates/bulk-generate/calculate-number-of-days.ts", () => {
   describe(".calculateNumberOfDays", () => {
@@ -16,8 +16,17 @@ describe("api/src/services/estimates/bulk-generate/calculate-number-of-days.ts",
     ])(
       "calculateNumberOfDays($arrivalAt, $departureAt)",
       ({ arrivalAt, departureAt, expected }) => {
-        expect(BulkGenerate.calculateNumberOfDays(arrivalAt, departureAt)).toBe(expected)
+        expect(calculateNumberOfDays(arrivalAt, departureAt)).toBe(expected)
       }
     )
+  })
+
+  test("when arrivalAt is after departureAt, errors informatively", () => {
+    expect(() => {
+      calculateNumberOfDays(
+        new Date("2022-06-07 12:00:00"),
+        new Date("2022-06-05 00:00:00")
+      )
+    }).toThrow("arrivalAt must be less than or equal to departureAt")
   })
 })

--- a/api/tests/services/estimates/bulk-generate/calculate-number-of-days.test.ts
+++ b/api/tests/services/estimates/bulk-generate/calculate-number-of-days.test.ts
@@ -8,6 +8,11 @@ describe("api/src/services/estimates/bulk-generate/calculate-number-of-days.ts",
         departureAt: new Date("2022-06-07 12:00:00"),
         expected: 3,
       },
+      {
+        arrivalAt: new Date("2022-06-05 23:00:00"),
+        departureAt: new Date("2022-06-07 07:00:00"),
+        expected: 3,
+      },
     ])(
       "calculateNumberOfDays($arrivalAt, $departureAt)",
       ({ arrivalAt, departureAt, expected }) => {

--- a/api/tests/services/estimates/bulk-generate/calculate-number-of-nights.test.ts
+++ b/api/tests/services/estimates/bulk-generate/calculate-number-of-nights.test.ts
@@ -8,6 +8,11 @@ describe("api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
         departureAt: new Date("2022-06-07 12:00:00"),
         expected: 2,
       },
+      {
+        arrivalAt: new Date("2022-06-05 23:00:00"),
+        departureAt: new Date("2022-06-07 07:00:00"),
+        expected: 2,
+      },
     ])(
       "calculateNumberOfNights($arrivalAt, $departureAt)",
       ({ arrivalAt, departureAt, expected }) => {

--- a/api/tests/services/estimates/bulk-generate/calculate-number-of-nights.test.ts
+++ b/api/tests/services/estimates/bulk-generate/calculate-number-of-nights.test.ts
@@ -1,4 +1,4 @@
-import { BulkGenerate } from "@/services/estimates"
+import { calculateNumberOfNights } from "@/services/estimates/bulk-generate"
 
 describe("api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts", () => {
   describe(".calculateNumberOfNights", () => {
@@ -16,8 +16,17 @@ describe("api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts
     ])(
       "calculateNumberOfNights($arrivalAt, $departureAt)",
       ({ arrivalAt, departureAt, expected }) => {
-        expect(BulkGenerate.calculateNumberOfNights(arrivalAt, departureAt)).toBe(expected)
+        expect(calculateNumberOfNights(arrivalAt, departureAt)).toBe(expected)
       }
     )
+  })
+
+  test("when arrivalAt is after departureAt, errors informatively", () => {
+    expect(() => {
+      calculateNumberOfNights(
+        new Date("2022-06-07 12:00:00"),
+        new Date("2022-06-05 00:00:00")
+      )
+    }).toThrow("arrivalAt must be less than or equal to departureAt")
   })
 })

--- a/api/tests/services/estimates/bulk-generate/calculate-number-of-nights.test.ts
+++ b/api/tests/services/estimates/bulk-generate/calculate-number-of-nights.test.ts
@@ -1,0 +1,18 @@
+import { BulkGenerate } from "@/services/estimates"
+
+describe("api/src/services/estimates/bulk-generate/calculate-number-of-nights.ts", () => {
+  describe(".calculateNumberOfNights", () => {
+    test.each([
+      {
+        arrivalAt: new Date("2022-06-05 00:00:00"),
+        departureAt: new Date("2022-06-07 12:00:00"),
+        expected: 2,
+      },
+    ])(
+      "calculateNumberOfNights($arrivalAt, $departureAt)",
+      ({ arrivalAt, departureAt, expected }) => {
+        expect(BulkGenerate.calculateNumberOfNights(arrivalAt, departureAt)).toBe(expected)
+      }
+    )
+  })
+})

--- a/api/tests/services/stops/bulk-convert-stops-to-travel-segments-service.test.ts
+++ b/api/tests/services/stops/bulk-convert-stops-to-travel-segments-service.test.ts
@@ -159,7 +159,7 @@ describe("api/src/services/stops/bulk-convert-stops-to-travel-segments-service.t
         })
 
         expect.assertions(1)
-        expect(
+        await expect(
           BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
         ).rejects.toThrow("Must have at least 2 stops to build a travel segments")
       })
@@ -176,7 +176,7 @@ describe("api/src/services/stops/bulk-convert-stops-to-travel-segments-service.t
         })
 
         expect.assertions(1)
-        expect(
+        await expect(
           BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
         ).rejects.toThrow("Must have at least 2 stops to build a travel segments")
       })
@@ -203,7 +203,7 @@ describe("api/src/services/stops/bulk-convert-stops-to-travel-segments-service.t
         })
 
         expect.assertions(1)
-        expect(
+        await expect(
           BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
         ).rejects.toThrow("Must have at least 4 stops to build a multi-stop travel segments")
       })

--- a/api/tests/services/stops/bulk-convert-stops-to-travel-segments-service.test.ts
+++ b/api/tests/services/stops/bulk-convert-stops-to-travel-segments-service.test.ts
@@ -1,0 +1,212 @@
+import { TravelSegment } from "@/models"
+import { stopFactory, travelAuthorizationFactory } from "@/factories"
+import { BulkConvertStopsToTravelSegmentsService } from "@/services/stops"
+
+describe("api/src/services/stops/bulk-convert-stops-to-travel-segments-service.ts", () => {
+  describe("BulkConvertStopsToTravelSegmentsService", () => {
+    describe(".perform", () => {
+      test("when has 2 stops, and is a round trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          { transient: { roundTrip: true } }
+        )
+        const stop1 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-11-29"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const stop2 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-11-30"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+
+        await BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
+
+        expect(travelAuthorization.travelSegments).toEqual([
+          expect.objectContaining({
+            departureLocationId: stop1.locationId,
+            arrivalLocationId: stop2.locationId,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: stop2.locationId,
+            arrivalLocationId: stop1.locationId,
+            segmentNumber: 1,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop2.departureDate,
+            departureTime: stop2.departureTime,
+          }),
+        ])
+      })
+
+      test("when has 2 stops, and is a one-way trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          oneWayTrip: true,
+          multiStop: false,
+        })
+        const stop1 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-11-29"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+        const stop2 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-11-30"),
+          transport: null,
+          accommodationType: null,
+        })
+
+        await BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
+
+        expect(travelAuthorization.travelSegments).toEqual([
+          expect.objectContaining({
+            departureLocationId: stop1.locationId,
+            arrivalLocationId: stop2.locationId,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+        ])
+      })
+
+      test("when has 4 stops, and is a multi-stop trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          multiStop: true,
+          oneWayTrip: false,
+        })
+        const stop1 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-11-29"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const stop2 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-11-30"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const stop3 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-12-01"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+        const stop4 = await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureDate: new Date("2023-12-02"),
+          transport: null,
+          accommodationType: null,
+        })
+
+        await BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
+
+        expect(travelAuthorization.travelSegments).toEqual([
+          expect.objectContaining({
+            departureLocationId: stop1.locationId,
+            arrivalLocationId: stop2.locationId,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: stop2.locationId,
+            arrivalLocationId: stop3.locationId,
+            segmentNumber: 1,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop2.departureDate,
+            departureTime: stop2.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: stop3.locationId,
+            arrivalLocationId: stop4.locationId,
+            segmentNumber: 2,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop3.departureDate,
+            departureTime: stop3.departureTime,
+          }),
+        ])
+      })
+
+      test("when stops length is less than 2 for round trip type, errors informatively", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          {
+            transient: {
+              roundTrip: true,
+            },
+          }
+        )
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+
+        expect.assertions(1)
+        expect(
+          BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
+        ).rejects.toThrow("Must have at least 2 stops to build a travel segments")
+      })
+
+      test("when stops length is less than 2 for one-way trip type, errors informatively", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          oneWayTrip: true,
+          multiStop: false,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+
+        expect.assertions(1)
+        expect(
+          BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
+        ).rejects.toThrow("Must have at least 2 stops to build a travel segments")
+      })
+
+      test("when stops length is less than 4, for multi-stop trip type, errors informatively", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          multiStop: true,
+          oneWayTrip: false,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        await stopFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+
+        expect.assertions(1)
+        expect(
+          BulkConvertStopsToTravelSegmentsService.perform(travelAuthorization)
+        ).rejects.toThrow("Must have at least 4 stops to build a multi-stop travel segments")
+      })
+    })
+  })
+})

--- a/api/tests/services/travel-authorizations/update-service.test.ts
+++ b/api/tests/services/travel-authorizations/update-service.test.ts
@@ -1,0 +1,60 @@
+import { TravelAuthorization, TravelSegment } from "@/models"
+import { UpdateService } from "@/services/travel-authorizations"
+import { locationFactory, stopFactory, travelAuthorizationFactory, userFactory } from "@/factories"
+
+describe("api/src/services/travel-authorizations/update-service.ts", () => {
+  describe("UpdateService", () => {
+    describe(".perform", () => {
+      test("when has 2 stops, and is a round trip, builds the correct travel segment", async () => {
+        const travelAuthorization = await travelAuthorizationFactory.create(
+          {},
+          { transient: { roundTrip: true } }
+        )
+        const location1 = await locationFactory.create()
+        const stop1 = stopFactory.build({
+          travelAuthorizationId: travelAuthorization.id,
+          locationId: location1.id,
+          departureDate: new Date("2023-11-29"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+        })
+        const location2 = await locationFactory.create()
+        const stop2 = stopFactory.build({
+          travelAuthorizationId: travelAuthorization.id,
+          locationId: location2.id,
+          departureDate: new Date("2023-11-30"),
+          transport: TravelSegment.TravelMethods.AIRCRAFT,
+          accommodationType: null,
+        })
+        const attributes = {
+          stops: [stop1.dataValues, stop2.dataValues],
+        } as Partial<TravelAuthorization>
+        const user = await userFactory.create()
+
+        await UpdateService.perform(travelAuthorization, attributes, user)
+
+        expect.assertions(1)
+        expect(await travelAuthorization.getTravelSegments()).toEqual([
+          expect.objectContaining({
+            departureLocationId: location1.id,
+            arrivalLocationId: location2.id,
+            segmentNumber: 0,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: TravelSegment.AccommodationTypes.HOTEL,
+            departureOn: stop1.departureDate,
+            departureTime: stop1.departureTime,
+          }),
+          expect.objectContaining({
+            departureLocationId: location2.id,
+            arrivalLocationId: location1.id,
+            segmentNumber: 1,
+            modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
+            accommodationType: null,
+            departureOn: stop2.departureDate,
+            departureTime: stop2.departureTime,
+          }),
+        ])
+      })
+    })
+  })
+})

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,8 +1,56 @@
+/*
+See https://jestjs.io/docs/configuration#setupfilesafterenv-array
+
+Run some code to configure or set up the testing framework before each test
+file in the suite is executed. Since setupFiles executes before the test framework is
+installed in the environment, this script file presents you the opportunity of running
+some code immediately after the test framework has been installed in the environment
+but before the test code itself.
+
+In other words, setupFilesAfterEnv modules are meant for code which is repeating in
+each test file. Having the test framework installed makes Jest globals,
+jest object and expect accessible in the modules. For example, you can add extra matchers
+from jest-extended library or call setup and teardown hooks.
+*/
+
+import { QueryTypes } from "sequelize"
+
 import db from "@/models"
 
-async function truncateAllTables() {
+async function getTableNames() {
+  const query = `
+    SELECT table_name as "tableName"
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+    AND table_type = 'BASE TABLE'
+    AND table_name != 'SequelizeMeta'
+    AND table_name != 'knex_migrations'
+    AND table_name != 'knex_migrations_lock';
+  `
+
   try {
-    await db.truncate({ cascade: true, restartIdentity: true })
+    const result = await db.query<{ tableName: string }>(query, { type: QueryTypes.SELECT })
+    const tableNames = result.map((row) => row.tableName)
+    return tableNames
+  } catch (error) {
+    console.error("Error fetching table names:", error)
+    throw error
+  }
+}
+
+async function cleanDatabase() {
+  const tableNames = await getTableNames()
+  const quotedTableNames = tableNames.map((name) => `"${name}"`)
+  const truncateQuery = `
+    TRUNCATE TABLE
+      ${quotedTableNames.join(",\n      ")}
+    RESTART IDENTITY
+    CASCADE;
+  `
+  try {
+    // TODO: once all tables are in Sequelize models, use this instead:
+    // await db.truncate({ cascade: true, restartIdentity: true })
+    await db.query(truncateQuery, { raw: true })
     return true
   } catch (error) {
     console.error(error)
@@ -10,7 +58,6 @@ async function truncateAllTables() {
   }
 }
 
-// Runs after all tests in a file are done
-afterAll(async () => {
-  await truncateAllTables()
+beforeEach(async () => {
+  await cleanDatabase()
 })

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,16 +1,8 @@
-// Runs after all tests in a file are done
 import db from "@/models"
 
 async function truncateAllTables() {
-  const modelNames = Object.keys(db.models).filter(
-    (modelName) => !["SequelizeMeta"].includes(modelName)
-  )
-  const models = modelNames.map((modelName) => db.models[modelName])
-
   try {
-    await Promise.all(
-      models.map((model) => model.destroy({ where: {}, force: true, logging: false }))
-    )
+    await db.truncate({ cascade: true, restartIdentity: true })
     return true
   } catch (error) {
     console.error(error)
@@ -18,6 +10,7 @@ async function truncateAllTables() {
   }
 }
 
+// Runs after all tests in a file are done
 afterAll(async () => {
   await truncateAllTables()
 })

--- a/web/src/api/stops-api.js
+++ b/web/src/api/stops-api.js
@@ -1,7 +1,7 @@
 import http from "@/api/http-client"
 
 // TODO: fetch accommodation types from backend,
-// until then, keep in sync with src/api/services/estimates/bulk-generate.ts
+// until then, keep in sync with api/src/models/travel-segment.ts
 export const ACCOMMODATION_TYPES = Object.freeze({
   HOTEL: "Hotel",
   PRIVATE: "Private",
@@ -9,6 +9,7 @@ export const ACCOMMODATION_TYPES = Object.freeze({
 })
 
 // TODO: load from back-end
+// until then, keep in sync with api/src/models/travel-segment.ts
 export const TRAVEL_METHODS = Object.freeze({
   AIRCRAFT: "Aircraft",
   POOL_VEHICLE: "Pool Vehicle",
@@ -18,6 +19,12 @@ export const TRAVEL_METHODS = Object.freeze({
   OTHER: "Other:",
 })
 
+/*
+DEPRECATED: Whenever you use this model, try and figure out how to migrate
+the functionality to the TravelSegment model instead.
+It was too large a project to migrate to the TravelSegment model all at once,
+so we're doing it piecemeal.
+*/
 export const stopsApi = {
   TRAVEL_METHODS,
   ACCOMMODATION_TYPES,


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/120

Relates to:

- https://github.com/icefoganalytics/travel-authorization/issues/122

# Context

**Is your feature request related to a problem? Please describe.**

In many cases travelers will not know their exact departure times. If they know it or put something in great. If not we need to assume they are travelling all day for the estimates.

**Describe the solution you'd like**

1. Make travel authorization -> stops departure times optional at the form level.
2. Make travel authorization -> stops departure times optional at the database level.
3. Make travel authorization -> stops departure times optional in the estimate generator.
    1. Assume all day travel if time is not supplied, i.e. maximize cost estimate per-diems

## Concerns

This way of building the form with travel time optional, seems like it would encourage people to avoid tracking their departure times. In the long run it would likely be better to simply make departure time tracking easy enough that requiring the user to enter it isn't a problem for them.

# Implementation

1. Add `TravelSegment` model and associated table to replace Stop model in the future.
2. Upgrade estimate generation so that it relies on travel segments instead of stops.
3. Fix a bunch of bugs in estimate generation.
4. Make travel authorization update create travel segments from stops. This means that you must run an update before trying to generate an estimate. The current UI is doing that, but any external API's need to be aware of this limitation.
5. Built a `BulkConvertStopsToTravelSegmentsService` in the "stops" namespace so that it's easy to remove the the code later. This service handles all the weirdness around converting stops to travel segments.
6. Stripped out all `id` generation from all factory `build` actions, this avoid creating id conflicts in the database.
7. Switch database cleanup to raw truncates of all tables.

# Screenshots

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/ea2ed657-f559-4226-bdbc-48ea470dc806)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the "My Travel Request" page via the top drop down nav.
5. Create a new travel request and fill in the form.
6. Check that you can generate estimates.
