### PR TITLE
Standardize Timezone Handling To UTC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ RUN apk add --no-cache \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
+# Persists TZ=UTC effect after container build and into container run
+# Ensures dates/times are consistently formated as UTC
+# Conversion to local time should happen in the UI
+ENV TZ=UTC
+
 ENV NODE_ENV=production
 USER node
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -2,6 +2,7 @@ version: "3"
 
 x-default-environment: &default-environment
   NODE_ENV: development
+  TZ: "UTC"
   AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com"
   AUTH0_AUDIENCE: testing
   DB_HOST: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     env_file:
       - .env
     environment:
+      TZ: "UTC"
       POSTGRES_USER: "${DB_USER}"
       POSTGRES_PASSWORD: "${DB_PASS}"
       POSTGRES_DB: "${DB_NAME}"


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/157

Relates to:
- https://github.com/icefoganalytics/elcc-data-management/pull/73/files

# Context

Using the pattern developed in the elcc-data-management project, make sure that all app components use UTC by default.
Time related data should only be converted to the User's timezone at the last minute, when displaying the data.

# Implementation

:globe_with_meridians: Enforce UTC timezone in development and production builds.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Not sure how to test the time settings as I haven't noticed anything weird about time stuff in this app. I looked around in production as well, but haven't seen anything with dates being weird.
