### PR TITLE
Add Submit Action To Travel Authorization Expense Tab User View

### DIFF
--- a/api/src/controllers/travel-authorizations/expense-claim-controller.ts
+++ b/api/src/controllers/travel-authorizations/expense-claim-controller.ts
@@ -1,0 +1,56 @@
+import { isNil } from "lodash"
+
+import { BaseController } from "@/controllers/base-controller"
+import { TravelAuthorization } from "@/models"
+import { ExpenseClaimService } from "@/services/travel-authorizations"
+import { ExpenseClaimPolicy } from "@/policies/travel-authorizations"
+import { TravelAuthorizationsSerializer } from "@/serializers"
+
+export class ExpenseClaimController extends BaseController {
+  async create() {
+    if (isNil(this.params.travelAuthorizationId)) {
+      return this.response.status(404).json({ message: "Missing travel authorization id param." })
+    }
+
+    const travelAuthorization = await this.loadTravelAuthorization()
+    if (isNil(travelAuthorization)) {
+      return this.response.status(404).json({ message: "Travel authorization not found." })
+    }
+
+    const policy = this.buildPolicy(travelAuthorization)
+    if (!policy.create()) {
+      return this.response
+        .status(403)
+        .json({
+          message:
+            "You are not authorized to submit an expense claim for this travel authorization.",
+        })
+    }
+
+    const { supervisorEmail } = this.request.body
+    return ExpenseClaimService.perform(travelAuthorization, supervisorEmail, this.currentUser)
+      .then((travelAuthorization) => {
+        const serializedTravelAuthorization =
+          TravelAuthorizationsSerializer.asDetailed(travelAuthorization)
+
+        return this.response
+          .status(200)
+          .json({ travelAuthorization: serializedTravelAuthorization })
+      })
+      .catch((error) => {
+        return this.response
+          .status(422)
+          .json({ message: `Travel authorization expense claim submission failed: ${error}` })
+      })
+  }
+
+  private loadTravelAuthorization(): Promise<TravelAuthorization | null> {
+    return TravelAuthorization.findByPk(this.params.travelAuthorizationId)
+  }
+
+  private buildPolicy(record: TravelAuthorization): ExpenseClaimPolicy {
+    return new ExpenseClaimPolicy(this.currentUser, record)
+  }
+}
+
+export default ExpenseClaimController

--- a/api/src/controllers/travel-authorizations/index.ts
+++ b/api/src/controllers/travel-authorizations/index.ts
@@ -1,7 +1,6 @@
-import { Expense } from "@/models"
-
 export { ApproveController } from "./approve-controller"
 export { DenyController } from "./deny-controller"
+export { ExpenseClaimController } from "./expense-claim-controller"
 
 // Namespaced controllers
 export * as Estimates from "./estimates"

--- a/api/src/models/travel-authorization-action-log.ts
+++ b/api/src/models/travel-authorization-action-log.ts
@@ -21,6 +21,7 @@ export enum Actions {
   APPROVE = "approve",
   DENY = "deny",
   UPDATE = "update",
+  EXPENSE_CLAIM = "expense_claim",
 }
 
 export class TravelAuthorizationActionLog extends Model<

--- a/api/src/policies/travel-authorizations/expense-claim-policy.ts
+++ b/api/src/policies/travel-authorizations/expense-claim-policy.ts
@@ -1,0 +1,18 @@
+import BasePolicy from "@/policies/base-policy"
+
+import { User, TravelAuthorization } from "@/models"
+
+export class ExpenseClaimPolicy extends BasePolicy<TravelAuthorization> {
+  // I'm not sure if the following logic should be in a policy or just the UI?
+  // Submit becomes enabled with there are more than zero "Coding" rows,
+  // and all expenses have an associated upload/receipt.
+  create(): boolean {
+    if (this.user.roles.includes(User.Roles.ADMIN)) return true
+    if (this.record.supervisorEmail === this.user.email) return true
+    if (this.record.userId === this.user.id) return true
+
+    return false
+  }
+}
+
+export default ExpenseClaimPolicy

--- a/api/src/policies/travel-authorizations/index.ts
+++ b/api/src/policies/travel-authorizations/index.ts
@@ -1,2 +1,3 @@
 export { ApprovePolicy } from "./approve-policy"
 export { DenyPolicy } from "./deny-policy"
