### PR TITLE
General Ledger Coding Format

### DIFF
--- a/api/src/db/migrations/20240115160048_re-size-general-ledger-coding-gl-code-field.ts
+++ b/api/src/db/migrations/20240115160048_re-size-general-ledger-coding-gl-code-field.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("general_ledger_codings", (table) => {
+    table.string("code", 26).notNullable().alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("general_ledger_codings", (table) => {
+    table.string("code", 25).alter()
+  })
+}

--- a/api/src/initializers/20-run-migrations.ts
+++ b/api/src/initializers/20-run-migrations.ts
@@ -12,7 +12,7 @@ async function runMigrations(): Promise<void> {
     .reduce(async (previousMigration, migration) => {
       await previousMigration
 
-      console.log(`Running migration: ${migration}`)
+      console.log(`Running migration:`, migration)
       return knex.migrate.up()
     }, Promise.resolve())
     .then(() => {

--- a/api/src/models/general-ledger-coding.ts
+++ b/api/src/models/general-ledger-coding.ts
@@ -71,8 +71,8 @@ GeneralLedgerCoding.init(
       allowNull: false,
       validate: {
         is: {
-          args: /^[a-zA-Z0-9]{3}-[a-zA-Z0-9]{6}-\d{4}-[a-zA-Z0-9]{0,4}-[a-zA-Z0-9]{0,5}$/,
-          msg: "Code must be in the format 'vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters)'",
+          args: /^[a-zA-Z0-9]{3}-[a-zA-Z0-9]{6}-\d{4}(?:-[a-zA-Z0-9]{1,4}(?:-[a-zA-Z0-9]{1,5})?)?$/,
+          msg: "Code must be in the format: vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters)",
         },
       },
     },

--- a/api/src/models/general-ledger-coding.ts
+++ b/api/src/models/general-ledger-coding.ts
@@ -67,8 +67,14 @@ GeneralLedgerCoding.init(
     // See https://www.tpsgc-pwgsc.gc.ca/recgen/pceaf-gwcoa/2223/2-eng.html
     // Department / Agency 	Financial Reporting Account (FRA) 	Authority 	Program 	Object 	Transaction Type
     code: {
-      type: DataTypes.STRING(25),
+      type: DataTypes.STRING(26),
       allowNull: false,
+      validate: {
+        is: {
+          args: /^[a-zA-Z0-9]{3}-[a-zA-Z0-9]{6}-\d{4}-[a-zA-Z0-9]{0,4}-[a-zA-Z0-9]{0,5}$/,
+          msg: "Code must be in the format 'vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters)'",
+        },
+      },
     },
     // Postgres decimal types are represented as strings, so much be converted to numbers JS side.
     // See https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL

--- a/api/tests/models/general-ledger-coding.test.ts
+++ b/api/tests/models/general-ledger-coding.test.ts
@@ -1,0 +1,37 @@
+import { GeneralLedgerCoding } from "@/models"
+
+describe("api/src/models/general-ledger-coding.ts", () => {
+  describe("GeneralLedgerCoding", () => {
+    describe("#code - validity - Code must be in the format: vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters)", () => {
+      test.each([
+        ["123-123456-1234", true],
+        ["123-123456-1234-", false],
+        ["123-123456-1234-1", true],
+        ["123-123456-1234-1-", false],
+        ["123-123456-1234-1234", true],
+        ["123-123456-1234-12345", false],
+        ["123-123456-1234-1-1", true],
+        ["123-123456-1234-1-12345", true],
+        ["123-123456-1234-1-123456", false],
+        ["123-123456-1234-1234-12345", true],
+      ])('.isValid("%s") == %s', async (code, expected) => {
+        const modelInstance = GeneralLedgerCoding.build({
+          travelAuthorizationId: -1, // not relevant to this test
+          amount: 0, // not relevant to this test
+          code,
+        })
+        let isValid
+        try {
+          await modelInstance.validate()
+          isValid = true
+        } catch (error: any) {
+          expect(error.message).toBe(
+            "Validation error: Code must be in the format: vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters)"
+          )
+          isValid = false
+        }
+        expect(isValid).toBe(expected)
+      })
+    })
+  })
+})

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -30,7 +30,7 @@
             <v-col>
               <v-text-field
                 v-model="generalLedgerCoding.code"
-                :rules="[required]"
+                :rules="[isGeneralLedgerCode]"
                 dense
                 outlined
                 required
@@ -95,7 +95,7 @@ import { ref, watch, nextTick } from "vue"
 import { useRoute, useRouter } from "vue2-helpers/vue-router"
 
 import { useSnack } from "@/plugins/snack-plugin"
-import { required } from "@/utils/validators"
+import { required, isGeneralLedgerCode } from "@/utils/validators"
 
 import generalLedgerCodingsApi from "@/api/general-ledger-codings-api"
 

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -29,9 +29,27 @@
               <v-text-field
                 v-model="generalLedgerCoding.code"
                 :rules="[required]"
-                label="Vote/Program/Object/Sub1/Sub2"
+                dense
+                outlined
                 required
-              ></v-text-field>
+              >
+                <template #label>
+                  <v-tooltip bottom>
+                    <template #activator="{ on }">
+                      <div v-on="on">
+                        G/L code
+                        <v-icon small> mdi-help-circle-outline </v-icon>
+                      </div>
+                    </template>
+                    <span>
+                      e.g. 552-123456-2015-1234-12345
+                      <br />
+                      The format is vote (3 characters) - Program (6 characters) - object code (4
+                      digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters).</span
+                    >
+                  </v-tooltip>
+                </template>
+              </v-text-field>
             </v-col>
           </v-row>
           <v-row>
@@ -40,6 +58,8 @@
                 v-model="generalLedgerCoding.amount"
                 :rules="[required]"
                 label="Amount"
+                dense
+                outlined
                 required
               />
             </v-col>

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -28,6 +28,7 @@
         <v-card-text>
           <v-row>
             <v-col>
+              <!-- See https://github.com/icefoganalytics/travel-authorization/issues/156#issuecomment-1890047168 -->
               <v-text-field
                 v-model="generalLedgerCoding.code"
                 :rules="[isGeneralLedgerCode]"

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -31,6 +31,7 @@
               <v-text-field
                 v-model="generalLedgerCoding.code"
                 :rules="[isGeneralLedgerCode]"
+                validate-on-blur
                 dense
                 outlined
                 required

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -1,8 +1,8 @@
 <template>
   <v-dialog
     v-model="showDialog"
-    persistent
     max-width="500px"
+    persistent
     @keydown.esc="close"
   >
     <template #activator="{ on, attrs }">

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -1,7 +1,9 @@
 <template>
   <v-dialog
     v-model="showDialog"
+    persistent
     max-width="500px"
+    @keydown.esc="close"
   >
     <template #activator="{ on, attrs }">
       <v-btn

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingEditDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingEditDialog.vue
@@ -2,6 +2,8 @@
   <v-dialog
     v-model="showDialog"
     max-width="500px"
+    persistent
+    @keydown.esc="close"
   >
     <v-form
       ref="form"

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingEditDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingEditDialog.vue
@@ -15,16 +15,32 @@
         <v-card-text>
           <v-row>
             <v-col>
-              <!--
-                See https://www.tpsgc-pwgsc.gc.ca/recgen/pceaf-gwcoa/2223/2-eng.html
-                Department/Agency, Financial Reporting Account (FRA), Authority, Program, Object, Transaction Type
-              -->
+              <!-- See https://github.com/icefoganalytics/travel-authorization/issues/156#issuecomment-1890047168 -->
               <v-text-field
                 v-model="generalLedgerCoding.code"
-                :rules="[required]"
-                label="Vote/Program/Object/Sub1/Sub2"
+                :rules="[isGeneralLedgerCode]"
+                validate-on-blur
+                dense
+                outlined
                 required
-              ></v-text-field>
+              >
+                <template #label>
+                  <v-tooltip bottom>
+                    <template #activator="{ on }">
+                      <div v-on="on">
+                        G/L code
+                        <v-icon small> mdi-help-circle-outline </v-icon>
+                      </div>
+                    </template>
+                    <span>
+                      e.g. 552-123456-2015-1234-12345
+                      <br />
+                      The format is vote (3 characters) - Program (6 characters) - object code (4
+                      digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters).</span
+                    >
+                  </v-tooltip>
+                </template>
+              </v-text-field>
             </v-col>
           </v-row>
           <v-row>
@@ -33,6 +49,8 @@
                 v-model="generalLedgerCoding.amount"
                 :rules="[required]"
                 label="Amount"
+                dense
+                outlined
                 required
               />
             </v-col>
@@ -69,7 +87,7 @@ import { useRoute, useRouter } from "vue2-helpers/vue-router"
 import { useSnack } from "@/plugins/snack-plugin"
 
 import generalLedgerCodingsApi from "@/api/general-ledger-codings-api"
-import { required } from "@/utils/validators"
+import { required, isGeneralLedgerCode } from "@/utils/validators"
 import CurrencyTextField from "@/components/Utils/CurrencyTextField"
 
 const emit = defineEmits(["saved"])

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue
@@ -16,6 +16,22 @@
         @deleted="emitChangedAndRefresh"
       />
     </template>
+    <template #header.code="{ header }">
+      <v-tooltip bottom>
+        <template #activator="{ on }">
+          <span v-on="on">
+            {{ header.text }}
+            <v-icon small> mdi-help-circle-outline </v-icon>
+          </span>
+        </template>
+        <span>
+          e.g. 552-123456-2015-1234-12345
+          <br />
+          The format is vote (3 characters) - Program (6 characters) - object code (4 digits) -
+          subledger-1 (0-4 characters) - subleger-2 (0-5 characters).</span
+        >
+      </v-tooltip>
+    </template>
     <template #item.amount="{ value }">
       {{ formatCurrency(value) }}
     </template>
@@ -80,7 +96,7 @@ const { generalLedgerCodings, isLoading, fetch } = useGeneralLedgerCodings()
 const totalAmount = computed(() => sumBy(generalLedgerCodings.value, "amount"))
 
 const headers = ref([
-  { text: "Vote/Program/Object/Sub1/Sub2", value: "code" },
+  { text: "G/L code", value: "code" },
   { text: "Amount", value: "amount" },
   { text: "", value: "actions" },
 ])

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingsTable.vue
@@ -17,6 +17,7 @@
       />
     </template>
     <template #header.code="{ header }">
+      <!-- See https://github.com/icefoganalytics/travel-authorization/issues/156#issuecomment-1890047168 -->
       <v-tooltip bottom>
         <template #activator="{ on }">
           <span v-on="on">

--- a/web/src/utils/validators.js
+++ b/web/src/utils/validators.js
@@ -8,7 +8,13 @@ export const greaterThanOrEqualToDate =
     new Date(a) >= new Date(b) ||
     `This field must be greater than or equal to ${b || referenceFieldLabel}`
 
+// See api/src/models/general-ledger-coding.ts -> code -> validate
+export const isGeneralLedgerCode = (v) =>
+  /^[a-zA-Z0-9]{3}-[a-zA-Z0-9]{6}-\d{4}(?:-[a-zA-Z0-9]{1,4}(?:-[a-zA-Z0-9]{1,5})?)?$/.test(v) ||
+  "Code must be in the format: vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger-1 (0-4 characters) - subleger-2 (0-5 characters)"
+
 export default {
+  isGeneralLedgerCode,
   greaterThanOrEqualToDate,
   required,
 }


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/156

# Context

On the Expense Form (https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/84/expense/edit?showEdit=1)
Coding Card

Can you update the coding to be accepted with hyphens rather than slashes?  Matches other data entry methods
eg. 552-123456-2015-1234-12345 rather than 552/123456/2015/1234/12345

a gl can be 26 characters I get the following error when I enter a valid gl code. "General ledger coding update failed: SequelizeDatabaseError: value too long for type character varying(25)"

The format is vote (3 characters) - Program (6 characters) - object code (4 digits) - subledger 1 (0-4 characters) - subleger 2 (0-5 characters)

# Implementation

Increase size of general ledger code field.
Add validation to field in front- and back-end.
Add some tests for the validation.
Put a bunch of tooltips in the UI.

# Screenshots

Create G/L code field
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/274076ac-114b-40f6-898b-a13f659c5845)

Edit G/L code field
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/e0d9a8c2-ab45-408a-9d98-277e291bbcc0)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the My Travel Request page via the top drop down nav.
5. Create a travel authorization via the "+ Travel Authorization" button.
6. Fill in the Details section.
7. Generate the Estimate.
8. Submit to yourself as the supervisor.
9. Go to the Manager View via the top drop down nav.
10. Find your travel request in the "Pending Approvals" section and click on it.
11. Scroll to the bottom and approve the request.
12. Go back to the My Travel Request page via the top drop down nav.
13. Find your travel request in the table and click on it.
14. Go to the Expense tab.
15. Scroll down and click on the Add Coding button.
16. Check out the validation and create a code.
17. Check out the tooltip on the Coding table.
18. Click the Edit button on the coding table, check out the validation.
19. Save the coding.
