### PR TITLE
Implement Submit Expense Claim Button In My Travel Authorizations Table

### DIFF
--- a/web/src/modules/travel-authorizations/components/my-travel-authorizations-table/SubmitExpenseClaimButton.vue
+++ b/web/src/modules/travel-authorizations/components/my-travel-authorizations-table/SubmitExpenseClaimButton.vue
@@ -2,25 +2,21 @@
   <v-btn
     class="ma-0"
     color="secondary"
-    @click.stop="submitExpenseClaim"
+    :to="{
+      name: 'EditMyTravelAuthorizationExpensePage',
+      params: { travelAuthorizationId },
+    }"
+    @click.stop
   >
     Submit Expense Claim
   </v-btn>
 </template>
 
-<script>
-export default {
-  name: "SubmitExpenseClaimButton",
-  props: {
-    travelAuthorizationId: {
-      type: Number,
-      required: true,
-    },
+<script setup>
+defineProps({
+  travelAuthorizationId: {
+    type: Number,
+    required: true,
   },
-  methods: {
-    submitExpenseClaim() {
-      alert("TODO: submit expense claim for travel authorization " + this.travelAuthorizationId)
-    },
-  },
-}
+})
 </script>


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/155

Relates to:
- https://governmentofyukon.slack.com/archives/C04ETKKJS1X/p1704993100211319

# Context

**Is your feature request related to a problem? Please describe.**
The Submit Expense Claim button in the My Travel authorizations table currently does nothing.

**Describe the solution you'd like**
The `web/src/modules/travel-authorizations/components/my-travel-authorizations-table/SubmitExpenseClaimButton.vue` needs to be wired up to redirect the user to the Expenses tab of the travel-authorization.

# Implementation

:sparkles: Implement submit expense claim button.
Button currently on redirects to the Expense Edit page. I don't _think_ it needs to also redirect to the Read page?

# Screenshots

When hovered on, button now displays that it's a link and will redirect to the expenses tab. See bottom left corner.
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/d8253f98-43d0-4f59-9ee5-679c1316bc16)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to http://localhost:8080/my-travel-requests.
5. Create  a travel authorization via the "+ Travel Authorization" button.
6. Fill in the details section and generate an estimate.
7. Submit the form to yourself.
8. Go back to the Expense table and check that your expense shows a Travel Auth Status as submitted.