+export { ExpenseClaimPolicy } from "./expense-claim-policy"

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -59,12 +59,17 @@ router
   .get(TravelAuthorizationsController.show)
   .patch(TravelAuthorizationsController.update)
   .delete(TravelAuthorizationsController.destroy)
+
+// Stateful routes for travel authorizations
 router
   .route("/api/travel-authorizations/:travelAuthorizationId/approve")
   .post(TravelAuthorizations.ApproveController.create)
 router
   .route("/api/travel-authorizations/:travelAuthorizationId/deny")
   .post(TravelAuthorizations.DenyController.create)
+router
+  .route("/api/travel-authorizations/:travelAuthorizationId/expense-claim")
+  .post(TravelAuthorizations.ExpenseClaimController.create)
 
 router
   .route("/api/travel-authorizations/:travelAuthorizationId/estimates/generate")

--- a/api/src/services/travel-authorizations/expense-claim-service.ts
+++ b/api/src/services/travel-authorizations/expense-claim-service.ts
@@ -31,7 +31,6 @@ export class ExpenseClaimService extends BaseService {
       throw new Error("Supervisor email is required to submit and expense claim.")
     }
 
-
     await db.transaction(async () => {
       await this.travelAuthorization.update({
         supervisorEmail: this.supervisorEmail,
@@ -44,7 +43,9 @@ export class ExpenseClaimService extends BaseService {
       })
     })
 
-    return this.travelAuthorization.reload({ include: ["expenses", "stops", "purpose", "user"] })
+    return this.travelAuthorization.reload({
+      include: ["expenses", "stops", "purpose", "user", "travelSegments"],
+    })
   }
 }
 

--- a/api/src/services/travel-authorizations/expense-claim-service.ts
+++ b/api/src/services/travel-authorizations/expense-claim-service.ts
@@ -1,0 +1,51 @@
+import { isEmpty, isNil } from "lodash"
+
+import db from "@/db/db-client"
+
+import BaseService from "@/services/base-service"
+import { TravelAuthorization, TravelAuthorizationActionLog, User } from "@/models"
+
+export class ExpenseClaimService extends BaseService {
+  private travelAuthorization: TravelAuthorization
+  private supervisorEmail: string
+  private currentUser: User
+
+  constructor(
+    travelAuthorization: TravelAuthorization,
+    supervisorEmail: string,
+    currentUser: User
+  ) {
+    super()
+    this.travelAuthorization = travelAuthorization
+    this.supervisorEmail = supervisorEmail
+    this.currentUser = currentUser
+  }
+
+  async perform(): Promise<TravelAuthorization> {
+    if (this.travelAuthorization.status !== TravelAuthorization.Statuses.APPROVED) {
+      throw new Error(
+        "Travel authorization must be in an approved state to submit an expense claim."
+      )
+    }
+    if (isNil(this.supervisorEmail) || isEmpty(this.supervisorEmail)) {
+      throw new Error("Supervisor email is required to submit and expense claim.")
+    }
+
+
+    await db.transaction(async () => {
+      await this.travelAuthorization.update({
+        supervisorEmail: this.supervisorEmail,
+        status: TravelAuthorization.Statuses.EXPENSE_CLAIM,
+      })
+      await TravelAuthorizationActionLog.create({
+        travelAuthorizationId: this.travelAuthorization.id,
+        userId: this.currentUser.id,
+        action: TravelAuthorizationActionLog.Actions.EXPENSE_CLAIM,
+      })
+    })
+
+    return this.travelAuthorization.reload({ include: ["expenses", "stops", "purpose", "user"] })
+  }
+}
+
+export default ExpenseClaimService

--- a/api/src/services/travel-authorizations/index.ts
+++ b/api/src/services/travel-authorizations/index.ts
@@ -5,3 +5,4 @@ export { DestroyService } from "./destroy-service"
 // State management services
 export { ApproveService } from "./approve-service"
 export { DenyService } from "./deny-service"
+export { ExpenseClaimService } from "./expense-claim-service"

--- a/web/src/api/travel-authorizations-api.js
+++ b/web/src/api/travel-authorizations-api.js
@@ -49,6 +49,11 @@ export const travelAuthorizationsApi = {
       .post(`/api/travel-authorizations/${travelAuthorizationId}/deny`)
       .then(({ data }) => data)
   },
+  expenseClaim(travelAuthorizationId, attributes) {
+    return http
+      .post(`/api/travel-authorizations/${travelAuthorizationId}/expense-claim`, attributes)
+      .then(({ data }) => data)
+  },
 }
 
 export default travelAuthorizationsApi

