### PR TITLE
Implement Correcting Lines for Non-Travel Status Days on Estimate Tab

### DIFF
--- a/api/src/controllers/expenses-controller.ts
+++ b/api/src/controllers/expenses-controller.ts
@@ -13,7 +13,7 @@ export class ExpensesController extends BaseController {
     const where = this.query.where as WhereOptions<Expense>
     return Expense.findAll({
       where,
-      order: ["date"],
+      order: ["date", "expenseType"],
     }).then((expenses) => {
       const serializedExpenses = ExpensesSerializer.asTable(expenses)
       return this.response.json({ expenses: serializedExpenses })
@@ -84,7 +84,8 @@ export class ExpensesController extends BaseController {
     const attributes = this.request.body
     const { travelAuthorizationId } = attributes
     const expense = Expense.build(attributes)
-    expense.travelAuthorization = (await TravelAuthorization.findByPk(travelAuthorizationId)) || undefined
+    expense.travelAuthorization =
+      (await TravelAuthorization.findByPk(travelAuthorizationId)) || undefined
     return expense
   }
 

--- a/api/src/controllers/travel-authorizations/estimates/generate-controller.ts
+++ b/api/src/controllers/travel-authorizations/estimates/generate-controller.ts
@@ -22,7 +22,9 @@ export class GenerateController extends BaseController {
     }
 
     const travelSegments = travelAuthorization.travelSegments || []
-    return BulkGenerateService.perform(travelAuthorization.id, travelSegments)
+    return BulkGenerateService.perform(travelAuthorization.id, travelSegments, {
+      daysOffTravelStatus: travelAuthorization.daysOffTravelStatus || 0,
+    })
       .then((estimates) => {
         return this.response.status(201).json({
           estimates,

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -21,6 +21,7 @@ export enum ExpenseTypes {
   ACCOMODATIONS = "Accomodations",
   TRANSPORTATION = "Transportation",
   MEALS_AND_INCIDENTALS = "Meals & Incidentals",
+  NON_TRAVEL_STATUS = "Non-Travel Status",
 }
 
 // TODO: replace this with a boolean of isEstimate or

--- a/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
+++ b/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
@@ -44,6 +44,7 @@ export function buildNonTravelStatusDaysCorrectingLine({
     perDiemReductionDays += 1
   })
 
+  // CONSIDER: moving this to the front-end or a serializer?
   const formatter = new Intl.NumberFormat("en-CA", {
     style: "decimal",
     currency: "CAD",
@@ -51,9 +52,9 @@ export function buildNonTravelStatusDaysCorrectingLine({
     maximumFractionDigits: 2,
   })
   const perDiemReductionFormatted = formatter.format(perDiemReduction)
-  const perDiemReductionDetails = `${perDiemReductionDays} day @ non-travel status per diem = -${perDiemReductionFormatted}`
+  const perDiemReductionDetails = `${perDiemReductionDays} day @ non-travel status per diem -${perDiemReductionFormatted}`
   const accommodationReductionFormatted = formatter.format(accommodationReduction)
-  const accommodationReductionDetails = `${accommodationReductionDays} day @ non-travel status accomodation = -${accommodationReductionFormatted}`
+  const accommodationReductionDetails = `${accommodationReductionDays} day @ non-travel status accomodation -${accommodationReductionFormatted}`
 
   return {
     type: Expense.Types.ESTIMATE,

--- a/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
+++ b/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
@@ -1,9 +1,7 @@
 import { CreationAttributes } from "sequelize"
-import { sumBy } from "lodash"
+import { sortBy, reverse } from "lodash"
 
 import { Expense } from "@/models"
-
-const HOTEL_ALLOWANCE_PER_NIGHT = 250
 
 export function buildNonTravelStatusDaysCorrectingLine({
   estimates,
@@ -16,31 +14,53 @@ export function buildNonTravelStatusDaysCorrectingLine({
   travelAuthorizationId: number
   travelEndAt: Date
 }): CreationAttributes<Expense> {
-  const accommodationCostTotal = sumBy(estimates, (estimate) => {
-    if (estimate.expenseType === Expense.ExpenseTypes.ACCOMODATIONS) {
-      return estimate.cost
+  const estimatesByDateReversed = reverse(sortBy(estimates, "date"))
+
+  const accommodationEstimates = estimatesByDateReversed.filter(
+    (estimate) => estimate.expenseType === Expense.ExpenseTypes.ACCOMODATIONS
+  )
+  let accommodationReduction = 0
+  let accommodationReductionDays = 0
+  accommodationEstimates.forEach((estimate) => {
+    if (accommodationReductionDays >= daysOffTravelStatus) {
+      return
     }
-    return 0
-  })
-  const perDiemCostTotal = sumBy(estimates, (estimate) => {
-    if (estimate.expenseType === Expense.ExpenseTypes.MEALS_AND_INCIDENTALS) {
-      return estimate.cost
-    }
-    return 0
+
+    accommodationReduction += estimate.cost
+    accommodationReductionDays += 1
   })
 
-  const accommodationReduction = Math.min(
-    accommodationCostTotal,
-    daysOffTravelStatus * HOTEL_ALLOWANCE_PER_NIGHT
+  const perDiemEstimates = estimatesByDateReversed.filter(
+    (estimate) => estimate.expenseType === Expense.ExpenseTypes.MEALS_AND_INCIDENTALS
   )
-  const perDiemReduction = Math.min(perDiemCostTotal, daysOffTravelStatus * 777)
+  let perDiemReduction = 0
+  let perDiemReductionDays = 0
+  perDiemEstimates.forEach((estimate) => {
+    if (perDiemReductionDays >= daysOffTravelStatus) {
+      return
+    }
+
+    perDiemReduction += estimate.cost
+    perDiemReductionDays += 1
+  })
+
+  const formatter = new Intl.NumberFormat("en-CA", {
+    style: "decimal",
+    currency: "CAD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+  const perDiemReductionFormatted = formatter.format(perDiemReduction)
+  const perDiemReductionDetails = `${perDiemReductionDays} day @ non-travel status per diem = -${perDiemReductionFormatted}`
+  const accommodationReductionFormatted = formatter.format(accommodationReduction)
+  const accommodationReductionDetails = `${accommodationReductionDays} day @ non-travel status accomodation = -${accommodationReductionFormatted}`
 
   return {
     type: Expense.Types.ESTIMATE,
     expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
     travelAuthorizationId,
     currency: "CAD",
-    description: `${daysOffTravelStatus} day @ non-travel status per diem = -${perDiemCostTotal} and ${daysOffTravelStatus} day @ non-travel status accomodation = -${accommodationReduction}`,
+    description: [perDiemReductionDetails, accommodationReductionDetails].join(" and "),
     cost: -(accommodationReduction + perDiemReduction),
     date: travelEndAt,
   }

--- a/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
+++ b/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
@@ -1,0 +1,49 @@
+import { CreationAttributes } from "sequelize"
+import { sumBy } from "lodash"
+
+import { Expense } from "@/models"
+
+const HOTEL_ALLOWANCE_PER_NIGHT = 250
+
+export function buildNonTravelStatusDaysCorrectingLine({
+  estimates,
+  daysOffTravelStatus,
+  travelAuthorizationId,
+  travelEndAt,
+}: {
+  estimates: CreationAttributes<Expense>[]
+  daysOffTravelStatus: number
+  travelAuthorizationId: number
+  travelEndAt: Date
+}): CreationAttributes<Expense> {
+  const accommodationCostTotal = sumBy(estimates, (estimate) => {
+    if (estimate.expenseType === Expense.ExpenseTypes.ACCOMODATIONS) {
+      return estimate.cost
+    }
+    return 0
+  })
+  const perDiemCostTotal = sumBy(estimates, (estimate) => {
+    if (estimate.expenseType === Expense.ExpenseTypes.MEALS_AND_INCIDENTALS) {
+      return estimate.cost
+    }
+    return 0
+  })
+
+  const accommodationReduction = Math.min(
+    accommodationCostTotal,
+    daysOffTravelStatus * HOTEL_ALLOWANCE_PER_NIGHT
+  )
+  const perDiemReduction = Math.min(perDiemCostTotal, daysOffTravelStatus * 777)
+
+  return {
+    type: Expense.Types.ESTIMATE,
+    expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
+    travelAuthorizationId,
+    currency: "CAD",
+    description: `${daysOffTravelStatus} day @ non-travel status per diem = -${perDiemCostTotal} and ${daysOffTravelStatus} day @ non-travel status accomodation = -${accommodationReduction}`,
+    cost: -(accommodationReduction + perDiemReduction),
+    date: travelEndAt,
+  }
+}
+
+export default buildNonTravelStatusDaysCorrectingLine

--- a/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
+++ b/api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts
@@ -54,7 +54,7 @@ export function buildNonTravelStatusDaysCorrectingLine({
   const perDiemReductionFormatted = formatter.format(perDiemReduction)
   const perDiemReductionDetails = `${perDiemReductionDays} day @ non-travel status per diem -${perDiemReductionFormatted}`
   const accommodationReductionFormatted = formatter.format(accommodationReduction)
-  const accommodationReductionDetails = `${accommodationReductionDays} day @ non-travel status accomodation -${accommodationReductionFormatted}`
+  const accommodationReductionDetails = `${accommodationReductionDays} day @ non-travel status accommodation -${accommodationReductionFormatted}`
 
   return {
     type: Expense.Types.ESTIMATE,

--- a/api/src/services/estimates/bulk-generate/index.ts
+++ b/api/src/services/estimates/bulk-generate/index.ts
@@ -1,3 +1,4 @@
+export { buildNonTravelStatusDaysCorrectingLine } from "./build-non-travel-status-days-correcting-line"
 export { calculateNumberOfNights } from "./calculate-number-of-nights"
 export { determineClaimsPerDay } from "./determine-claims-per-day"
 export { determineLocationFromDate } from "./determine-location-from-date"

--- a/api/tests/controllers/travel-authorizations/estimates/generate-controller.test.ts
+++ b/api/tests/controllers/travel-authorizations/estimates/generate-controller.test.ts
@@ -35,12 +35,9 @@ describe("api/src/controllers/travel-authorizations/estimates/generate-controlle
 
   describe("POST /api/travel-authorizations/:travelAuthorizationId/estimates/generate", () => {
     test("when authorized and bulk generation is successful", async () => {
-      const travelAuthorization = await travelAuthorizationFactory.create(
-        {
-          status: TravelAuthorization.Statuses.DRAFT,
-        },
-        { associations: { user } }
-      )
+      const travelAuthorization = await travelAuthorizationFactory.associations({ user }).create({
+        status: TravelAuthorization.Statuses.DRAFT,
+      })
 
       const mockBulkGenerateServicePerformResponse = "mock bulk generate response"
       mockedBulkGenerateServicePerform.mockImplementation(() => {
@@ -50,16 +47,16 @@ describe("api/src/controllers/travel-authorizations/estimates/generate-controlle
       return request(app)
         .post(`/api/travel-authorizations/${travelAuthorization.id}/estimates/generate`)
         .expect("Content-Type", /json/)
-        .expect(201, { estimates: mockBulkGenerateServicePerformResponse, message: "Generated estimates" })
+        .expect(201, {
+          estimates: mockBulkGenerateServicePerformResponse,
+          message: "Generated estimates",
+        })
     })
 
     test("when authorized and bulk generation not is successful", async () => {
-      const travelAuthorization = await travelAuthorizationFactory.create(
-        {
-          status: TravelAuthorization.Statuses.DRAFT,
-        },
-        { associations: { user } }
-      )
+      const travelAuthorization = await travelAuthorizationFactory.associations({ user }).create({
+        status: TravelAuthorization.Statuses.DRAFT,
+      })
 
       const mockBulkGenerateServicePerformResponse = "mock bulk generate response"
       mockedBulkGenerateServicePerform.mockImplementation(() => {
@@ -69,16 +66,15 @@ describe("api/src/controllers/travel-authorizations/estimates/generate-controlle
       return request(app)
         .post(`/api/travel-authorizations/${travelAuthorization.id}/estimates/generate`)
         .expect("Content-Type", /json/)
-        .expect(422, { message: `Failed to generate estimate: ${mockBulkGenerateServicePerformResponse}` })
+        .expect(422, {
+          message: `Failed to generate estimate: ${mockBulkGenerateServicePerformResponse}`,
+        })
     })
 
     test("when not authorized", async () => {
-      const travelAuthorization = await travelAuthorizationFactory.create(
-        {
-          status: TravelAuthorization.Statuses.SUBMITTED,
-        },
-        { associations: { user } }
-      )
+      const travelAuthorization = await travelAuthorizationFactory.associations({ user }).create({
+        status: TravelAuthorization.Statuses.SUBMITTED,
+      })
 
       return request(app)
         .post(`/api/travel-authorizations/${travelAuthorization.id}/estimates/generate`)

--- a/api/tests/factories/expense-factory.ts
+++ b/api/tests/factories/expense-factory.ts
@@ -1,0 +1,58 @@
+import { DeepPartial, Factory } from "fishery"
+import { faker } from "@faker-js/faker"
+import { isNil } from "lodash"
+
+import { Expense, PerDiem, TravelSegment } from "@/models"
+import { travelAuthorizationFactory } from "@/factories"
+
+class ExpenseFactory extends Factory<Expense> {
+  estimate(params: Pick<DeepPartial<Expense>, "expenseType">) {
+    let description: string
+    const expenseType = params.expenseType || faker.helpers.enumValue(Expense.ExpenseTypes)
+    if (expenseType === Expense.ExpenseTypes.ACCOMODATIONS) {
+      const accommodationType = faker.helpers.enumValue(TravelSegment.AccommodationTypes)
+      const city = faker.location.city()
+      description = `${accommodationType} in ${city}`
+    } else if (expenseType === Expense.ExpenseTypes.MEALS_AND_INCIDENTALS) {
+      const claims = faker.helpers.arrayElements(Object.values(PerDiem.ClaimTypes))
+      description = claims.join("/")
+    } else if (expenseType === Expense.ExpenseTypes.TRANSPORTATION) {
+      const modeOfTransport = faker.helpers.enumValue(TravelSegment.TravelMethods)
+      const departureCity = faker.location.city()
+      const arrivalCity = faker.location.city()
+      description = `${modeOfTransport} from ${departureCity} to ${arrivalCity}`
+    } else {
+      description = faker.lorem.sentence({ min: 3, max: 6 })
+    }
+
+    return this.params({
+      type: Expense.Types.ESTIMATE,
+      description,
+      expenseType,
+    })
+  }
+}
+
+export const expenseFactory = ExpenseFactory.define(({ associations, onCreate }) => {
+  onCreate(async (expense) => {
+    if (isNil(expense.travelAuthorizationId)) {
+      const travelAuthorization =
+        associations.travelAuthorization || travelAuthorizationFactory.build()
+      await travelAuthorization.save()
+      expense.travelAuthorizationId = travelAuthorization.id
+    }
+
+    return expense.save()
+  })
+
+  return Expense.build({
+    type: faker.helpers.enumValue(Expense.Types),
+    currency: "CAD",
+    expenseType: faker.helpers.enumValue(Expense.ExpenseTypes),
+    description: faker.lorem.sentence({ min: 3, max: 6 }),
+    cost: parseFloat(faker.finance.amount({ min: 17.3, max: 500 })),
+    date: faker.date.soon({ days: 30 }),
+  })
+})
+
+export default expenseFactory

--- a/api/tests/factories/index.ts
+++ b/api/tests/factories/index.ts
@@ -1,4 +1,5 @@
 // Factories
+export { expenseFactory } from "./expense-factory"
 export { locationFactory } from "./location-factory"
 export { perDiemFactory } from "./per-diem-factory"
 export { stopFactory } from "./stop-factory"

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -6,7 +6,11 @@ import { TravelAuthorization } from "@/models"
 import { travelPurposeFactory, userFactory } from "@/factories"
 import { POSTGRES_INT_4_MAX, presence } from "./helpers"
 
-export const travelAuthorizationFactory = Factory.define<TravelAuthorization>(
+type TransientParam = {
+  roundTrip?: boolean
+}
+
+export const travelAuthorizationFactory = Factory.define<TravelAuthorization, TransientParam>(
   ({ associations, params, transientParams, onCreate }) => {
     onCreate(async (travelAuthorization) => {
       if (isNil(travelAuthorization.purposeId)) {

--- a/api/tests/models/travel-authorization.test.ts
+++ b/api/tests/models/travel-authorization.test.ts
@@ -5,10 +5,9 @@ describe("api/src/models/travel-authorization.ts", () => {
   describe("TravelAuthorization", () => {
     describe("#buildTravelSegmentsFromStops", () => {
       test("when has 2 stops, and is a round trip, builds the correct travel segment", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create(
-          {},
-          { transient: { roundTrip: true } }
-        )
+        const travelAuthorization = await travelAuthorizationFactory
+          .transient({ roundTrip: true })
+          .create()
         const stop1 = await stopFactory.create({
           travelAuthorizationId: travelAuthorization.id,
           transport: TravelSegment.TravelMethods.AIRCRAFT,
@@ -135,15 +134,10 @@ describe("api/src/models/travel-authorization.ts", () => {
       })
 
       test("when stops length is less than 2 for round trip type, errors informatively", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create(
-          {},
-          {
-            transient: {
-              roundTrip: true,
-            },
-          }
-        )
-       await stopFactory.create({
+        const travelAuthorization = await travelAuthorizationFactory
+          .transient({ roundTrip: true })
+          .create()
+        await stopFactory.create({
           travelAuthorizationId: travelAuthorization.id,
           transport: TravelSegment.TravelMethods.AIRCRAFT,
           accommodationType: TravelSegment.AccommodationTypes.HOTEL,

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -71,10 +71,11 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
             accommodationType: null,
           })
 
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id, [
-          travelSegment1,
-          travelSegment2,
-        ])
+        const expenses = await BulkGenerateService.perform(
+          travelAuthorization.id,
+          [travelSegment1, travelSegment2],
+          { daysOffTravelStatus: 0 }
+        )
 
         expect(expenses).toEqual([
           expect.objectContaining({
@@ -176,10 +177,13 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
             accommodationType: null,
           })
 
-        const expenses = await BulkGenerateService.perform(travelAuthorization.id, [
-          travelSegment1,
-          travelSegment2,
-        ])
+        const expenses = await BulkGenerateService.perform(
+          travelAuthorization.id,
+          [travelSegment1, travelSegment2],
+          {
+            daysOffTravelStatus: 0,
+          }
+        )
 
         expect(expenses).toEqual([
           expect.objectContaining({

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -39,46 +39,37 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
 
     describe(".perform", () => {
       test("creates some new estimates against the travel authorization", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create(
-          {},
-          {
-            transient: { roundTrip: true },
-          }
-        )
+        const travelAuthorization = await travelAuthorizationFactory
+          .transient({ roundTrip: true })
+          .create()
         const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
         const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
-        const travelSegment1 = await travelSegmentFactory.create(
-          {
+        const travelSegment1 = await travelSegmentFactory
+          .associations({
+            travelAuthorization,
+            departureLocation: whitehorse,
+            arrivalLocation: vancouver,
+          })
+          .create({
             segmentNumber: 1,
             departureOn: new Date("2022-06-05"),
             departureTime: Stop.BEGINNING_OF_DAY,
             modeOfTransport: Stop.TravelMethods.AIRCRAFT,
             accommodationType: Stop.AccommodationTypes.HOTEL,
-          },
-          {
-            associations: {
-              travelAuthorization,
-              departureLocation: whitehorse,
-              arrivalLocation: vancouver,
-            },
-          }
-        )
-        const travelSegment2 = await travelSegmentFactory.create(
-          {
+          })
+        const travelSegment2 = await travelSegmentFactory
+          .associations({
+            travelAuthorization,
+            departureLocation: vancouver,
+            arrivalLocation: whitehorse,
+          })
+          .create({
             segmentNumber: 2,
             departureOn: new Date("2022-06-07"),
             departureTime: "15:00:00",
             modeOfTransport: Stop.TravelMethods.AIRCRAFT,
             accommodationType: null,
-          },
-          {
-            associations: {
-              travelAuthorization,
-              departureLocation: vancouver,
-              arrivalLocation: whitehorse,
-            },
-          }
-        )
+          })
 
         const expenses = await BulkGenerateService.perform(travelAuthorization.id, [
           travelSegment1,
@@ -153,46 +144,37 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
       })
 
       test("when times are not specified, defaults to full day times", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create(
-          {},
-          {
-            transient: { roundTrip: true },
-          }
-        )
+        const travelAuthorization = await travelAuthorizationFactory
+          .transient({ roundTrip: true })
+          .create()
         const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
         const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
-        const travelSegment1 = await travelSegmentFactory.create(
-          {
+        const travelSegment1 = await travelSegmentFactory
+          .associations({
+            travelAuthorization,
+            departureLocation: whitehorse,
+            arrivalLocation: vancouver,
+          })
+          .create({
             segmentNumber: 1,
             departureOn: new Date("2022-06-05"),
             departureTime: null,
             modeOfTransport: Stop.TravelMethods.AIRCRAFT,
             accommodationType: Stop.AccommodationTypes.HOTEL,
-          },
-          {
-            associations: {
-              travelAuthorization,
-              departureLocation: whitehorse,
-              arrivalLocation: vancouver,
-            },
-          }
-        )
-        const travelSegment2 = await travelSegmentFactory.create(
-          {
+          })
+        const travelSegment2 = await travelSegmentFactory
+          .associations({
+            travelAuthorization,
+            departureLocation: vancouver,
+            arrivalLocation: whitehorse,
+          })
+          .create({
             segmentNumber: 2,
             departureOn: new Date("2022-06-07"),
             departureTime: null,
             modeOfTransport: Stop.TravelMethods.AIRCRAFT,
             accommodationType: null,
-          },
-          {
-            associations: {
-              travelAuthorization,
-              departureLocation: vancouver,
-              arrivalLocation: whitehorse,
-            },
-          }
-        )
+          })
 
         const expenses = await BulkGenerateService.perform(travelAuthorization.id, [
           travelSegment1,

--- a/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
+++ b/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
@@ -1,0 +1,53 @@
+import { faker } from "@faker-js/faker"
+
+import { expenseFactory } from "@/factories"
+import { Expense } from "@/models"
+
+import { buildNonTravelStatusDaysCorrectingLine } from "@/services/estimates/bulk-generate"
+
+describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts", () => {
+  describe("buildNonTravelStatusDaysCorrectingLine", () => {
+    test("when given some estimates and daysOffTravelStatus, it returns an array of correcting lines", () => {
+      // Arrange
+      const accommodation = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
+        .build()
+      const mealsAndIncidentals = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build()
+      const transportation = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
+        .build()
+      const estimates = [
+        accommodation.dataValues,
+        mealsAndIncidentals.dataValues,
+        transportation.dataValues,
+      ]
+      const daysOffTravelStatus = 1
+      const travelAuthorizationId = faker.number.int({ min: 1, max: 1000 })
+      const travelEndAt = faker.date.soon({ days: 30 })
+
+      // Act
+      const result = buildNonTravelStatusDaysCorrectingLine({
+        estimates,
+        daysOffTravelStatus,
+        travelAuthorizationId,
+        travelEndAt,
+      })
+
+      // Assert
+      // "2 days @ non-travel status per diem = -230" and "2 days @ non-travel status accomodation = -500"
+      expect(result).toEqual(
+        {
+          type: Expense.Types.ESTIMATE,
+          expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
+          travelAuthorizationId,
+          currency: "CAD",
+          cost: -(accommodation.cost + mealsAndIncidentals.cost),
+          description: `1 day @ non-travel status per diem = -${mealsAndIncidentals.cost} and 1 day @ non-travel status accomodation = -${accommodation.cost}`,
+          date: travelEndAt,
+        },
+      )
+    })
+  })
+})

--- a/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
+++ b/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
@@ -9,21 +9,37 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
   describe("buildNonTravelStatusDaysCorrectingLine", () => {
     test("when given some estimates and daysOffTravelStatus, it returns an array of correcting lines", () => {
       // Arrange
-      const accommodation = expenseFactory
+      const accommodation1 = expenseFactory
         .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
-        .build()
-      const mealsAndIncidentals = expenseFactory
-        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
-        .build()
-      const transportation = expenseFactory
+        .build({ cost: 250, date: new Date("2022-06-05") })
+      const accommodation2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
+        .build({ cost: 250, date: new Date("2022-06-06") })
+      const transportation1 = expenseFactory
         .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
-        .build()
+        .build({ cost: 350, date: new Date("2022-06-05") })
+      const transportation2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
+        .build({ cost: 350, date: new Date("2022-06-07") })
+      const mealsAndIncidentals1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 98.45, date: new Date("2022-06-05") })
+      const mealsAndIncidentals2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 115.75, date: new Date("2022-06-06") })
+      const mealsAndIncidentals3 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 61.35, date: new Date("2022-06-07") })
       const estimates = [
-        accommodation.dataValues,
-        mealsAndIncidentals.dataValues,
-        transportation.dataValues,
+        accommodation1.dataValues,
+        accommodation2.dataValues,
+        transportation1.dataValues,
+        transportation2.dataValues,
+        mealsAndIncidentals1.dataValues,
+        mealsAndIncidentals2.dataValues,
+        mealsAndIncidentals3.dataValues,
       ]
-      const daysOffTravelStatus = 1
+      const daysOffTravelStatus = 2
       const travelAuthorizationId = faker.number.int({ min: 1, max: 1000 })
       const travelEndAt = faker.date.soon({ days: 30 })
 
@@ -36,18 +52,15 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
       })
 
       // Assert
-      // "2 days @ non-travel status per diem = -230" and "2 days @ non-travel status accomodation = -500"
-      expect(result).toEqual(
-        {
-          type: Expense.Types.ESTIMATE,
-          expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
-          travelAuthorizationId,
-          currency: "CAD",
-          cost: -(accommodation.cost + mealsAndIncidentals.cost),
-          description: `1 day @ non-travel status per diem = -${mealsAndIncidentals.cost} and 1 day @ non-travel status accomodation = -${accommodation.cost}`,
-          date: travelEndAt,
-        },
-      )
+      expect(result).toEqual({
+        type: Expense.Types.ESTIMATE,
+        expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
+        travelAuthorizationId,
+        currency: "CAD",
+        cost: -677.1,
+        description: `2 day @ non-travel status per diem = -177.10 and 2 day @ non-travel status accomodation = -500.00`,
+        date: travelEndAt,
+      })
     })
   })
 })

--- a/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
+++ b/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
@@ -58,7 +58,7 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         travelAuthorizationId,
         currency: "CAD",
         cost: -677.1,
-        description: `2 day @ non-travel status per diem -177.10 and 2 day @ non-travel status accomodation -500.00`,
+        description: `2 day @ non-travel status per diem -177.10 and 2 day @ non-travel status accommodation -500.00`,
         date: travelEndAt,
       })
     })
@@ -114,7 +114,7 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         travelAuthorizationId,
         currency: "CAD",
         cost: -311.35,
-        description: `1 day @ non-travel status per diem -61.35 and 1 day @ non-travel status accomodation -250.00`,
+        description: `1 day @ non-travel status per diem -61.35 and 1 day @ non-travel status accommodation -250.00`,
         date: travelEndAt,
       })
     })
@@ -170,7 +170,7 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         travelAuthorizationId,
         currency: "CAD",
         cost: -775.55,
-        description: `3 day @ non-travel status per diem -275.55 and 2 day @ non-travel status accomodation -500.00`,
+        description: `3 day @ non-travel status per diem -275.55 and 2 day @ non-travel status accommodation -500.00`,
         date: travelEndAt,
       })
     })

--- a/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
+++ b/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
@@ -7,7 +7,7 @@ import { buildNonTravelStatusDaysCorrectingLine } from "@/services/estimates/bul
 
 describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.ts", () => {
   describe("buildNonTravelStatusDaysCorrectingLine", () => {
-    test("when given some estimates and daysOffTravelStatus, it returns an array of correcting lines", () => {
+    test("when given some estimates and 2 days off travel status, returns the expected correcting entry", () => {
       // Arrange
       const accommodation1 = expenseFactory
         .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
@@ -59,6 +59,118 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         currency: "CAD",
         cost: -677.1,
         description: `2 day @ non-travel status per diem = -177.10 and 2 day @ non-travel status accomodation = -500.00`,
+        date: travelEndAt,
+      })
+    })
+
+    test("when given some estimates and 1 day off travel status, assumes non travel status day is final day", () => {
+      // Arrange
+      const accommodation1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
+        .build({ cost: 250, date: new Date("2022-06-05") })
+      const accommodation2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
+        .build({ cost: 250, date: new Date("2022-06-06") })
+      const transportation1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
+        .build({ cost: 350, date: new Date("2022-06-05") })
+      const transportation2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
+        .build({ cost: 350, date: new Date("2022-06-07") })
+      const mealsAndIncidentals1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 98.45, date: new Date("2022-06-05") })
+      const mealsAndIncidentals2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 115.75, date: new Date("2022-06-06") })
+      const mealsAndIncidentals3 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 61.35, date: new Date("2022-06-07") })
+      const estimates = [
+        accommodation1.dataValues,
+        accommodation2.dataValues,
+        transportation1.dataValues,
+        transportation2.dataValues,
+        mealsAndIncidentals1.dataValues,
+        mealsAndIncidentals2.dataValues,
+        mealsAndIncidentals3.dataValues,
+      ]
+      const daysOffTravelStatus = 1
+      const travelAuthorizationId = faker.number.int({ min: 1, max: 1000 })
+      const travelEndAt = faker.date.soon({ days: 30 })
+
+      // Act
+      const result = buildNonTravelStatusDaysCorrectingLine({
+        estimates,
+        daysOffTravelStatus,
+        travelAuthorizationId,
+        travelEndAt,
+      })
+
+      // Assert
+      expect(result).toEqual({
+        type: Expense.Types.ESTIMATE,
+        expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
+        travelAuthorizationId,
+        currency: "CAD",
+        cost: -311.35,
+        description: `1 day @ non-travel status per diem = -61.35 and 1 day @ non-travel status accomodation = -250.00`,
+        date: travelEndAt,
+      })
+    })
+
+    test("when no travel status days are longer than trip, maxes out at number or relevant entries per expense type", () => {
+      // Arrange
+      const accommodation1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
+        .build({ cost: 250, date: new Date("2022-06-05") })
+      const accommodation2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.ACCOMODATIONS })
+        .build({ cost: 250, date: new Date("2022-06-06") })
+      const transportation1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
+        .build({ cost: 350, date: new Date("2022-06-05") })
+      const transportation2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.TRANSPORTATION })
+        .build({ cost: 350, date: new Date("2022-06-07") })
+      const mealsAndIncidentals1 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 98.45, date: new Date("2022-06-05") })
+      const mealsAndIncidentals2 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 115.75, date: new Date("2022-06-06") })
+      const mealsAndIncidentals3 = expenseFactory
+        .estimate({ expenseType: Expense.ExpenseTypes.MEALS_AND_INCIDENTALS })
+        .build({ cost: 61.35, date: new Date("2022-06-07") })
+      const estimates = [
+        accommodation1.dataValues,
+        accommodation2.dataValues,
+        transportation1.dataValues,
+        transportation2.dataValues,
+        mealsAndIncidentals1.dataValues,
+        mealsAndIncidentals2.dataValues,
+        mealsAndIncidentals3.dataValues,
+      ]
+      const daysOffTravelStatus = 3
+      const travelAuthorizationId = faker.number.int({ min: 1, max: 1000 })
+      const travelEndAt = faker.date.soon({ days: 30 })
+
+      // Act
+      const result = buildNonTravelStatusDaysCorrectingLine({
+        estimates,
+        daysOffTravelStatus,
+        travelAuthorizationId,
+        travelEndAt,
+      })
+
+      // Assert
+      expect(result).toEqual({
+        type: Expense.Types.ESTIMATE,
+        expenseType: Expense.ExpenseTypes.NON_TRAVEL_STATUS,
+        travelAuthorizationId,
+        currency: "CAD",
+        cost: -775.55,
+        description: `3 day @ non-travel status per diem = -275.55 and 2 day @ non-travel status accomodation = -500.00`,
         date: travelEndAt,
       })
     })

--- a/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
+++ b/api/tests/services/estimates/bulk-generate/build-non-travel-status-days-correcting-line.test.ts
@@ -58,7 +58,7 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         travelAuthorizationId,
         currency: "CAD",
         cost: -677.1,
-        description: `2 day @ non-travel status per diem = -177.10 and 2 day @ non-travel status accomodation = -500.00`,
+        description: `2 day @ non-travel status per diem -177.10 and 2 day @ non-travel status accomodation -500.00`,
         date: travelEndAt,
       })
     })
@@ -114,7 +114,7 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         travelAuthorizationId,
         currency: "CAD",
         cost: -311.35,
-        description: `1 day @ non-travel status per diem = -61.35 and 1 day @ non-travel status accomodation = -250.00`,
+        description: `1 day @ non-travel status per diem -61.35 and 1 day @ non-travel status accomodation -250.00`,
         date: travelEndAt,
       })
     })
@@ -170,7 +170,7 @@ describe("api/src/services/estimates/bulk-generate/build-non-travel-status-days-
         travelAuthorizationId,
         currency: "CAD",
         cost: -775.55,
-        description: `3 day @ non-travel status per diem = -275.55 and 2 day @ non-travel status accomodation = -500.00`,
+        description: `3 day @ non-travel status per diem -275.55 and 2 day @ non-travel status accomodation -500.00`,
         date: travelEndAt,
       })
     })

--- a/api/tests/services/estimates/bulk-generate/determine-location-from-date.test.ts
+++ b/api/tests/services/estimates/bulk-generate/determine-location-from-date.test.ts
@@ -6,51 +6,44 @@ import { determineLocationFromDate } from "@/services/estimates/bulk-generate/de
 describe("api/src/services/estimates/bulk-generate/determine-location-from-date.ts", () => {
   describe(".determineLocationFromDate", () => {
     test("example case of 3 day trip", async () => {
-      const travelAuthorization = await travelAuthorizationFactory.create(
-        {},
-        {
-          transient: { roundTrip: true },
-        }
-      )
+      const travelAuthorization = await travelAuthorizationFactory
+        .transient({ roundTrip: true })
+        .create()
       const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
       const vancouver = await locationFactory.create({ city: "Vancouver", province: "BC" })
-      const travelSegment1 = await travelSegmentFactory.create(
-        {
+      const travelSegment1 = await travelSegmentFactory
+        .associations({
+          travelAuthorization,
+          departureLocation: whitehorse,
+          arrivalLocation: vancouver,
+        })
+        .create({
           segmentNumber: 1,
           departureOn: new Date("2022-06-05"),
           departureTime: "00:00:00",
           modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
           accommodationType: TravelSegment.AccommodationTypes.HOTEL,
-        },
-        {
-          associations: {
-            travelAuthorization,
-            departureLocation: whitehorse,
-            arrivalLocation: vancouver,
-          },
-        }
-      )
-      const travelSegment2 = await travelSegmentFactory.create(
-        {
+        })
+      const travelSegment2 = await travelSegmentFactory
+        .associations({
+          travelAuthorization,
+          departureLocation: vancouver,
+          arrivalLocation: whitehorse,
+        })
+        .create({
           segmentNumber: 2,
           departureOn: new Date("2022-06-07"),
           departureTime: "15:00:00",
           modeOfTransport: TravelSegment.TravelMethods.AIRCRAFT,
           accommodationType: null,
-        },
-        {
-          associations: {
-            travelAuthorization,
-            departureLocation: vancouver,
-            arrivalLocation: whitehorse,
-          },
-        }
-      )
+        })
       const travelSegments = [travelSegment1, travelSegment2]
 
       expect(determineLocationFromDate(travelSegments, new Date("2022-06-05"))).toEqual(vancouver)
       expect(determineLocationFromDate(travelSegments, new Date("2022-06-06"))).toEqual(vancouver)
-      expect(determineLocationFromDate(travelSegments, new Date("2022-06-07 15:00:00"))).toEqual(vancouver)
+      expect(determineLocationFromDate(travelSegments, new Date("2022-06-07 15:00:00"))).toEqual(
+        vancouver
+      )
     })
   })
 })

--- a/api/tests/services/stops/bulk-convert-stops-to-travel-segments-service.test.ts
+++ b/api/tests/services/stops/bulk-convert-stops-to-travel-segments-service.test.ts
@@ -6,10 +6,9 @@ describe("api/src/services/stops/bulk-convert-stops-to-travel-segments-service.t
   describe("BulkConvertStopsToTravelSegmentsService", () => {
     describe(".perform", () => {
       test("when has 2 stops, and is a round trip, builds the correct travel segment", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create(
-          {},
-          { transient: { roundTrip: true } }
-        )
+        const travelAuthorization = await travelAuthorizationFactory
+          .transient({ roundTrip: true })
+          .create()
         const stop1 = await stopFactory.create({
           travelAuthorizationId: travelAuthorization.id,
           departureDate: new Date("2023-11-29"),

--- a/api/tests/services/travel-authorizations/update-service.test.ts
+++ b/api/tests/services/travel-authorizations/update-service.test.ts
@@ -6,10 +6,9 @@ describe("api/src/services/travel-authorizations/update-service.ts", () => {
   describe("UpdateService", () => {
     describe(".perform", () => {
       test("when has 2 stops, and is a round trip, builds the correct travel segment", async () => {
-        const travelAuthorization = await travelAuthorizationFactory.create(
-          {},
-          { transient: { roundTrip: true } }
-        )
+        const travelAuthorization = await travelAuthorizationFactory
+          .transient({ roundTrip: true })
+          .create()
         const location1 = await locationFactory.create()
         const stop1 = stopFactory.build({
           travelAuthorizationId: travelAuthorization.id,


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/119

Relates to:
- https://github.com/icefoganalytics/travel-authorization/issues/68

# Context

When a user files a travel authorization request, they have the ability to enter "non-travel status days" in the form. This feature needs to affect the estimate generation system. 

Where the user enters non-travel status days of "4: on the estimate tab, we need to add a couple rows - I'm not sure how many - that are correcting lines. The will subtracts the cost of 4 days of accommodations and 4 days worth of per-diems. 

In the travel authorization form we don't track which days are non-travel status days, so we can't remove the exact days.

# Implementation

1. Implement correcting entry for non-travel status days.
2. Switch to using cleaner interface for transient/association factory params.

# Screenshots

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/fd7cee41-ca94-485b-a655-ca42525be4fe)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
3. Boot the app via `dev up`
4. Log in to the app at http://localhost:8080
5. Go to the "My Travel Requests" page via the top drop down nav.
6. Create a new "Travel Authorization" via the top right button.
7. Go to the "Details" section.
8. Make a trip from Whitehorse to Vancouver on the 5th of the current month.
9. Don't set a time for the departure date from Whitehorse.
10. Leave the travel method and accommodation type as their defaults of Aircraft + Hotel.
11. Make the return date the 7th of the month at 15:00 (3pm).
12. Set the "Days on non-travel status" to 4. Even though this is a 3 day trip.
13. Go to the "Approvals" Section.
14. Generate the estimate via the call-to-action button.
15. Click the "Edit Estimate" button to view the generated estimates.
16. Check that the estimates calculations for per-diems match expected values calculated in BC (Rest of Canada).
    1. Check that the "Non-Travel Status" entry looks like amount  `-$775.55`
        > 3 day @ non-travel status per diem -275.55 and 2 day @ non-travel status accommodation -500.00
    2. Note that the max non-travel status entries are the max number of related entries that exist. 3 for means, 2 for accommodations
   
