### PR TITLE
Travel Desk Request to Tab

### DIFF
--- a/web/src/modules/travelDesk/router/index.js
+++ b/web/src/modules/travelDesk/router/index.js
@@ -4,12 +4,12 @@ const routes = [
     component: () => import("@/layouts/Layout"),
     children: [
       {
-        name: "TravelDeskHome",
+        name: "TravelDesk",
         path: "",
         meta: {
           requiresAuth: true,
         },
-        component: () => import("../views/TravelDesk.vue"),
+        component: () => import("@/modules/travelDesk/views/TravelDesk.vue"),
       },
     ],
   },
@@ -18,15 +18,15 @@ const routes = [
     component: () => import("@/layouts/Layout"),
     children: [
       {
-        name: "TravelRequestHome",
+        name: "TravelRequest",
         path: "",
         meta: {
           requiresAuth: true,
         },
-        component: () => import("../views/TravelRequest.vue"),
+        component: () => import("@/modules/travelDesk/views/TravelRequest.vue"),
       },
     ],
   },
-];
+]
 
-export default routes;
+export default routes

--- a/web/src/modules/travelDesk/views/Requests/TravelerRequests.vue
+++ b/web/src/modules/travelDesk/views/Requests/TravelerRequests.vue
@@ -1,114 +1,128 @@
 <template>
-	<div class="mx-10 mb-5">
-		<v-data-table
-			:headers="headers"
-			:items="authorizedTravels"
-			:items-per-page="15"
-			class="elevation-1 mt-4">
+  <div class="mx-10 mb-5">
+    <v-data-table
+      :headers="headers"
+      :items="authorizedTravels"
+      :items-per-page="15"
+      class="elevation-1 mt-4"
+    >
+      <template #item.name="{ item }">
+        {{ item.name.replace(".", " ") }}
+      </template>
 
-			<template v-slot:[`item.name`]="{ item }">
-				{{item.name.replace('.', ' ')}}
-			</template>			
+      <template #item.location="{ item }">
+        {{ getLocationName(item.locationIds) }}
+      </template>
 
-			<template v-slot:[`item.location`]="{ item }">
-				{{getLocationName(item.locationIds)}}
-			</template>
+      <template #item.startDate="{ item }">
+        <div v-if="item.dateUnkInd">
+          {{ item.month }}
+        </div>
+        <div v-else>
+          <div>
+            {{ item.startDate | beautifyDate }}
+          </div>
+        </div>
+      </template>
+      <template #item.endDate="{ item }">
+        <div v-if="item.dateUnkInd">
+          {{ item.month }}
+        </div>
+        <div v-else>
+          <div>
+            {{ item.endDate | beautifyDate }}
+          </div>
+        </div>
+      </template>
 
-			<template v-slot:[`item.startDate`]="{ item }">
-				<div v-if="item.dateUnkInd">
-					{{ item.month }}
-				</div>
-				<div v-else>
-					<div>						
-						{{ item.startDate | beautifyDate }}
-					</div>					
-				</div>
-			</template>
-			<template v-slot:[`item.endDate`]="{ item }">
-				<div v-if="item.dateUnkInd">
-					{{ item.month }}
-				</div>
-				<div v-else>					
-					<div>						
-						{{ item.endDate | beautifyDate }}
-					</div>
-				</div>
-			</template>
-
-			<template v-slot:[`item.edit`]="{ item }">
-				<new-travel-desk-request
-					v-if="item.status=='Approved' && item.phase != 'Travel Arrangements Requested' && item.phase != 'Options Ranked' && item.phase != 'Booked'"
-					:type="(item.phase=='Travel Approved' || item.phase=='Request Draft')? 'Submit': 'Review'"
-					@updateTable="updateTable()"
-					:authorizedTravel="item"/>
-				<itinerary-modal 
-					v-if="item.status=='Approved' && item.phase == 'Booked' && item.invoiceNumber"
-					:invoiceNumber="item.invoiceNumber"					
-					/>
-			</template>
-		</v-data-table>
-	</div>
+      <template #item.edit="{ item }">
+        <NewTravelDeskRequest
+          v-if="
+            item.status == 'Approved' &&
+            item.phase != 'Travel Arrangements Requested' &&
+            item.phase != 'Options Ranked' &&
+            item.phase != 'Booked'
+          "
+          :type="
+            item.phase == 'Travel Approved' || item.phase == 'Request Draft' ? 'Submit' : 'Review'
+          "
+          :authorized-travel="item"
+          @updateTable="updateTable"
+        />
+        <ItineraryModal
+          v-if="item.status == 'Approved' && item.phase == 'Booked' && item.invoiceNumber"
+          :invoice-number="item.invoiceNumber"
+        />
+      </template>
+    </v-data-table>
+  </div>
 </template>
 
 <script>
