### PR TITLE
Refactor: Switch Export Pattern for All Modules

### DIFF
--- a/api/src/controllers/README.md
+++ b/api/src/controllers/README.md
@@ -52,16 +52,12 @@ export { GenerateController } from "./generate-controller"
 
 ```typescript
 // api/src/controllers/forms/index.ts
-import * as Estimates from "./estimates"
-
-export { Estimates }
+export * as Estimates from "./estimates"
 ```
 
 ```typescript
 // api/src/controllers/index.ts
-import * as Forms from "./forms"
-
-export { Forms }
+export * as Forms from "./forms"
 ```
 
 ```typescript

--- a/api/src/controllers/README.md
+++ b/api/src/controllers/README.md
@@ -47,9 +47,7 @@ export class GenerateController extends BaseController {
 
 ```typescript
 // api/src/controllers/forms/estimates/index.ts
-export * from "./generate-controller"
-
-export default undefined
+export { GenerateController } from "./generate-controller"
 ```
 
 ```typescript

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -1,11 +1,11 @@
-export * from "./expenses-controller"
-export * from "./locations-controller"
-export * from "./pre-approved-travel-requests-controller"
-export * from "./pre-approved-travelers-controller"
-export * from "./stops-controller"
-export * from "./travel-authorizations-controller"
-export * from "./travel-purposes-controller"
-export * from "./users-controller"
+export { ExpensesController } from "./expenses-controller"
+export { LocationsController } from "./locations-controller"
+export { PreApprovedTravelRequestsController } from "./pre-approved-travel-requests-controller"
+export { PreApprovedTravelersController } from "./pre-approved-travelers-controller"
+export { StopsController } from "./stops-controller"
+export { TravelAuthorizationsController } from "./travel-authorizations-controller"
+export { TravelPurposesController } from "./travel-purposes-controller"
+export { UsersController } from "./users-controller"
 
 // Namespaced controllers
 import * as Qa from "./qa"
@@ -13,5 +13,3 @@ import * as TravelAuthorizations from "./travel-authorizations"
 import * as Users from "./users"
 
 export { Qa, TravelAuthorizations, Users }
-
-export default undefined

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -8,8 +8,6 @@ export { TravelPurposesController } from "./travel-purposes-controller"
 export { UsersController } from "./users-controller"
 
 // Namespaced controllers
-import * as Qa from "./qa"
-import * as TravelAuthorizations from "./travel-authorizations"
-import * as Users from "./users"
-
-export { Qa, TravelAuthorizations, Users }
+export * as Qa from "./qa"
+export * as TravelAuthorizations from "./travel-authorizations"
+export * as Users from "./users"

--- a/api/src/controllers/qa/index.ts
+++ b/api/src/controllers/qa/index.ts
@@ -1,7 +1,6 @@
-export * from "./scenarios-controller"
+export { ScenariosController } from "./scenarios-controller"
+export { ScenarioTypes } from "./scenario-types"
 
 import * as Scenarios from "./scenarios"
 
 export { Scenarios }
-
-export default undefined

--- a/api/src/controllers/qa/index.ts
+++ b/api/src/controllers/qa/index.ts
@@ -1,6 +1,4 @@
 export { ScenariosController } from "./scenarios-controller"
 export { ScenarioTypes } from "./scenario-types"
 
-import * as Scenarios from "./scenarios"
-
-export { Scenarios }
+export * as Scenarios from "./scenarios"

--- a/api/src/controllers/qa/scenario-types.ts
+++ b/api/src/controllers/qa/scenario-types.ts
@@ -1,0 +1,6 @@
+// This is really a model ... but it's so small I put it here
+export enum ScenarioTypes {
+  MY_TRAVEL_REQUESTS = "my-travel-requests",
+  BECOME_ADMIN_ROLE = "become-admin-role",
+  BECOME_USER_ROLE = "become-user-role",
+}

--- a/api/src/controllers/qa/scenarios-controller.ts
+++ b/api/src/controllers/qa/scenarios-controller.ts
@@ -1,11 +1,6 @@
 import BaseController from "@/controllers/base-controller"
 
