### PR TITLE
Add Ability To Delete Travel Authorization in Draft State

### DIFF
--- a/api/src/models/travel-authorization-action-log.ts
+++ b/api/src/models/travel-authorization-action-log.ts
@@ -20,7 +20,8 @@ import TravelAuthorization from "./travel-authorization"
 export enum Actions {
   APPROVE = "approve",
   DENY = "deny",
-  UPDATE = "update"
+  UPDATE = "update",
+  DELETE = "delete",
 }
 
 export class TravelAuthorizationActionLog extends Model<

--- a/api/src/models/travel-authorization-action-log.ts
+++ b/api/src/models/travel-authorization-action-log.ts
@@ -21,7 +21,6 @@ export enum Actions {
   APPROVE = "approve",
   DENY = "deny",
   UPDATE = "update",
-  DELETE = "delete",
 }
 
 export class TravelAuthorizationActionLog extends Model<

--- a/api/src/policies/travel-authorizations-policy.ts
+++ b/api/src/policies/travel-authorizations-policy.ts
@@ -32,6 +32,21 @@ export class TravelAuthorizationsPolicy extends BasePolicy<TravelAuthorization> 
     return false
   }
 
+  // Currently the same as the update policy, but this is likely to change in the future
+  // so opted for duplication over premature abstraction.
+  destroy(): boolean {
+    if (this.user.roles.includes(User.Roles.ADMIN)) return true
+    if (this.record.supervisorEmail === this.user.email) return true
+    if (
+      this.record.userId === this.user.id &&
+      this.record.status === TravelAuthorization.Statuses.DRAFT
+    ) {
+      return true
+    }
+
+    return false
+  }
+
   static applyScope(
     modelClass: ModelStatic<TravelAuthorization>,
     currentUser: User

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -47,6 +47,10 @@ router.patch(
   "/api/travel-authorizations/:travelAuthorizationId",
   TravelAuthorizationsController.update
 )
+router.delete(
+  "/api/travel-authorizations/:travelAuthorizationId",
+  TravelAuthorizationsController.destroy
+)
 router.post(
   "/api/travel-authorizations/:travelAuthorizationId/estimates/generate",
   TravelAuthorizations.Estimates.GenerateController.create

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -35,6 +35,7 @@ router.use("/api", checkJwt)
 router.use("/api", loadUser)
 
 // TODO: move all routing logic to this file, and move all route actions into controllers
+// TODO: convert all routes to use the router.route(/path).action(...).action(...) syntax
 router.get("/api/expenses", ExpensesController.index)
 router.post("/api/expenses", ExpensesController.create)
 router.patch("/api/expenses/:expenseId", ExpensesController.update)

--- a/api/src/serializers/travel-authorizations-serializer.ts
+++ b/api/src/serializers/travel-authorizations-serializer.ts
@@ -93,7 +93,9 @@ export class TravelAuthorizationsSerializer extends BaseSerializer<TravelAuthori
 
   // TODO: double check the order of these conditions
   determineAction() {
-    if (this.isApproved() && this.anyTransportTypeIsAircraft()) {
+    if (this.isDraft()) {
+      return ["delete"]
+    } else if (this.isApproved() && this.anyTransportTypeIsAircraft()) {
       return ["submit_travel_desk_request"]
     } else if (this.travellingComplete()) {
       return ["submit_expense_claim"]

--- a/api/src/services/travel-authorizations/destroy-service.ts
+++ b/api/src/services/travel-authorizations/destroy-service.ts
@@ -1,0 +1,33 @@
+import db from "@/db/db-client"
+import BaseService from "@/services/base-service"
+
+import { TravelAuthorization, TravelAuthorizationActionLog, User } from "@/models"
+
+export class DestroyService extends BaseService {
+  private travelAuthorization: TravelAuthorization
+  private currentUser: User
+
+  constructor(travelAuthorization: TravelAuthorization, currentUser: User) {
+    super()
+    this.travelAuthorization = travelAuthorization
+    this.currentUser = currentUser
+  }
+
+  async perform(): Promise<void> {
+    return db.transaction(async () => {
+      await this.travelAuthorization.destroy().catch((error) => {
+        throw new Error(`Could not delete TravelAuthorization: ${error}`)
+      })
+
+      await TravelAuthorizationActionLog.create({
+        travelAuthorizationId: this.travelAuthorization.id,
+        userId: this.currentUser.id,
+        action: TravelAuthorizationActionLog.Actions.DELETE,
+      })
+
+      return
+    })
+  }
+}
+
+export default DestroyService

--- a/api/src/services/travel-authorizations/destroy-service.ts
+++ b/api/src/services/travel-authorizations/destroy-service.ts
@@ -1,7 +1,7 @@
 import db from "@/db/db-client"
 import BaseService from "@/services/base-service"
 
-import { TravelAuthorization, TravelAuthorizationActionLog, User } from "@/models"
+import { TravelAuthorization, User } from "@/models"
 
 export class DestroyService extends BaseService {
   private travelAuthorization: TravelAuthorization
@@ -14,20 +14,11 @@ export class DestroyService extends BaseService {
   }
 
   async perform(): Promise<void> {
-    return db.transaction(async () => {
-      const travelAuthorizationId = this.travelAuthorization.id
-      await this.travelAuthorization.destroy().catch((error) => {
-        throw new Error(`Could not delete TravelAuthorization: ${error}`)
-      })
-
-      await TravelAuthorizationActionLog.create({
-        travelAuthorizationId,
-        userId: this.currentUser.id,
-        action: TravelAuthorizationActionLog.Actions.DELETE,
-      })
-
-      return
+    await this.travelAuthorization.destroy().catch((error) => {
+      throw new Error(`Could not delete TravelAuthorization: ${error}`)
     })
+
+    return
   }
 }
 

--- a/api/src/services/travel-authorizations/destroy-service.ts
+++ b/api/src/services/travel-authorizations/destroy-service.ts
@@ -15,12 +15,13 @@ export class DestroyService extends BaseService {
 
   async perform(): Promise<void> {
     return db.transaction(async () => {
+      const travelAuthorizationId = this.travelAuthorization.id
       await this.travelAuthorization.destroy().catch((error) => {
         throw new Error(`Could not delete TravelAuthorization: ${error}`)
       })
 
       await TravelAuthorizationActionLog.create({
-        travelAuthorizationId: this.travelAuthorization.id,
+        travelAuthorizationId,
         userId: this.currentUser.id,
         action: TravelAuthorizationActionLog.Actions.DELETE,
       })

--- a/api/src/services/travel-authorizations/index.ts
+++ b/api/src/services/travel-authorizations/index.ts
@@ -1,5 +1,6 @@
 export { CreateService } from "./create-service"
 export { UpdateService } from "./update-service"
+export { DestroyService } from "./destroy-service"
 
 // State management services
 export { ApproveService } from "./approve-service"

--- a/web/src/api/travel-authorizations-api.js
+++ b/web/src/api/travel-authorizations-api.js
@@ -33,6 +33,11 @@ export const travelAuthorizationsApi = {
       .patch(`/api/travel-authorizations/${travelAuthorizationId}`, attributes)
       .then(({ data }) => data)
   },
+  delete(travelAuthorizationId) {
+    return http
+      .delete(`/api/travel-authorizations/${travelAuthorizationId}`)
+      .then(({ data }) => data)
+  },
   // State Management Actions
   approve(travelAuthorizationId) {
     return http

--- a/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
+++ b/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
@@ -10,6 +10,12 @@
       class="elevation-2"
       @click:row="goToFormDetails"
     >
+      <template #top>
+        <DeleteTravelAuthorizationDialog
+          ref="deleteDialog"
+          @deleted="refresh"
+        />
+      </template>
       <template #item.phase="{ value }">
         <span>{{ formatPhase(value) }}</span>
       </template>
@@ -29,10 +35,13 @@
         <template v-if="isEmpty(actions)">
           <!-- no action: this is a valid state -->
         </template>
-        <DeleteTravelAuthorizationDialog
+        <v-btn
           v-else-if="actions.includes('delete')"
-          :travel-authorization-id="item.id"
-        />
+          class="ml-2"
+          color="error"
+          @click.stop="showDeleteDialog(item)"
+          >Delete</v-btn
+        >
         <SubmitTravelDeskRequestButton
           v-else-if="actions.includes('submit_travel_desk_request')"
           :travel-authorization-id="item.id"
@@ -128,6 +137,7 @@ export default {
   },
   async mounted() {
     await this.refresh()
+    this.showDeleteDialogForRouteQuery()
   },
   methods: {
     ...mapActions("current/user/travelAuthorizations", ["ensure"]),
@@ -148,6 +158,18 @@ export default {
           params: { formId },
         })
       }
+    },
+    showDeleteDialog(item) {
+      this.$refs.deleteDialog.show(item)
+    },
+    showDeleteDialogForRouteQuery() {
+      const itemId = parseInt(this.$route.query.showDelete)
+      if (isNaN(itemId)) return
+
+      const item = this.items.find((item) => item.id === itemId)
+      if (!item) return
+
+      this.showDeleteDialog(item)
     },
     formatDate(value) {
       if (isNil(value)) return "Unknown"

--- a/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
+++ b/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
@@ -49,7 +49,7 @@
           v-else-if="actions.includes('submit_pool_vehicle_request')"
           :travel-authorization-id="item.id"
         />
-        <span v-else> ERROR: unknown action: {{ value }}</span>
+        <span v-else> ERROR: unknown actions: {{ actions }}</span>
       </template>
     </v-data-table>
   </div>

--- a/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
+++ b/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
@@ -29,6 +29,10 @@
         <template v-if="isEmpty(actions)">
           <!-- no action: this is a valid state -->
         </template>
+        <DeleteTravelAuthorizationDialog
+          v-else-if="actions.includes('delete')"
+          :travel-authorization-id="item.id"
+        />
         <SubmitTravelDeskRequestButton
           v-else-if="actions.includes('submit_travel_desk_request')"
           :travel-authorization-id="item.id"
@@ -61,6 +65,7 @@ import { isNil, isEmpty } from "lodash"
 import { DateTime } from "luxon"
 
 import AddExpenseButton from "./my-travel-authorizations-table/AddExpenseButton"
+import DeleteTravelAuthorizationDialog from "./my-travel-authorizations-table/DeleteTravelAuthorizationDialog"
 import SubmitExpenseClaimButton from "./my-travel-authorizations-table/SubmitExpenseClaimButton"
 import SubmitPoolVehicleRequestButton from "./my-travel-authorizations-table/SubmitPoolVehicleRequestButton"
 import SubmitTravelDeskRequestButton from "./my-travel-authorizations-table/SubmitTravelDeskRequestButton"
@@ -70,6 +75,7 @@ export default {
   name: "MyTravelAuthorizationsTable",
   components: {
     AddExpenseButton,
+    DeleteTravelAuthorizationDialog,
     SubmitExpenseClaimButton,
     SubmitPoolVehicleRequestButton,
     SubmitTravelDeskRequestButton,

--- a/web/src/modules/travel-authorizations/components/my-travel-authorizations-table/DeleteTravelAuthorizationDialog.vue
+++ b/web/src/modules/travel-authorizations/components/my-travel-authorizations-table/DeleteTravelAuthorizationDialog.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-btn
+    class="ma-0"
+    color="error"
+    @click.stop="deleteTravelAuthorization"
+  >
+    Delete
+  </v-btn>
+</template>
+
+<script>
+export default {
+  name: "DeleteTravelAuthorizationDialog",
+  props: {
+    travelAuthorizationId: {
+      type: Number,
+      required: true,
+    },
+  },
+  methods: {
+    deleteTravelAuthorization() {
+      alert("TODO: delete travel authorization " + this.travelAuthorizationId)
+    },
+  },
+}
+</script>

--- a/web/src/modules/travel-authorizations/components/my-travel-authorizations-table/DeleteTravelAuthorizationDialog.vue
+++ b/web/src/modules/travel-authorizations/components/my-travel-authorizations-table/DeleteTravelAuthorizationDialog.vue
@@ -1,25 +1,132 @@
 <template>
-  <v-btn
-    class="ma-0"
-    color="error"
-    @click.stop="deleteTravelAuthorization"
+  <v-dialog
+    v-model="showDialog"
+    max-width="500px"
   >
-    Delete
-  </v-btn>
+    <v-card>
+      <v-card-title class="text-h5">
+        Are you sure you want to delete the following travel authorization request?
+      </v-card-title>
+      <v-card-text>
+        <v-container v-if="hasTravelAuthorization">
+          <v-row no-gutters>
+            <v-col class="text-center">
+              {{ formatPhase(travelAuthorization.phase) }}
+            </v-col>
+          </v-row>
+          <v-row no-gutters>
+            <v-col class="text-center">
+              {{ formatLocation(travelAuthorization.finalDestination) }}
+            </v-col>
+          </v-row>
+          <v-row no-gutters>
+            <v-col class="text-center">
+              {{ formatDate(travelAuthorization.departingAt) }}
+            </v-col>
+          </v-row>
+          <v-row no-gutters>
+            <v-col class="text-center">
+              {{ formatDate(travelAuthorization.returningAt) }}
+            </v-col>
+          </v-row>
+          <v-row no-gutters>
+            <v-col class="text-center">
+              {{ formatStatus(travelAuthorization.status) }}
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="secondary"
+          :loading="loading"
+          @click="close"
+          >Cancel</v-btn
+        >
+        <v-btn
+          color="error"
+          :loading="loading"
+          @click="deleteAndClose"
+          >OK</v-btn
+        >
+        <v-spacer></v-spacer>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script>
+import { isEmpty, isNil } from "lodash"
+import { DateTime } from "luxon"
+
+import travelAuthorizations from "@/api/travel-authorizations-api"
+
 export default {
   name: "DeleteTravelAuthorizationDialog",
-  props: {
-    travelAuthorizationId: {
-      type: Number,
-      required: true,
+  data: () => ({
+    travelAuthorization: {},
+    showDialog: false,
+    loading: false,
+  }),
+  computed: {
+    travelAuthorizationId() {
+      return this.travelAuthorization.id
+    },
+    hasTravelAuthorization() {
+      return !isEmpty(this.travelAuthorization)
+    },
+  },
+  watch: {
+    showDialog(value) {
+      if (value) {
+        if (this.$route.query.showDelete === this.travelAuthorization.id.toString()) return
+
+        this.$router.push({ query: { showDelete: this.travelAuthorization.id } })
+      } else {
+        this.$router.push({ query: { showDelete: undefined } })
+      }
     },
   },
   methods: {
-    deleteTravelAuthorization() {
-      alert("TODO: delete travel authorization " + this.travelAuthorizationId)
+    show(travelAuthorization) {
+      this.travelAuthorization = travelAuthorization
+      this.showDialog = true
+    },
+    close() {
+      this.showDialog = false
+    },
+    deleteAndClose() {
+      this.loading = true
+      return travelAuthorizations
+        .delete(this.travelAuthorizationId)
+        .then(() => {
+          this.$emit("deleted")
+          this.close()
+        })
+        .catch((error) => {
+          this.$snack(error.message, { color: "error" })
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    },
+    formatDate(value) {
+      if (isNil(value)) return "Unknown"
+
+      const date = DateTime.fromISO(value, { zone: "utc" })
+      return date.toFormat("dd-LLL-yyyy")
+    },
+    formatLocation(value) {
+      if (isNil(value) || isNil(value.city)) return "Unknown"
+
+      return value.city
+    },
+    formatStatus(value) {
+      return this.$t(`global.status.${value}`, { $default: "Unknown" })
+    },
+    formatPhase(value) {
+      return this.$t(`global.phase.${value}`, { $default: "Unknown" })
     },
   },
 }


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/93

# Context

Original Context
> I accidentally generated a whole bunch of travel auth requests.  This was I think when the app was updating an it looked the button didn't do anything.  Through this I realize I do not have the ability to delete any of my travel auth form.
> 
> A user should be able to delete there travel auth. requests if it has not been sent for processing.

## Proposed Solution

- add a deletion button to the "My Travel Requests" table, the same as I have for the "Estimates" table. 
- Travel (Authorization) Requests should only be deletable when in the `draft` state.

# Implementation

1. Add travel authorization delete endpoint to back-end. Opted not to track deletion action in logs, as current logging system not set up to handle that scenario. See https://github.com/icefoganalytics/travel-authorization/commit/0f44f662e81c84866314400547648146bb83718a for ways to handle this.
2. Add "delete" action to travel authorization serialized data in the back-end when travel authorization is in draft.
3. Add deletion confirmation model using pattern from Estimates table.

# Screenshots

Draft travel authorization with delete action
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/4c313238-65b6-4d97-b834-354093d18516)

Deletion confirmation model
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/14c59ea9-77ae-4db2-ba2f-29ab5048745f)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the "My Travel Requests" page via the top drop down nav.
5. Create a new travel authorization via the "+Travel Authorization" button.
6. Fill in the Purpose and Details sections and then scroll to the bottom and select "Save Draft"
7. Go back to the previous page by clicking on the top breadcrumb "My-Travel-Request".
8. Check that there is a new travel request with a "Delete" button available.
9. Click the button, and note that it shows a modal with info about the request to be deleted.
10. Delete the travel request, and see that it is removed from the table.
11. Next create a new travel authorization via the "+Travel Authorization" button, again.
12. Fill in the Details panel and then scroll down to the Approvals panel.
13. Click the Generate Estimate button, then save and generate.
14. Fill in the "Submit to" field with your email address and click the "Submit to Supervisor" button.
15. Go back to the previous page by clicking on the top breadcrumb "My-Travel-Request", again.
16. Check that the "Submitted" travel request does not have a delete action.
