### PR TITLE
Approve Button on Ta No Screen Change

### DIFF
--- a/web/src/modules/travel-authorizations/components/TravelAuthorizationActionLogsTable.vue
+++ b/web/src/modules/travel-authorizations/components/TravelAuthorizationActionLogsTable.vue
@@ -22,7 +22,7 @@
 <script setup>
 import { startCase } from "lodash"
 import { DateTime } from "luxon"
-import { onMounted } from "vue"
+import { watch } from "vue"
 
 import { useI18n } from "@/plugins/vue-i18n-plugin"
 import { useTravelAuthorizationActionLogs } from "@/use/travel-authorization-action-logs"
@@ -67,9 +67,15 @@ const headers = [
   },
 ]
 
-onMounted(async () => {
-  await fetch()
-})
+watch(
+  () => props.travelAuthorizationId,
+  async () => {
+    await fetch()
+  },
+  {
+    immediate: true,
+  }
+)
 
 function formatAction(value) {
   const fallback = startCase(value.replace("_", " "))
@@ -82,4 +88,8 @@ function formatDate(value) {
   const date = DateTime.fromISO(iso8601Value, { zone: "utc" })
   return date.toFormat("LLLL-dd-yyyy")
 }
+
+defineExpose({
+  refresh: fetch,
+})
 </script>

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
@@ -96,7 +96,7 @@ const {
   isLoading: isLoadingTravelAuthorization,
   fetch: fetchTravelAuthorization,
   expenseClaim,
-} = useTravelAuthorization()
+} = useTravelAuthorization(props.travelAuthorizationId)
 const {
   generalLedgerCodings,
   isLoading: isLoadingGeneralLedgerCodings,
@@ -133,7 +133,7 @@ onMounted(async () => {
 
 async function refresh() {
   await Promise.all([
-    await fetchTravelAuthorization(props.travelAuthorizationId),
+    await fetchTravelAuthorization(),
     await fetchGeneralLedgerCodings({
       where: {
         travelAuthorizationId: props.travelAuthorizationId,
@@ -150,7 +150,7 @@ async function refresh() {
 
 async function requestApprovalForExpenseClaim() {
   try {
-    await expenseClaim(props.travelAuthorizationId, {
+    await expenseClaim({
       supervisorEmail: travelAuthorization.value.supervisorEmail,
     })
     snack("Expense claim submitted for approval.", { color: "success" })

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/TotalsTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/TotalsTable.vue
@@ -69,7 +69,7 @@ const {
   travelAuthorization,
   isLoading: isLoadingTravelAuthorization,
   fetch: fetchTravelAuthorization,
-} = useTravelAuthorization()
+} = useTravelAuthorization(props.travelAuthorizationId)
 
 const isLoading = computed(() => isLoadingExpenses.value || isLoadingTravelAuthorization.value)
 // Will need to be calculated in the back-end if data is multi-page.
@@ -89,7 +89,7 @@ async function refresh() {
         type: TYPES.EXPENSE,
       },
     }),
-    await fetchTravelAuthorization(props.travelAuthorizationId),
+    await fetchTravelAuthorization(),
   ])
 }
 

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
@@ -52,9 +52,10 @@ export default {
     // TODO: move this to a store action
     approve() {
       return travelAuthorizationApi
-        .approve(this.travelAuthorization.id)
+        .approve(this.travelAuthorizationId)
         .then(() => {
           this.$snack("Travel authorization approved!", { color: "success" })
+          this.$emit("approved")
         })
         .catch((error) => {
           this.$snack(error.message, { color: "error" })
@@ -62,9 +63,10 @@ export default {
     },
     deny() {
       return travelAuthorizationApi
-        .deny(this.travelAuthorization.id)
+        .deny(this.travelAuthorizationId)
         .then(() => {
           this.$snack("Travel authorization denied.", { color: "success" })
+          this.$emit("denied")
         })
         .catch((error) => {
           this.$snack(error.message, { color: "error" })

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
@@ -6,12 +6,16 @@
       <v-row>
         <v-col class="d-flex justify-end">
           <v-btn
+            :loading="isLoading"
+            :disabled="isDisabled"
             color="success"
             @click="approveWrapper"
           >
             Approve
           </v-btn>
           <v-btn
+            :loading="isLoading"
+            :disabled="isDisabled"
             class="ml-2"
             color="error"
             @click="denyWrapper"
@@ -43,6 +47,10 @@ const snack = useSnack()
 const { travelAuthorization, isLoading, fetch, approve, deny, STATUSES } = useTravelAuthorization(
   props.travelAuthorizationId
 )
+
+const isDisabled = computed(() => {
+  return isLoading.value || travelAuthorization.value.status !== STATUSES.SUBMITTED
+})
 
 async function approveWrapper() {
   return approve()

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-expense-page/ReassignApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-expense-page/ReassignApprovalForm.vue
@@ -56,12 +56,14 @@ const form = ref(null)
 const snack = useSnack()
 const router = useRouter()
 
-const { travelAuthorization, isLoading, fetch, save } = useTravelAuthorization()
+const { travelAuthorization, isLoading, fetch, save } = useTravelAuthorization(
+  props.travelAuthorizationId
+)
 
 watch(
   () => props.travelAuthorizationId,
   async () => {
-    await fetch(props.travelAuthorizationId)
+    await fetch()
   },
   { immediate: true }
 )

--- a/web/src/modules/travel-authorizations/components/my-travel-authorization-layout/ExpenseTab.vue
+++ b/web/src/modules/travel-authorizations/components/my-travel-authorization-layout/ExpenseTab.vue
@@ -52,7 +52,9 @@ const props = defineProps({
   },
 })
 
-const { travelAuthorization, fetch, isLoading, STATUSES } = useTravelAuthorization()
+const { travelAuthorization, fetch, isLoading, STATUSES } = useTravelAuthorization(
+  props.travelAuthorizationId
+)
 const isInPreExpensingStates = computed(
   () =>
     travelAuthorization.value.status === STATUSES.DRAFT ||
@@ -82,14 +84,14 @@ const componentName = computed(() => {
 watch(
   () => props.travelAuthorizationId,
   async () => {
-    await fetch(props.travelAuthorizationId)
+    await fetch()
   },
   { immediate: true }
 )
 
 onMounted(async () => {
   if (!isLoading.value) {
-    await fetch(props.travelAuthorizationId)
+    await fetch()
   }
 })
 </script>

--- a/web/src/modules/travel-authorizations/components/read-travel-authorization-details-page/ApprovalsCard.vue
+++ b/web/src/modules/travel-authorizations/components/read-travel-authorization-details-page/ApprovalsCard.vue
@@ -63,7 +63,10 @@
       </v-row>
       <v-row>
         <v-col>
-          <TravelAuthorizationActionLogsTable :travel-authorization-id="travelAuthorizationId" />
+          <TravelAuthorizationActionLogsTable
+            ref="travelAuthorizationActionLogsTable"
+            :travel-authorization-id="travelAuthorizationId"
+          />
         </v-col>
       </v-row>
     </v-card-text>
@@ -140,6 +143,9 @@ export default {
     ...mapActions("travelAuthorization", {
       ensureTravelAuthorization: "ensure",
     }),
+    refresh() {
+      this.$refs.travelAuthorizationActionLogsTable.refresh()
+    },
     formatCurrency(amount) {
       const formatter = new Intl.NumberFormat("en-CA", {
         style: "currency",

--- a/web/src/modules/travel-authorizations/components/read-travel-authorization-expense-page/TotalsTable.vue
+++ b/web/src/modules/travel-authorizations/components/read-travel-authorization-expense-page/TotalsTable.vue
@@ -64,7 +64,7 @@ const {
   travelAuthorization,
   isLoading: isLoadingTravelAuthorization,
   fetch: fetchTravelAuthorization,
-} = useTravelAuthorization()
+} = useTravelAuthorization(props.travelAuthorizationId)
 
 const isLoading = computed(() => isLoadingExpenses.value || isLoadingTravelAuthorization.value)
 // Will need to be calculated in the back-end if data is multi-page.
@@ -82,7 +82,7 @@ watch(
           type: TYPES.EXPENSE,
         },
       }),
-      await fetchTravelAuthorization(props.travelAuthorizationId),
+      await fetchTravelAuthorization(),
     ])
   },
   { immediate: true }

--- a/web/src/modules/travel-authorizations/layouts/ManageTravelAuthorizationLayout.vue
+++ b/web/src/modules/travel-authorizations/layouts/ManageTravelAuthorizationLayout.vue
@@ -81,13 +81,13 @@ const {
   travelAuthorization,
   isLoading: isLoadingTravelAuthorization,
   fetch: fetchTravelAuthorization,
-} = useTravelAuthorization()
+} = useTravelAuthorization(props.travelAuthorizationId)
 const travelAuthorizationUser = computed(() => travelAuthorization.value?.user)
 
 watch(
   () => props.travelAuthorizationId,
   async () => {
-    await fetchTravelAuthorization(props.travelAuthorizationId)
+    await fetchTravelAuthorization()
   },
   { immediate: true }
 )

--- a/web/src/modules/travel-authorizations/pages/ManageTravelAuthorizationDetailsPage.vue
+++ b/web/src/modules/travel-authorizations/pages/ManageTravelAuthorizationDetailsPage.vue
@@ -54,6 +54,7 @@ defineProps({
   },
 })
 
+/** @type {import('vue').Ref<InstanceType<typeof ApprovalsCard> | null>} */
 const approvalsCard = ref(null)
 
 function refresh() {

--- a/web/src/modules/travel-authorizations/pages/ManageTravelAuthorizationDetailsPage.vue
+++ b/web/src/modules/travel-authorizations/pages/ManageTravelAuthorizationDetailsPage.vue
@@ -12,12 +12,19 @@
     </v-row>
     <v-row>
       <v-col>
-        <ApprovalsCard :travel-authorization-id="travelAuthorizationId" />
+        <ApprovalsCard
+          ref="approvalsCard"
+          :travel-authorization-id="travelAuthorizationId"
+        />
       </v-col>
     </v-row>
     <v-row>
       <v-col>
-        <ManagementCard :travel-authorization-id="travelAuthorizationId" />
+        <ManagementCard
+          :travel-authorization-id="travelAuthorizationId"
+          @approved="refresh"
+          @denied="refresh"
+        />
       </v-col>
     </v-row>
     <div class="d-flex justify-end">
@@ -32,6 +39,8 @@
 </template>
 
 <script setup>
+import { ref } from "vue"
+
 import PurposeCard from "@/modules/travel-authorizations/components/read-travel-authorization-details-page/PurposeCard"
 import DetailsCard from "@/modules/travel-authorizations/components/read-travel-authorization-details-page/DetailsCard"
 import ApprovalsCard from "@/modules/travel-authorizations/components/read-travel-authorization-details-page/ApprovalsCard"
@@ -44,4 +53,10 @@ defineProps({
     required: true,
   },
 })
+
+const approvalsCard = ref(null)
+
+function refresh() {
+  approvalsCard.value.refresh()
+}
 </script>

--- a/web/src/use/travel-authorization.js
+++ b/web/src/use/travel-authorization.js
@@ -54,6 +54,42 @@ export function useTravelAuthorization(travelAuthorizationId) {
   }
 
   // Stateful actions
+  async function approve() {
+    state.isLoading = true
+    try {
+      const { travelAuthorization } = await travelAuthorizationsApi.approve(
+        unref(travelAuthorizationId)
+      )
+      state.isErrored = false
+      state.travelAuthorization = travelAuthorization
+      return travelAuthorization
+    } catch (error) {
+      console.error("Failed to approve for travel authorization:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  async function deny() {
+    state.isLoading = true
+    try {
+      const { travelAuthorization } = await travelAuthorizationsApi.deny(
+        unref(travelAuthorizationId)
+      )
+      state.isErrored = false
+      state.travelAuthorization = travelAuthorization
+      return travelAuthorization
+    } catch (error) {
+      console.error("Failed to deny for travel authorization:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
   async function expenseClaim(attributes) {
     state.isLoading = true
     try {
@@ -73,11 +109,16 @@ export function useTravelAuthorization(travelAuthorizationId) {
     }
   }
 
+  // TODO: switch to auto-fetching by adding a watch immediate here
+
   return {
     STATUSES,
     ...toRefs(state),
     fetch,
     save,
+    // stateful action
+    approve,
+    deny,
     expenseClaim,
   }
 }

--- a/web/src/use/travel-authorization.js
+++ b/web/src/use/travel-authorization.js
@@ -1,8 +1,8 @@
-import { reactive, toRefs } from "vue"
+import { reactive, toRefs, unref } from "vue"
 
 import travelAuthorizationsApi, { STATUSES } from "@/api/travel-authorizations-api"
 
-export function useTravelAuthorization() {
+export function useTravelAuthorization(travelAuthorizationId) {
   const state = reactive({
     travelAuthorization: {
       expenses: [],
@@ -15,11 +15,11 @@ export function useTravelAuthorization() {
     isErrored: false,
   })
 
-  async function fetch(travelAuthorizationId, params = {}) {
+  async function fetch(params = {}) {
     state.isLoading = true
     try {
       const { travelAuthorization } = await travelAuthorizationsApi.get(
-        travelAuthorizationId,
+        unref(travelAuthorizationId),
         params
       )
       state.isErrored = false
@@ -38,7 +38,7 @@ export function useTravelAuthorization() {
     state.isLoading = true
     try {
       const { travelAuthorization } = await travelAuthorizationsApi.update(
-        state.travelAuthorization.id,
+        unref(travelAuthorizationId),
         state.travelAuthorization
       )
       state.isErrored = false
@@ -54,11 +54,11 @@ export function useTravelAuthorization() {
   }
 
   // Stateful actions
-  async function expenseClaim(travelAuthorizationId, attributes) {
+  async function expenseClaim(attributes) {
     state.isLoading = true
     try {
       const { travelAuthorization } = await travelAuthorizationsApi.expenseClaim(
-        travelAuthorizationId,
+        unref(travelAuthorizationId),
         attributes
       )
       state.isErrored = false


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/153

# Context

When I approve a TA (eg. hit the Approve Button navigating to the TA from the manager view page).  There is a pop-up saying that the approval was complete shows up.  But I still have access to the approve and decline buttons.  These should no longer be available and the approval should be written to the audit table above.

![image](https://github.com/icefoganalytics/travel-authorization/assets/89539008/39f62847-f14b-4b7b-91f0-9e6aae54c3b0)

# Implementation

Enable reactivity between approve/deny buttons and TravelAuthorizationActionLogsTable with standard pattern of exposing "refresh" and emiting updates.
Upgrade useTravelAuthorization pattern to use reactive props.
Lock approve/deny buttons after use.

# Screenshots

Before approval
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/61411423-83f9-45b0-9017-f76d8ce24c4e)

After approval ->  buttons disabled
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/e2c07107-51a3-4396-ac77-394acc835c23)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the My Travel Requests page via the top drop down nav.
5. Create a new Travel Authorization via the call-to-action button.
6. Fill in the Details section and Generate the estimates.
7. Submit the travel authorization to yourself.
8. Go to the Manager View page and click on the record in the Pending Approvals table.
9. Click the approve or deny button at the bottom.
10. Note that the action log table gets updated, and the buttons are now disabled.