-// This is really a model ... but it's so small I put it here
-export enum ScenarioTypes {
-  MY_TRAVEL_REQUESTS = "my-travel-requests",
-  BECOME_ADMIN_ROLE = "become-admin-role",
-  BECOME_USER_ROLE = "become-user-role",
-}
+import { ScenarioTypes } from "./scenario-types"
 
 export class ScenariosController extends BaseController {
   async index() {

--- a/api/src/controllers/qa/scenarios/index.ts
+++ b/api/src/controllers/qa/scenarios/index.ts
@@ -1,5 +1,3 @@
-export * from "./become-admin-role-controller"
-export * from "./become-user-role-controller"
-export * from "./my-travel-requests-controller"
-
-export default undefined
+export { BecomeAdminRoleController } from "./become-admin-role-controller"
+export { BecomeUserRoleController } from "./become-user-role-controller"
+export { MyTravelRequestsController } from "./my-travel-requests-controller"

--- a/api/src/controllers/travel-authorizations/estimates/index.ts
+++ b/api/src/controllers/travel-authorizations/estimates/index.ts
@@ -1,3 +1,1 @@
-export * from "./generate-controller"
-
-export default undefined
+export { GenerateController } from "./generate-controller"

--- a/api/src/controllers/travel-authorizations/index.ts
+++ b/api/src/controllers/travel-authorizations/index.ts
@@ -2,6 +2,4 @@ export { ApproveController } from "./approve-controller"
 export { DenyController } from "./deny-controller"
 
 // Namespaced controllers
-import * as Estimates from "./estimates"
-
-export { Estimates }
+export * as Estimates from "./estimates"

--- a/api/src/controllers/travel-authorizations/index.ts
+++ b/api/src/controllers/travel-authorizations/index.ts
@@ -1,9 +1,7 @@
-export * from "./approve-controller"
-export * from "./deny-controller"
+export { ApproveController } from "./approve-controller"
+export { DenyController } from "./deny-controller"
 
 // Namespaced controllers
 import * as Estimates from "./estimates"
 
 export { Estimates }
-
-export default undefined

--- a/api/src/controllers/users/index.ts
+++ b/api/src/controllers/users/index.ts
@@ -1,3 +1,1 @@
-export * from "./yg-government-directory-sync-controller"
-
-export default undefined
+export { YgGovernmentDirectorySyncController } from "./yg-government-directory-sync-controller"

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -17,8 +17,7 @@ import sequelize from "@/db/db-client"
 import TravelAuthorization from "./travel-authorization"
 
 // Keep in sync with web/src/modules/travel-authorizations/components/ExpenseTypeSelect.vue
-// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
-enum ExpenseTypes {
+export enum ExpenseTypes {
   ACCOMODATIONS = "Accomodations",
   TRANSPORTATION = "Transportation",
   MEALS_AND_INCIDENTALS = "Meals & Incidentals",
@@ -28,8 +27,7 @@ enum ExpenseTypes {
 // move estimates to there own table.
 // It's also possible that this is a single table inheritance model,
 // and there should be two models, one for each "type".
-// Avoid exporting here, and instead expose via the Expense model to avoid naming conflicts
-enum Types {
+export enum Types {
   ESTIMATE = "Estimate",
   EXPENSE = "Expense",
 }

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -20,21 +20,22 @@ TravelAuthorizationActionLog.establishAssociations()
 TravelSegment.establishAssociations()
 
 // Alphabetically - order does not matter
-export * from "./distance-matrix"
-export * from "./expense"
-export * from "./location"
-export * from "./per-diem"
-export * from "./preapproved-traveler"
-export * from "./preapproved"
-export * from "./stop"
-export * from "./travel-authorization-action-log"
-export * from "./travel-authorization"
-export * from "./travel-desk-passenger-name-record-document"
-export * from "./travel-desk-travel-agent"
-export * from "./travel-desk-travel-request"
-export * from "./travel-purpose"
-export * from "./travel-segment"
-export * from "./user"
+export { DistanceMatrix } from "./distance-matrix"
+export { Location } from "./location"
+export { PerDiem } from "./per-diem"
+export { Preapproved } from "./preapproved"
+export { PreapprovedTraveler } from "./preapproved-traveler"
+export { TravelPurpose } from "./travel-purpose"
+export {
+  Expense,
+  Stop,
+  TravelAuthorization,
+  TravelAuthorizationActionLog,
+  TravelDeskPassengerNameRecordDocument,
+  TravelDeskTravelRequest,
+  TravelSegment,
+  User,
+}
 
 // special db instance that has access to all models.
 export default db

--- a/api/src/models/travel-authorization-action-log.ts
+++ b/api/src/models/travel-authorization-action-log.ts
@@ -17,8 +17,7 @@ import sequelize from "@/db/db-client"
 import User from "./user"
 import TravelAuthorization from "./travel-authorization"
 
-// Avoid exporting here, and instead expose via the model to avoid naming conflicts
-enum Actions {
+export enum Actions {
   APPROVE = "approve",
   DENY = "deny",
   UPDATE = "update"

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -34,8 +34,7 @@ import User from "./user"
 
 // TODO: state management is going to be a bit deal for this project
 // we should do some aggressive data modeling an engineering before this becomes unmagable
-// Avoid exporting here, and instead expose via the model to avoid naming conflicts
-enum Statuses {
+export enum Statuses {
   // TODO: might want replace DELETED status with `deleted_at` field from Sequelize paranoid feature.
   // See https://sequelize.org/docs/v6/core-concepts/paranoid/
   DELETED = "deleted",

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -19,16 +19,15 @@ import Location from "./location"
 import Stop from "./stop"
 import TravelAuthorization from "./travel-authorization"
 
-enum FallbackTimes {
+export enum FallbackTimes {
   BEGINNING_OF_DAY = "00:00:00",
   END_OF_DAY = "23:59:59",
 }
 
 // Keep in sync with web/src/api/stops-api.js
 // Until both are using a shared location
-// Avoid exporting here, and instead expose via the model to avoid naming conflicts
 // TODO: normalize casing of these to snake_case, and add UI localization
-enum TravelMethods {
+export enum TravelMethods {
   AIRCRAFT = "Aircraft",
   POOL_VEHICLE = "Pool Vehicle",
   PERSONAL_VEHICLE = "Personal Vehicle",
@@ -39,9 +38,8 @@ enum TravelMethods {
 
 // Keep in sync with web/src/api/stops-api.js
 // Until both are using a shared location
-// Avoid exporting here, and instead expose via the model to avoid naming conflicts
 // TODO: normalize casing of these to snake_case, and add UI localization
-enum AccommodationTypes {
+export enum AccommodationTypes {
   HOTEL = "Hotel",
   PRIVATE = "Private",
   OTHER = "Other", // value stored in accommodationTypeOther

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -23,8 +23,7 @@ import moment from "moment"
 import sequelize from "@/db/db-client"
 import TravelAuthorization from "./travel-authorization"
 
-// Avoid exporting here, and instead expose via the User model to avoid naming conflicts
-enum Roles {
+export enum Roles {
   ADMIN = "admin",
   USER = "user",
   PAT_ADMIN = "pat_admin",
@@ -32,8 +31,7 @@ enum Roles {
   TD_USER = "td_user",
 }
 
-// Avoid exporting here, and instead expose via the User model to avoid naming conflicts
-enum Statuses {
+export enum Statuses {
   ACTIVE = "active",
   INACTIVE = "inactive",
 }

--- a/api/src/policies/index.ts
+++ b/api/src/policies/index.ts
@@ -3,6 +3,4 @@ export { TravelAuthorizationsPolicy } from "./travel-authorizations-policy"
 export { UsersPolicy } from "./users-policy"
 
 // Namespaced policies
-import * as TravelAuthorizations from "./travel-authorizations"
-
-export { TravelAuthorizations }
+export * as TravelAuthorizations from "./travel-authorizations"

--- a/api/src/policies/index.ts
+++ b/api/src/policies/index.ts
@@ -1,10 +1,8 @@
-export * from "./expenses-policy"
-export * from "./travel-authorizations-policy"
-export * from "./users-policy"
+export { ExpensesPolicy } from "./expenses-policy"
+export { TravelAuthorizationsPolicy } from "./travel-authorizations-policy"
+export { UsersPolicy } from "./users-policy"
 
 // Namespaced policies
 import * as TravelAuthorizations from "./travel-authorizations"
 
 export { TravelAuthorizations }
-
-export default undefined

--- a/api/src/policies/travel-authorizations/index.ts
+++ b/api/src/policies/travel-authorizations/index.ts
@@ -1,4 +1,2 @@
-export * from "./approve-policy"
-export * from "./deny-policy"
-
-export default undefined
+export { ApprovePolicy } from "./approve-policy"
+export { DenyPolicy } from "./deny-policy"

--- a/api/src/serializers/index.ts
+++ b/api/src/serializers/index.ts
@@ -1,6 +1,4 @@
-export * from './expenses-serializer'
-export * from './stops-serializer'
-export * from './travel-authorizations-serializer'
-export * from './users-serializer'
-
-export default undefined
+export { ExpensesSerializer } from "./expenses-serializer"
+export { StopsSerializer } from "./stops-serializer"
+export { TravelAuthorizationsSerializer } from "./travel-authorizations-serializer"
+export { UsersSerializer } from "./users-serializer"

--- a/api/src/services/README.md
+++ b/api/src/services/README.md
@@ -72,9 +72,7 @@ Imported in services as
 ```typescript
 // services/index.ts
 // Namespaced services
-import * as estimates from "./estimates"
-
-export { estimates }
+export * as estimates from "./estimates"
 ```
 
 The usages of this would be

--- a/api/src/services/estimates/bulk-generate-service.ts
+++ b/api/src/services/estimates/bulk-generate-service.ts
@@ -2,11 +2,9 @@ import { clone, isNil, max, min, times } from "lodash"
 import { CreationAttributes, Op } from "sequelize"
 
 import {
-  ClaimTypes,
   DistanceMatrix,
   Expense,
   Location,
-  LocationTypes,
   PerDiem,
   Stop,
   TravelSegment,
@@ -14,6 +12,7 @@ import {
 
 import BaseService from "@/services/base-service"
 import { BulkGenerate } from "@/services/estimates"
+import { ClaimTypes, LocationTypes } from "@/models/per-diem"
 
 const MAXIUM_AIRCRAFT_ALLOWANCE = 1000
 const AIRCRAFT_ALLOWANCE_PER_SEGMENT = 350

--- a/api/src/services/estimates/bulk-generate/index.ts
+++ b/api/src/services/estimates/bulk-generate/index.ts
@@ -1,4 +1,2 @@
-export * from "./calculate-number-of-days"
-export * from "./calculate-number-of-nights"
-
-export default undefined
+export { calculateNumberOfDays } from "./calculate-number-of-days"
+export { calculateNumberOfNights } from "./calculate-number-of-nights"

--- a/api/src/services/estimates/index.ts
+++ b/api/src/services/estimates/index.ts
@@ -1,8 +1,6 @@
-export * from "./bulk-generate-service"
+export { BulkGenerateService } from "./bulk-generate-service"
 
 // Namespaced exports
 import * as BulkGenerate from "./bulk-generate"
 
 export { BulkGenerate }
-
-export default undefined

--- a/api/src/services/estimates/index.ts
+++ b/api/src/services/estimates/index.ts
@@ -1,6 +1,4 @@
 export { BulkGenerateService } from "./bulk-generate-service"
 
 // Namespaced exports
-import * as BulkGenerate from "./bulk-generate"
-
-export { BulkGenerate }
+export * as BulkGenerate from "./bulk-generate"

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,9 +1,9 @@
-export * from "./audit-service"
-export * from "./distance-matrix-service"
-export * from "./expenses-service"
-export * from "./form-service"
-export * from "./stops-service"
-export * from "./yk-government-directory-sync-service"
+export { AuditService } from "./audit-service"
+export { DistanceMatrixService } from "./distance-matrix-service"
+export { ExpensesService } from "./expenses-service"
+export { FormService } from "./form-service"
+export { StopsService } from "./stops-service"
+export { YkGovernmentDirectorySyncService } from "./yk-government-directory-sync-service"
 
 // Namespaced services
 import * as Estimates from "./estimates"
@@ -30,5 +30,3 @@ export enum SortDirection {
   ASCENDING = "asc",
   DESCENDING = "desc",
 }
-
-export default undefined

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -6,13 +6,11 @@ export { StopsService } from "./stops-service"
 export { YkGovernmentDirectorySyncService } from "./yk-government-directory-sync-service"
 
 // Namespaced services
-import * as Estimates from "./estimates"
-import * as Qa from "./qa"
-import * as TravelAuthorizations from "./travel-authorizations"
-import * as TravelSegments from "./travel-segments"
-import * as Stops from "./stops"
-
-export { Estimates, Qa, TravelAuthorizations, TravelSegments, Stops }
+export * as Estimates from "./estimates"
+export * as Qa from "./qa"
+export * as TravelAuthorizations from "./travel-authorizations"
+export * as TravelSegments from "./travel-segments"
+export * as Stops from "./stops"
 
 // TODO: move these to their own files, or deprecate and remove them completely
 export interface QueryStatement {

--- a/api/src/services/qa/index.ts
+++ b/api/src/services/qa/index.ts
@@ -1,5 +1,3 @@
 import * as Scenarios from "./scenarios"
 
 export { Scenarios }
-
-export default undefined

--- a/api/src/services/qa/index.ts
+++ b/api/src/services/qa/index.ts
@@ -1,3 +1,1 @@
-import * as Scenarios from "./scenarios"
-
-export { Scenarios }
+export * as Scenarios from "./scenarios"

--- a/api/src/services/qa/scenarios/index.ts
+++ b/api/src/services/qa/scenarios/index.ts
@@ -1,3 +1,1 @@
-export * from "./my-travel-requests-service"
-
-export default undefined
+export { MyTravelRequestsService } from "./my-travel-requests-service"

--- a/api/src/services/stops/index.ts
+++ b/api/src/services/stops/index.ts
@@ -1,3 +1,1 @@
-export * from "./bulk-convert-stops-to-travel-segments-service"
-
-export default undefined
+export { BulkConvertStopsToTravelSegmentsService } from "./bulk-convert-stops-to-travel-segments-service"

--- a/api/src/services/travel-authorizations/index.ts
+++ b/api/src/services/travel-authorizations/index.ts
@@ -1,8 +1,6 @@
-export * from "./create-service"
-export * from "./update-service"
+export { CreateService } from "./create-service"
+export { UpdateService } from "./update-service"
 
 // State management services
-export * from "./approve-service"
-export * from "./deny-service"
-
-export default undefined
+export { ApproveService } from "./approve-service"
+export { DenyService } from "./deny-service"

--- a/api/src/services/travel-segments/index.ts
+++ b/api/src/services/travel-segments/index.ts
@@ -1,3 +1,1 @@
-export * from "./bulk-replace-service"
-
-export default undefined
+export { BulkReplaceService } from "./bulk-replace-service"

--- a/api/tests/factories/index.ts
+++ b/api/tests/factories/index.ts
@@ -1,12 +1,11 @@
-export * from "./helpers"
-
 // Factories
-export * from "./location-factory"
-export * from "./per-diem-factory"
-export * from "./stop-factory"
-export * from "./travel-authorization-factory"
-export * from "./travel-purpose-factory"
-export * from "./travel-segment-factory"
-export * from "./user-factory"
+export { locationFactory } from "./location-factory"
+export { perDiemFactory } from "./per-diem-factory"
+export { stopFactory } from "./stop-factory"
+export { travelAuthorizationFactory } from "./travel-authorization-factory"
+export { travelPurposeFactory } from "./travel-purpose-factory"
+export { travelSegmentFactory } from "./travel-segment-factory"
+export { userFactory } from "./user-factory"
 
-export default undefined
+// Namespaced Exports
+export * as Helpers from "./helpers"

--- a/api/tests/factories/stop-factory.ts
+++ b/api/tests/factories/stop-factory.ts
@@ -3,7 +3,8 @@ import { faker } from "@faker-js/faker"
 import { isNil } from "lodash"
 
 import { Stop } from "@/models"
-import { anytime, locationFactory, travelAuthorizationFactory } from "@/factories"
+import { locationFactory, travelAuthorizationFactory } from "@/factories"
+import { anytime } from "./helpers"
 
 export const stopFactory = Factory.define<Stop>(({ associations, onCreate }) => {
   onCreate(async (stop) => {

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -3,7 +3,8 @@ import { faker } from "@faker-js/faker"
 import { isNil } from "lodash"
 
 import { TravelAuthorization } from "@/models"
-import { travelPurposeFactory, POSTGRES_INT_4_MAX, userFactory, presence } from "@/factories"
+import { travelPurposeFactory, userFactory } from "@/factories"
+import { POSTGRES_INT_4_MAX, presence } from "./helpers"
 
 export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
   ({ associations, params, transientParams, onCreate }) => {

--- a/api/tests/factories/travel-segment-factory.ts
+++ b/api/tests/factories/travel-segment-factory.ts
@@ -2,7 +2,8 @@ import { Factory } from "fishery"
 import { faker } from "@faker-js/faker"
 
 import { TravelSegment } from "@/models"
-import { anytime, locationFactory, presence, travelAuthorizationFactory } from "@/factories"
+import { locationFactory, travelAuthorizationFactory } from "@/factories"
+import { anytime, presence } from "./helpers"
 
 export const travelSegmentFactory = Factory.define<TravelSegment>(
   ({ associations, params, onCreate }) => {


### PR DESCRIPTION
Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/125

# Context

I ran into some import/export conflicts, and issues around enums namespaced inside a classes. As a result I rebuilt all the exports I've been using in a newer simpler, and likely more traditional pattern.
> "Don't fight the framework/language/whatever"(tm)

# Implementation

Avoid export * for the same reason every other language does it; it introduces the inevitability of random namespace conflicts. I believe this new pattern is better, because, I no longer need to do the weird `export default undefined`, as I'm no longer exporting a bunch of conflicting default exports.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