-	import Vue from "vue";
-	import NewTravelDeskRequest from "./NewTravelDeskRequest.vue";
-	import ItineraryModal from './Components/ItineraryModal.vue';
+import Vue from "vue"
+import NewTravelDeskRequest from "@/modules/travelDesk/views/Requests/NewTravelDeskRequest.vue"
+import ItineraryModal from "@/modules/travelDesk/views/Requests/Components/ItineraryModal.vue"
 
-	export default {
-		components: {
-			NewTravelDeskRequest,
-			ItineraryModal
-		},
-		name: "TravelerRequests",
-		props: {
-			authorizedTravels: {
-				type: []
-			}
-		},
-		data() {
-			return {
-				headers: [	
-					{ text: "Name",				  value: "name",		class: "blue-grey lighten-4"},			
-					{ text: "Phase",			  value: "phase",		class: "blue-grey lighten-4"},
-					{ text: "Location",			  value: "location",	class: "blue-grey lighten-4"},
-					{ text: "Description", 		  value: "description", class: "blue-grey lighten-4"},
-					{ text: "Start Date",		  value: "startDate",	class: "blue-grey lighten-4"},
-					{ text: "End Date", 		  value: "endDate",		class: "blue-grey lighten-4"},
-					{ text: "Travel Auth Status", value: "status", 		class: "blue-grey lighten-4"},
-					{ text: "Travel Action", 	  value: "edit",	    class: "blue-grey lighten-4", cellClass: "px-0 mx-0",sortable: false}
-				],
-				admin: false,
-				department: "",				
-			};
-		},
-		mounted() {
-			this.department = this.$store.state.auth?.department
-			this.admin = Vue.filter("isAdmin")();
-		},
-		computed: {},
-		methods: {
-			updateTable() {
-				this.$emit("updateTable");
-			},
-			getLocationName(locations){
-				const names = []
-				const destinations = this.$store.state.traveldesk.destinations; 
-				for(const locationId of locations){
-					const location = destinations.filter(dest =>dest.value==locationId)
-					if (location.length > 0){
-						names.push(location[0].text)
-					}
-					
-				}
-				return names.join(', ')
-			}
-		}
-	};
+export default {
+  name: "TravelerRequests",
+  components: {
+    NewTravelDeskRequest,
+    ItineraryModal,
+  },
+  props: {
+    authorizedTravels: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data() {
+    return {
+      headers: [
+        { text: "Name", value: "name", class: "blue-grey lighten-4" },
+        { text: "Phase", value: "phase", class: "blue-grey lighten-4" },
+        { text: "Location", value: "location", class: "blue-grey lighten-4" },
+        { text: "Description", value: "description", class: "blue-grey lighten-4" },
+        { text: "Start Date", value: "startDate", class: "blue-grey lighten-4" },
+        { text: "End Date", value: "endDate", class: "blue-grey lighten-4" },
+        { text: "Travel Auth Status", value: "status", class: "blue-grey lighten-4" },
+        {
+          text: "Travel Action",
+          value: "edit",
+          class: "blue-grey lighten-4",
+          cellClass: "px-0 mx-0",
+          sortable: false,
+        },
+      ],
+      admin: false,
+      department: "",
+    }
+  },
+  computed: {},
+  mounted() {
+    this.department = this.$store.state.auth?.department
+    this.admin = Vue.filter("isAdmin")()
+  },
+  methods: {
+    updateTable() {
+      this.$emit("updateTable")
+    },
+    getLocationName(locations) {
+      const names = []
+      const destinations = this.$store.state.traveldesk.destinations
+      for (const locationId of locations) {
+        const location = destinations.filter((dest) => dest.value == locationId)
+        if (location.length > 0) {
+          names.push(location[0].text)
+        }
+      }
+      return names.join(", ")
+    },
+  },
+}
 </script>
 
 <style scoped>
-	::v-deep(tbody tr:nth-of-type(even)) {
-		background-color: rgba(0, 0, 0, 0.05);
-	}
+::v-deep(tbody tr:nth-of-type(even)) {
+  background-color: rgba(0, 0, 0, 0.05);
+}
 </style>

--- a/web/src/modules/travelDesk/views/TravelRequest.vue
+++ b/web/src/modules/travelDesk/views/TravelRequest.vue
@@ -1,136 +1,159 @@
 <template>
-    <v-card :loading="loadingData" :disabled="loadingData" en class="px-5 pb-15">
-        <div v-if="loadingData" class="mt-10" style="text-align: center">loading ...</div>
+  <v-card
+    :loading="loadingData"
+    :disabled="loadingData"
+    en
+    class="px-5 pb-15"
+  >
+    <div
+      v-if="loadingData"
+      class="mt-10"
+      style="text-align: center"
+    >
+      loading ...
+    </div>
 
-        <div v-else>
-            <v-toolbar  class="" height="100px" flat>
-                <v-toolbar-title>
-                    <b>Travel Status </b>
-                    <b v-if="admin" class="mt-4 blue--text">( {{department}} )</b>
-                </v-toolbar-title>
-            </v-toolbar>
-            <v-card>
-                <traveler-requests :authorizedTravels="authorizedTravels" @updateTable="getAuthorizedTravels()" />
-            </v-card>
-        </div>
-
-    </v-card>
+    <div v-else>
+      <v-toolbar
+        class=""
+        height="100px"
+        flat
+      >
+        <v-toolbar-title>
+          <b>Travel Status </b>
+          <b
+            v-if="admin && department"
+            class="mt-4 blue--text"
+            >( {{ department }} )</b
+          >
+        </v-toolbar-title>
+      </v-toolbar>
+      <v-card>
+        <TravelerRequests
+          :authorized-travels="authorizedTravels"
+          @updateTable="getAuthorizedTravels"
+        />
+      </v-card>
+    </div>
+  </v-card>
 </template>
 
 <script>
-    import Vue from "vue";
-    import TravelerRequests from "./Requests/TravelerRequests.vue";
-    import { TRAVEL_DESK_URL, PROFILE_URL} from "../../../urls";
-    import { secureGet } from "../../../store/jwt";
-    import locationsApi from "@/api/locations-api"
+import Vue from "vue"
+import { isNil } from "lodash"
 
-    export default {
+import { TRAVEL_DESK_URL, PROFILE_URL } from "@/urls"
+import { secureGet } from "@/store/jwt"
+import locationsApi from "@/api/locations-api"
 
-        name: "TravelRequest",
-        components: {
-            TravelerRequests
-        },
-        data() {
-            return {
-                tabs: null,
-                authorizedTravels: [],
-                loadingData: false,
-                department: "",
-                admin: false
-            };
-        },
-        async mounted() {
-            this.loadingData=true
-            // await this.getUserAuth();
-            this.department = this.$store.state.auth.department
-            this.admin = Vue.filter("isAdmin")();
-            await this.getDestinations();
-            await this.getAuthorizedTravels()
-            this.loadingData=false
-        },
+import TravelerRequests from "@/modules/travelDesk/views/Requests/TravelerRequests.vue"
 
-        methods: {
+export default {
+  name: "TravelRequest",
+  components: {
+    TravelerRequests,
+  },
+  data() {
+    return {
+      tabs: null,
+      authorizedTravels: [],
+      loadingData: false,
+      department: "",
+      admin: false,
+    }
+  },
+  async mounted() {
+    this.loadingData = true
+    // await this.getUserAuth();
+    this.department = this.$store.state.auth.department
+    this.admin = Vue.filter("isAdmin")()
+    await this.getDestinations()
+    await this.getAuthorizedTravels()
+    this.loadingData = false
+  },
 
-            async getUserAuth() {
-                return secureGet(`${PROFILE_URL}`)
-                    .then(resp => {
-                        this.$store.commit("auth/setUser", resp.data.user);
-                    })
-                    .catch(e => {
-                        console.log(e);
-                    });
-            },
+  methods: {
+    async getUserAuth() {
+      return secureGet(PROFILE_URL)
+        .then((resp) => {
+          this.$store.commit("auth/setUser", resp.data.user)
+        })
+        .catch((e) => {
+          console.log(e)
+        })
+    },
 
-            async getDestinations() {
-                return locationsApi.list().then(({ locations }) => {
-                    const formattedLocations = locations.map(({ id, city, province }) => {
-                        return {
-                            value: id,
-                            text: `${city} (${province})`,
-                            city,
-                            province,
-                        }
-                    })
-                    this.$store.commit("traveldesk/SET_DESTINATIONS", formattedLocations)
-                    return formattedLocations
-                })
-            },
+    async getDestinations() {
+      return locationsApi.list().then(({ locations }) => {
+        const formattedLocations = locations.map(({ id, city, province }) => {
+          return {
+            value: id,
+            text: `${city} (${province})`,
+            city,
+            province,
+          }
+        })
+        this.$store.commit("traveldesk/SET_DESTINATIONS", formattedLocations)
+        return formattedLocations
+      })
+    },
 
-            async getAuthorizedTravels() {
-                this.loadingData=true
-                return secureGet(`${TRAVEL_DESK_URL}/authorized-travels/`)
-                .then(resp => {
-                    const authorizedTravels = resp.data;
-                    this.extractAuthorizedTravels(authorizedTravels);
-                    this.loadingData=false
-                })
-                .catch(e => {
-                    console.log(e);
-                    this.loadingData=false
-                });
-            },
+    async getAuthorizedTravels() {
+      this.loadingData = true
+      return secureGet(`${TRAVEL_DESK_URL}/authorized-travels`)
+        .then((resp) => {
+          const authorizedTravels = resp.data
+          this.extractAuthorizedTravels(authorizedTravels)
+          this.loadingData = false
+        })
+        .catch((e) => {
+          console.log(e)
+          this.loadingData = false
+        })
+    },
 
-            extractAuthorizedTravels(authorizedTravels) {
+    extractAuthorizedTravels(authorizedTravels) {
+      // console.log(authorizedTravels)
+      this.authorizedTravels = []
 
-                // console.log(authorizedTravels)
-                this.authorizedTravels = []
+      for (const authorizedTravel of authorizedTravels) {
+        // console.log(authorizedTravel)
+        const phase = this.determineTravelPhase(authorizedTravel)
 
-                for(const authorizedTravel of authorizedTravels){
-                    // console.log(authorizedTravel)
-                    const phase = this.determineTravelPhase(authorizedTravel)
+        const status =
+          authorizedTravel.status == "Approved" ? "Approved" : "Awaiting Director Approval"
 
-
-                    const status = authorizedTravel.status=="Approved"? 'Approved':'Awaiting Director Approval'
-
-                    const startDate = new Date(authorizedTravel.dateBackToWork.slice(0,10) +'T01:00:00.000Z');
-                    //console.log(startDate.toUTCString())
-                    startDate.setDate(startDate.getDate()-1*Number(authorizedTravel.travelDuration));
-                    // console.log(startDate.toISOString())
-                    // console.log(startDate.toUTCString())
-
-                    const locationIds = authorizedTravel.stops.map(stop => stop.locationId)
-
-                    this.authorizedTravels.push({
-                        id: authorizedTravel.id,
-                        email: authorizedTravel.email,
-                        phase: phase,
-                        name: authorizedTravel.firstName + ' ' + authorizedTravel.lastName,
-                        locationIds: locationIds,
-                        description: authorizedTravel.purpose,
-                        startDate: startDate.toISOString(),
-                        endDate:  authorizedTravel.dateBackToWork,
-                        status: status,
-                        invoiceNumber: authorizedTravel.travelRequest?.invoiceNumber
-                    })
-
-                }
-            },
-
-            determineTravelPhase(authorizedTravel){
-                if(authorizedTravel.status!="Approved") return 'Authorization'
-                if(!authorizedTravel?.travelRequest?.status) return 'Travel Approved'
-                return Vue.filter("getTravelStatus")(authorizedTravel.travelRequest.status)
-            }
+        let startDate
+        if (!isNil(authorizedTravel.dateBackToWork)) {
+          startDate = new Date(authorizedTravel.dateBackToWork.slice(0, 10) + "T01:00:00.000Z")
+          //console.log(startDate.toUTCString())
+          startDate.setDate(startDate.getDate() - 1 * Number(authorizedTravel.travelDuration))
+          // console.log(startDate.toISOString())
+          // console.log(startDate.toUTCString())
         }
-};
+
+        const locationIds = authorizedTravel.stops.map((stop) => stop.locationId)
+
+        this.authorizedTravels.push({
+          id: authorizedTravel.id,
+          email: authorizedTravel.email,
+          phase: phase,
+          name: authorizedTravel.firstName + " " + authorizedTravel.lastName,
+          locationIds: locationIds,
+          description: authorizedTravel.purpose,
+          startDate: startDate?.toISOString(),
+          endDate: authorizedTravel.dateBackToWork,
+          status: status,
+          invoiceNumber: authorizedTravel.travelRequest?.invoiceNumber,
+        })
+      }
+    },
+
+    determineTravelPhase(authorizedTravel) {
+      if (authorizedTravel.status != "Approved") return "Authorization"
+      if (!authorizedTravel?.travelRequest?.status) return "Travel Approved"
+      return Vue.filter("getTravelStatus")(authorizedTravel.travelRequest.status)
+    },
+  },
+}
 </script>


### PR DESCRIPTION
Relates to:
- https://github.com/icefoganalytics/travel-authorization/issues/132

Move the existing Travel desk form to the travel request/travel desk tab.
https://github.com/ytgov/travel-authorization/tree/main/web/src/modules/travelDesk/views/Requests

as this is a prototype were possible just make it work. Note where changes should be made and we will include rework to another iteration.

See https://governmentofyukon.slack.com/archives/C04ETKKJS1X/p1701881666825959?thread_ts=1701879058.602759&cid=C04ETKKJS1X

# Implementation

:recycle: Unbreak and lint travel request page.

# Screenshots

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/6f9d8cbf-ed36-457d-81ea-e3f89d07863a)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to http://localhost:8080/travel-request and open the browser console with ctrl+shift+i.
5. Reload the page and check that there are no errors in the console.