--- a/web/src/modules/travel-authorizations/components/ExpenseTypeSelect.vue
+++ b/web/src/modules/travel-authorizations/components/ExpenseTypeSelect.vue
@@ -16,6 +16,8 @@
 <script>
 import { required } from "@/utils/validators"
 
+import { EXPENSE_TYPES } from "@/api/expenses-api"
+
 export default {
   inheritAttrs: false,
   props: {
@@ -23,16 +25,15 @@ export default {
       type: String,
       default: () => null,
     },
+    expenseTypes: {
+      type: Array,
+      default: () => Object.values(EXPENSE_TYPES),
+    },
   },
   data: () => ({
-    expenseTypes: [],
     loading: true,
   }),
   mounted() {
-    this.loading = true
-    // TODO: fetch expense types from backend,
-    // until then, keep in sync with src/api/models/expense.ts
-    this.expenseTypes = ["Transportation", "Accommodations", "Meals & Incidentals"]
     this.loading = false
   },
   methods: {

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog.vue
@@ -28,6 +28,7 @@
             <v-col>
               <ExpenseTypeSelect
                 v-model="expense.expenseType"
+                :expense-types="expenseTypes"
                 :rules="[required]"
                 label="Expense Type"
                 required
@@ -91,11 +92,11 @@
 <script>
 import { required } from "@/utils/validators"
 
+import expensesApi, { EXPENSE_TYPES } from "@/api/expenses-api"
+
 import CurrencyTextField from "@/components/Utils/CurrencyTextField"
 import DatePicker from "@/components/Utils/DatePicker"
 import ExpenseTypeSelect from "@/modules/travel-authorizations/components/ExpenseTypeSelect"
-
-import expensesApi from "@/api/expenses-api"
 
 export default {
   name: "ExpenseCreateDialog",
@@ -112,6 +113,9 @@ export default {
   },
   data() {
     return {
+      expenseTypes: Object.values(EXPENSE_TYPES).filter(
+        (type) => type !== EXPENSE_TYPES.MEALS_AND_INCIDENTALS
+      ),
       expense: this.newExpense(),
       showDialog: this.$route.query.showCreate === "true",
       loading: false,

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog.vue
@@ -113,9 +113,7 @@ export default {
   },
   data() {
     return {
-      expenseTypes: Object.values(EXPENSE_TYPES).filter(
-        (type) => type !== EXPENSE_TYPES.MEALS_AND_INCIDENTALS
-      ),
+      expenseTypes: [EXPENSE_TYPES.ACCOMMODATIONS, EXPENSE_TYPES.TRANSPORTATION],
       expense: this.newExpense(),
       showDialog: this.$route.query.showCreate === "true",
       loading: false,

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseEditDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseEditDialog.vue
@@ -17,6 +17,7 @@
             <v-col>
               <ExpenseTypeSelect
                 v-model="expense.expenseType"
+                :expense-types="expenseTypes"
                 :rules="[required]"
                 label="Expense Type"
                 required
@@ -86,7 +87,7 @@ import CurrencyTextField from "@/components/Utils/CurrencyTextField"
 import DatePicker from "@/components/Utils/DatePicker"
 import ExpenseTypeSelect from "@/modules/travel-authorizations/components/ExpenseTypeSelect"
 
-import expensesApi from "@/api/expenses-api"
+import expensesApi, { EXPENSE_TYPES } from "@/api/expenses-api"
 
 export default {
   name: "ExpenseEditDialog",
@@ -96,6 +97,7 @@ export default {
     ExpenseTypeSelect,
   },
   data: () => ({
+    expenseTypes: [EXPENSE_TYPES.ACCOMMODATIONS, EXPENSE_TYPES.TRANSPORTATION],
     expense: {},
     showDialog: false,
     loading: false,

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensesTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensesTable.vue
@@ -9,11 +9,11 @@
     <template #top>
       <ExpenseEditDialog
         ref="editDialog"
-        @saved="refresh"
+        @saved="emitChangedAndRefresh"
       />
       <ExpenseDeleteDialog
         ref="deleteDialog"
-        @deleted="refresh"
+        @deleted="emitChangedAndRefresh"
       />
     </template>
     <template #item.date="{ value }">
@@ -36,7 +36,7 @@
           <AddReceiptButton
             v-if="item.fileSize === null"
             :expense-id="item.id"
-            @uploaded="refresh"
+            @uploaded="emitChangedAndRefresh"
           />
           <ViewRecieptLink
             v-else
@@ -149,6 +149,10 @@ export default {
           expenseType: [EXPENSE_TYPES.ACCOMMODATIONS, EXPENSE_TYPES.TRANSPORTATION],
         },
       })
+    },
+    emitChangedAndRefresh() {
+      this.$emit("changed")
+      return this.refresh()
     },
     showDeleteDialog(item) {
       this.$refs.deleteDialog.show(item)

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue
@@ -9,11 +9,11 @@
     <template #top>
       <GeneralLedgerCodingEditDialog
         ref="editDialog"
-        @saved="refresh"
+        @saved="emitChangedAndRefresh"
       />
       <GeneralLedgerCodingDeleteDialog
         ref="deleteDialog"
-        @deleted="refresh"
+        @deleted="emitChangedAndRefresh"
       />
     </template>
     <template #item.amount="{ value }">
@@ -66,6 +66,8 @@ const props = defineProps({
   },
 })
 
+const emit = defineEmits(["changed"])
+
 defineExpose({
   refresh,
 })
@@ -104,6 +106,11 @@ async function refresh() {
       travelAuthorizationId: props.travelAuthorizationId,
     },
   })
+}
+
+async function emitChangedAndRefresh() {
+  emit("changed")
+  await refresh()
 }
 
 function showDeleteDialog(item) {

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
@@ -65,6 +65,7 @@
 
 <script setup>
 import { onMounted, ref, computed } from "vue"
+import { useRouter } from "vue2-helpers/vue-router"
 
 import { required } from "@/utils/validators"
 
@@ -88,17 +89,18 @@ defineExpose({
 
 const form = ref(null)
 const snack = useSnack()
+const router = useRouter()
 
 const {
   travelAuthorization,
   isLoading: isLoadingTravelAuthorization,
   fetch: fetchTravelAuthorization,
+  expenseClaim,
 } = useTravelAuthorization()
 const {
   generalLedgerCodings,
   isLoading: isLoadingGeneralLedgerCodings,
   fetch: fetchGeneralLedgerCodings,
-  expenseClaim,
 } = useGeneralLedgerCodings()
 const {
   expenses,
@@ -151,13 +153,11 @@ async function requestApprovalForExpenseClaim() {
     await expenseClaim(props.travelAuthorizationId, {
       supervisorEmail: travelAuthorization.value.supervisorEmail,
     })
-    // TODO: build out read only view of Expenses page.
-    // import { useRouter } from "vue2-helpers/vue-router"
-    // const router = useRouter()
-    // router.push({
-    //   name: "ReadMyTravelAuthorizationExpensesPage",
-    //   params: { travelAuthorizationId: this.travelAuthorizationId },
-    // })
+    snack("Expense claim submitted for approval.", { color: "success" })
+    router.push({
+      name: "ReadMyTravelAuthorizationExpensePage",
+      params: { travelAuthorizationId: props.travelAuthorizationId },
+    })
   } catch (error) {
     snack(error.message, { color: "error" })
   }

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
@@ -114,6 +114,7 @@ const isReadyToSubmit = computed(
 )
 
 onMounted(async () => {
+  // TODO: refresh this when user updates/adds expenses or when they add/remove codings rows
   await Promise.all([
     await fetchTravelAuthorization(props.travelAuthorizationId),
     await fetchGeneralLedgerCodings({

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
@@ -1,0 +1,148 @@
+<template>
+  <v-form
+    ref="form"
+    :loading="isLoading"
+  >
+    <v-row>
+      <v-col
+        cols="12"
+        md="3"
+      >
+        <SearchableUserEmailCombobox
+          v-model="travelAuthorization.supervisorEmail"
+          :rules="[required]"
+          label="Submit to"
+          dense
+          outlined
+          required
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="3"
+      >
+        <v-btn
+          v-if="isReadyToSubmit"
+          :loading="isLoading"
+          class="mt-0"
+          color="primary"
+          @click="requestApprovalForExpenseClaim"
+        >
+          Submit to Supervisor
+        </v-btn>
+        <v-tooltip
+          v-else
+          bottom
+        >
+          <template #activator="{ on, attrs }">
+            <span
+              v-bind="attrs"
+              v-on="on"
+            >
+              <v-btn
+                class="mt-0"
+                color="secondary"
+                disabled
+                >Submit to Supervisor
+                <v-icon
+                  class="ml-1"
+                  small
+                >
+                  mdi-help-circle-outline
+                </v-icon>
+              </v-btn>
+            </span>
+          </template>
+          <span
+            >Submit becomes enabled when there are more than zero "Coding" rows, and all expenses
+            have an associated upload/receipt.</span
+          >
+        </v-tooltip>
+      </v-col>
+    </v-row>
+  </v-form>
+</template>
+
+<script setup>
+import { onMounted, ref, computed } from "vue"
+
+import travelAuthorizationsApi from "@/api/travel-authorizations-api"
+
+import { useSnack } from "@/plugins/snack-plugin"
+import { useTravelAuthorization } from "@/use/travel-authorization"
+import { useGeneralLedgerCodings } from "@/use/general-ledger-codings"
+import { useExpenses } from "@/use/expenses"
+
+import SearchableUserEmailCombobox from "@/components/SearchableUserEmailCombobox"
+
+const props = defineProps({
+  travelAuthorizationId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const form = ref(null)
+const snack = useSnack()
+
+const {
+  travelAuthorization,
+  isLoading: isLoadingTravelAuthorization,
+  fetch: fetchTravelAuthorization,
+} = useTravelAuthorization()
+const {
+  generalLedgerCodings,
+  isLoading: isLoadingGeneralLedgerCodings,
+  fetch: fetchGeneralLedgerCodings,
+} = useGeneralLedgerCodings()
+const { expenses, isLoading: isLoadingExpenses, fetch: fetchExpenses } = useExpenses()
+
+const isLoading = computed(
+  () =>
+    isLoadingTravelAuthorization.value ||
+    isLoadingGeneralLedgerCodings.value ||
+    isLoadingExpenses.value
+)
+
+const hasGeneralLedgerCodings = computed(() => generalLedgerCodings.value.length > 0)
+const expensesWithReceipts = computed(() =>
+  expenses.value.filter((expense) => expense.fileSize > 0)
+)
+const hasExpensesWithReceipts = computed(() => expensesWithReceipts.value.length > 0)
+const isReadyToSubmit = computed(
+  () => hasGeneralLedgerCodings.value && hasExpensesWithReceipts.value
+)
+
+onMounted(async () => {
+  await Promise.all([
+    await fetchTravelAuthorization(props.travelAuthorizationId),
+    await fetchGeneralLedgerCodings({
+      where: {
+        travelAuthorizationId: props.travelAuthorizationId,
+      },
+    }),
+    await fetchExpenses({
+      where: {
+        travelAuthorizationId: props.travelAuthorizationId,
+      },
+    }),
+  ])
+})
+
+async function requestApprovalForExpenseClaim() {
+  try {
+    await travelAuthorizationsApi.expenseClaim(props.travelAuthorizationId, {
+      supervisorEmail: travelAuthorization.value.supervisorEmail,
+    })
+    // TODO: build out read only view of Expenses page.
+    // import { useRouter } from "vue2-helpers/vue-router"
+    // const router = useRouter()
+    // router.push({
+    //   name: "ReadMyTravelAuthorizationExpensesPage",
+    //   params: { travelAuthorizationId: this.travelAuthorizationId },
+    // })
+  } catch (error) {
+    snack(error.message, { color: "error" })
+  }
+}
+</script>

--- a/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
+++ b/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
@@ -8,18 +8,19 @@
           <ExpenseCreateDialog
             v-if="hasExpenses"
             :form-id="travelAuthorizationId"
-            @created="refreshExpenses"
+            @created="refreshExpenseCreationDependencies"
           />
           <ExpensePrefillDialog
             v-else
             :travel-authorization-id="travelAuthorizationId"
-            @created="refreshExpenses"
+            @created="refreshExpenseCreationDependencies"
           />
         </div>
 
         <ExpensesTable
           ref="expensesTable"
           :travel-authorization-id="travelAuthorizationId"
+          @changed="refreshExpenseChangedDependencies"
         />
         * Meals and Incidentals will be calculated by the system; do not add these expenses.
       </v-col>
@@ -48,20 +49,24 @@
 
           <GeneralLedgerCodingCreateDialog
             :travel-authorization-id="travelAuthorizationId"
-            @created="refreshCodings"
+            @created="refreshCodingsCreatedDependencies"
           />
         </div>
 
         <GeneralLedgerCodingsTable
           ref="codingsTable"
           :travel-authorization-id="travelAuthorizationId"
+          @changed="refreshCodingsChangedDependencies"
         />
       </v-col>
       <v-col cols="4"></v-col>
     </v-row>
     <v-row class="mt-12">
       <v-col>
-        <RequestApprovalForm :travel-authorization-id="travelAuthorizationId" />
+        <RequestApprovalForm
+          ref="requestApprovalForm"
+          :travel-authorization-id="travelAuthorizationId"
+        />
       </v-col>
     </v-row>
   </div>
@@ -124,16 +129,29 @@ export default {
         },
       })
     },
-    async refreshExpenses() {
+    async refreshExpenseCreationDependencies() {
       await Promise.all([
         this.refresh(),
         this.$refs.expensesTable.refresh(),
         this.$refs.mealsAndIncidentalsTable.refresh(),
         this.$refs.totalsTable.refresh(),
+        await this.$refs.requestApprovalForm.refresh(),
       ])
     },
-    refreshCodings() {
-      this.$refs.codingsTable.refresh()
+    async refreshExpenseChangedDependencies() {
+      await Promise.all([
+        this.$refs.totalsTable.refresh(),
+        await this.$refs.requestApprovalForm.refresh(),
+      ])
+    },
+    async refreshCodingsCreatedDependencies() {
+      await Promise.all([
+        await this.$refs.codingsTable.refresh(),
+        await this.$refs.requestApprovalForm.refresh(),
+      ])
+    },
+    async refreshCodingsChangedDependencies() {
+      await this.$refs.requestApprovalForm.refresh()
     },
   },
 }

--- a/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
+++ b/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
@@ -75,6 +75,7 @@
 <script>
 import { TYPES } from "@/api/expenses-api"
 import { useExpenses } from "@/use/expenses"
+import store from "@/store"
 
 import ExpenseCreateDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog"
 import ExpensePrefillDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensePrefillDialog"
@@ -96,6 +97,24 @@ export default {
     MealsAndIncidentalsTable,
     RequestApprovalForm,
     TotalsTable,
+  },
+  // CONSIDER: Should I just put this in the mounted hook?
+  // Or if if I should controll this problem by never showing the edit link to a user if they can't edit?
+  async beforeRouteEnter(to, _from, next) {
+    if (to.name !== "EditMyTravelAuthorizationExpensePage") {
+      return next()
+    }
+
+    await store.dispatch("travelAuthorization/ensure", to.params.travelAuthorizationId)
+
+    if (store.getters["travelAuthorization/isExpenseEditable"]) {
+      return next()
+    }
+
+    next({
+      name: "ReadMyTravelAuthorizationExpensePage",
+      params: { travelAuthorizationId: to.params.travelAuthorizationId },
+    })
   },
   props: {
     travelAuthorizationId: {

--- a/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
+++ b/web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
@@ -59,6 +59,11 @@
       </v-col>
       <v-col cols="4"></v-col>
     </v-row>
+    <v-row class="mt-12">
+      <v-col>
+        <RequestApprovalForm :travel-authorization-id="travelAuthorizationId" />
+      </v-col>
+    </v-row>
   </div>
 </template>
 
@@ -72,6 +77,7 @@ import ExpensesTable from "@/modules/travel-authorizations/components/edit-my-tr
 import GeneralLedgerCodingCreateDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue"
 import GeneralLedgerCodingsTable from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue"
 import MealsAndIncidentalsTable from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/MealsAndIncidentalsTable.vue"
+import RequestApprovalForm from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue"
 import TotalsTable from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/TotalsTable.vue"
 
 export default {
@@ -83,6 +89,7 @@ export default {
     GeneralLedgerCodingCreateDialog,
     GeneralLedgerCodingsTable,
     MealsAndIncidentalsTable,
+    RequestApprovalForm,
     TotalsTable,
   },
   props: {

--- a/web/src/modules/travel-authorizations/pages/ReadMyTravelAuthorizationExpensePage.vue
+++ b/web/src/modules/travel-authorizations/pages/ReadMyTravelAuthorizationExpensePage.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    TODO: add read-only equivalents of components from
+    web/src/modules/travel-authorizations/pages/EditMyTravelAuthorizationExpensePage.vue
+  </div>
+</template>
+
+<script setup>
+// Do some stuff here
+</script>

--- a/web/src/modules/travel-authorizations/router.js
+++ b/web/src/modules/travel-authorizations/router.js
@@ -62,6 +62,13 @@ const routes = [
             props: cast("travelAuthorizationId", parseInt),
           },
           {
+            path: "expense",
+            name: "ReadMyTravelAuthorizationExpensePage",
+            component: () =>
+              import("@/modules/travel-authorizations/pages/ReadMyTravelAuthorizationExpensePage"),
+            props: cast("travelAuthorizationId", parseInt),
+          },
+          {
             path: "expense/edit",
             name: "EditMyTravelAuthorizationExpensePage",
             component: () =>

--- a/web/src/store/travel-authorization.js
+++ b/web/src/store/travel-authorization.js
@@ -1,3 +1,5 @@
+import { isNil } from "lodash"
+
 import travelAuthorizationsApi, { STATUSES } from "@/api/travel-authorizations-api"
 import { TYPES as EXPENSE_TYPES } from "@/api/expenses-api"
 
@@ -36,6 +38,18 @@ const getters = withGettersFromState(state, {
   isEditable: (_state, getters, _rootState, rootGetters) => {
     const currentUserId = rootGetters["current/user/id"]
     return getters.isEditableByUser(currentUserId)
+  },
+  isBeforeTravelStartDate(state) {
+    const firstTravelSegment = state.attributes.travelSegments[0]
+    if (isNil(firstTravelSegment)) return false
+
+    return new Date(firstTravelSegment.departureOn) > new Date()
+  },
+  isAfterTravelStartDate(_state, getters) {
+    return !getters.isBeforeTravelStartDate
+  },
+  isExpenseEditable: (state, getters) => {
+    return state.attributes.status === STATUSES.APPROVED && getters.isAfterTravelStartDate
   },
 })
 

--- a/web/src/use/travel-authorization.js
+++ b/web/src/use/travel-authorization.js
@@ -34,9 +34,29 @@ export function useTravelAuthorization() {
     }
   }
 
+  async function expenseClaim(travelAuthorizationId, attributes) {
+    state.isLoading = true
+    try {
+      const { travelAuthorization } = await travelAuthorizationsApi.expenseClaim(
+        travelAuthorizationId,
+        attributes
+      )
+      state.isErrored = false
+      state.travelAuthorization = travelAuthorization
+      return travelAuthorization
+    } catch (error) {
+      console.error("Failed to submit expense claim for travel authorization:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
   return {
     ...toRefs(state),
     fetch,
+    expenseClaim,
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/146

Relates to:
- [Analysis, Expense Pages, 2023-12-19](https://docs.google.com/document/d/1cWEA-0w9ro1TyajfnffkYaKL42yYnA89i9gdQysht_A/edit?pli=1#heading=h.zc2nwn7nmjlu)

# Context

**Is your feature request related to a problem? Please describe.**
The minimum permission User needs the ability to submit their expense report.

**Describe the solution you'd like**
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/d365c5ae-d734-4f70-99e7-ad30452f9c7c)

**Additional context**
- The minimum permission User will only have a submit action.
- Submit becomes enabled with there are more than zero "Coding" rows and all expenses have an associated upload/receipt.

# Implementation

- Add state machine endpoint for "expense_claim" state. This state can be transitioned to from the "approved" state.
- Use a bunch of emited events and exposed actions to refresh various components on the Expense tab when various sibling components changed state. This is a huge pain and pretty hard to read. I think I might like to iterated on my "use" store concept, and either switch to per-query states, or use a shared emitter such as https://www.npmjs.com/package/mitt for each "use" file.
- redirect to unbuilt read view of expense tab after submission.

# Screenshots

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/4fe265f5-251c-4862-9612-09b027517612)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the "My Travel Requests" page from the top nav drop down.
5. Create a new travel authorization via the "+ Travel Authorization" button.
6. Fill in the various sections, and then click "Generate Estimate".
8. Submit the form to yourself.
9. Go to the Manager View from the top drop down nav.
10. Find your travel request in the top left widget.
11. Click on it and then scroll to the bottom and click Approve.
12. Go back to the "My Travel Requests" page from the top nav drop down.
13. Select the travel authorization you previously created.
14. Go to Expense tab.
15. Upload a receipt for all of your expenses.
16. Add some rows to the "Coding" table.
17. Check that the submit button is now enabled.
18. Submit the request for expense approval.
19. Check that you are redirected to the "read-only" view of the expense tab
    > the readonly view has not been built yet.
