### PR TITLE
Add Totals Section To Travel Authorization Expense Tab

### DIFF
--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/TotalsTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/TotalsTable.vue
@@ -1,0 +1,112 @@
+<template>
+  <v-skeleton-loader
+    v-if="isLoading"
+    type="table-heading@3"
+  />
+  <v-container
+    v-else
+    class="elevation-2"
+  >
+    <v-row>
+      <v-col
+        cols="6"
+        class="text-right"
+        >Subtotal Claim:</v-col
+      >
+      <v-col cols="6">{{ formatCurrency(subTotalClaim) }}</v-col>
+    </v-row>
+    <v-row>
+      <v-col
+        cols="6"
+        class="text-right"
+        >Travel Advance:</v-col
+      >
+      <v-col cols="6">{{ formatCurrency(travelAdvance) }}</v-col>
+    </v-row>
+    <v-row class="mt-0">
+      <v-col cols="6"></v-col>
+      <v-col cols="6">
+        <div class="border-solid border-t border-black w-16"></div>
+      </v-col>
+    </v-row>
+    <v-row class="mt-0">
+      <v-col
+        cols="6"
+        class="text-right"
+      >
+        <strong>Total Claim:</strong>
+      </v-col>
+      <v-col cols="6">
+        <strong>
+          {{ formatCurrency(totalClaim) }}
+        </strong>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { sumBy } from "lodash"
+import { computed, onMounted, ref } from "vue"
+
+import { TYPES } from "@/api/expenses-api"
+import useExpenses from "@/use/expenses"
+
+const props = defineProps({
+  travelAuthorizationId: {
+    type: Number,
+    required: true,
+  },
+})
+
+defineExpose({
+  refresh,
+})
+
+const { expenses, isLoading, fetch } = useExpenses()
+
+// Will need to be calculated in the back-end if data is multi-page.
+const subTotalClaim = computed(() => sumBy(expenses.value, "cost"))
+const travelAdvance = ref(0) // TODO: load this from the travel authorization
+const totalClaim = computed(() => subTotalClaim.value - travelAdvance.value)
+
+onMounted(async () => {
+  await refresh()
+})
+
+async function refresh() {
+  await fetch({
+    where: {
+      travelAuthorizationId: props.travelAuthorizationId,
+      type: TYPES.EXPENSE,
+    },
+  })
+}
+
+function formatCurrency(amount) {
+  const formatter = new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+  })
+  return formatter.format(amount)
+}
+</script>
+
+<style scoped>
+/* See https://tailwindcss.com/docs/border-width */
+.border-solid {
+  border-style: solid;
+}
+.border-t {
+  border-width: 0px;
+  border-top-width: 1px;
+}
+
+.border-black {
+  border-color: rgb(0 0 0);
+}
+
+.w-16 {
+  width: 4rem; /* 64px */
+}
+</style>

--- a/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
+++ b/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
@@ -33,7 +33,13 @@
           :travel-authorization-id="travelAuthorizationId"
         />
       </v-col>
-      <v-col></v-col>
+      <v-col>
+        <h3>Totals</h3>
+        <TotalsTable
+          ref="totalsTable"
+          :travel-authorization-id="travelAuthorizationId"
+        />
+      </v-col>
     </v-row>
   </div>
 </template>
@@ -46,6 +52,7 @@ import ExpenseCreateDialog from "@/modules/travel-authorizations/components/edit
 import ExpensePrefillDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensePrefillDialog"
 import ExpensesTable from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensesTable"
 import MealsAndIncidentalsTable from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/MealsAndIncidentalsTable.vue"
+import TotalsTable from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/TotalsTable.vue"
 
 export default {
   name: "EditMyTravelAuthorizationExpensePage",
@@ -54,6 +61,7 @@ export default {
     ExpensePrefillDialog,
     ExpensesTable,
     MealsAndIncidentalsTable,
+    TotalsTable,
   },
   props: {
     travelAuthorizationId: {
@@ -92,6 +100,7 @@ export default {
         this.refresh(),
         this.$refs.expensesTable.refresh(),
         this.$refs.mealsAndIncidentalsTable.refresh(),
+        this.$refs.totalsTable.refresh(),
       ])
     },
   },

--- a/web/src/use/expenses.js
+++ b/web/src/use/expenses.js
@@ -1,9 +1,8 @@
-import { isEmpty } from "lodash"
-import { reactive, computed, toRefs } from "vue"
+import { reactive, toRefs } from "vue"
 
 import expensesApi, { TYPES, EXPENSE_TYPES } from "@/api/expenses-api"
 
-export const useExpenses = () => {
+export function useExpenses() {
   const state = reactive({
     expenses: [],
     isLoading: false,
@@ -11,21 +10,12 @@ export const useExpenses = () => {
     isCached: false,
   })
 
-  const estimates = computed(() => state.expenses.filter((item) => item.type === TYPES.ESTIMATE))
-
-  async function ensure({ where, page, perPage, ...otherParams } = {}) {
-    if (state.isCached) return state.expenses
-
-    return fetch({ where, page, perPage, ...otherParams })
-  }
-
   async function fetch({ where, page, perPage, ...otherParams } = {}) {
     state.isLoading = true
     try {
       const { expenses } = await expensesApi.list({ where, page, perPage, ...otherParams })
       state.isErrored = false
       state.expenses = expenses
-      state.isCached = !isEmpty(expenses)
       return expenses
     } catch (error) {
       console.error("Failed to fetch expenses:", error)
@@ -40,8 +30,6 @@ export const useExpenses = () => {
     TYPES,
     EXPENSE_TYPES,
     ...toRefs(state),
-    estimates,
-    ensure,
     fetch,
   }
 }

--- a/web/src/use/travel-authorization.js
+++ b/web/src/use/travel-authorization.js
@@ -1,0 +1,43 @@
+import { reactive, toRefs } from "vue"
+
+import travelAuthorizationsApi from "@/api/travel-authorizations-api"
+
+export function useTravelAuthorization() {
+  const state = reactive({
+    travelAuthorization: {
+      expenses: [],
+      purpose: {},
+      stops: [],
+      travelSegments: [],
+      user: {},
+    },
+    isLoading: false,
+    isErrored: false,
+  })
+
+  async function fetch(travelAuthorizationId, params = {}) {
+    state.isLoading = true
+    try {
+      const { travelAuthorization } = await travelAuthorizationsApi.get(
+        travelAuthorizationId,
+        params
+      )
+      state.isErrored = false
+      state.travelAuthorization = travelAuthorization
+      return travelAuthorization
+    } catch (error) {
+      console.error("Failed to fetch travel authorization:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  return {
+    ...toRefs(state),
+    fetch,
+  }
+}
+
+export default useTravelAuthorization


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/142

Relates to:
- [Analysis, Expense Pages, 2023-12-19](https://docs.google.com/document/d/1cWEA-0w9ro1TyajfnffkYaKL42yYnA89i9gdQysht_A/edit?pli=1#heading=h.zc2nwn7nmjlu)

# Context

**Is your feature request related to a problem? Please describe.**
Add totals section to Expense tab.

**Describe the solution you'd like**
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/831ca6cc-209a-4290-9f02-0517c4cf17c4)

**Additional context**
Add simple table component with custom back-end endpoint, or just load all expenses to front-end and do the computation there.

# Implementation

Add total table thing.
Add new use file for travel authorization.

# Screenshots

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/eb63136a-b1f5-42a1-b964-a423d875b4ed)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the "My Travel Requests" page from the top nav drop down.
5. Create a new travel authorization via the "+ Travel Authorization" button.
6. Fill in the various sections, and then click "Generate Estimate".
7. Fill and a value for the "Travel Advance".
8. Submit the form to yourself.
9. Go to the Manager View from the top drop down nav.
10. Find your travel request in the top left widget.
11. Click on it and then scroll to the bottom and click Approve.
12. Go back to the "My Travel Requests" page from the top nav drop down.
13. Select the travel authorization you previously created.
14. Go to Expense tab and click the "Prefill" expense button.
15. This now prefills the editable expenses and the non-editable meals and incidentals expenses.
16. Check that the generated data adds up to the new Total widget.
