### PR TITLE
Supervisor: Travel Authorization: If I Decline, I Want To Provide a Reason

### DIFF
--- a/api/src/controllers/locations-controller.ts
+++ b/api/src/controllers/locations-controller.ts
@@ -4,10 +4,14 @@ import { Location } from "@/models"
 
 export class LocationsController extends BaseController {
   // TODO: support pagination and filtering, or replace with external api
-  index() {
-    return Location.findAll().then((locations) => {
-      return this.response.json({ locations })
-    })
+  async index() {
+    const locations = await Location.findAll()
+    return this.response.json({ locations })
+  }
+
+  async show() {
+    const location = await Location.findByPk(this.params.locationId)
+    return this.response.json({ location })
   }
 }
 

--- a/api/src/controllers/travel-authorizations/deny-controller.ts
+++ b/api/src/controllers/travel-authorizations/deny-controller.ts
@@ -24,7 +24,12 @@ export class DenyController extends BaseController {
         .json({ message: "You are not authorized to deny this travel authorization." })
     }
 
-    return TravelAuthorizations.DenyService.perform(travelAuthorization, this.currentUser)
+    const { denialReason } = this.request.body
+    return TravelAuthorizations.DenyService.perform(
+      travelAuthorization,
+      denialReason,
+      this.currentUser
+    )
       .then((travelAuthorization) => {
         const serializedTravelAuthorization =
           TravelAuthorizationsSerializer.asDetailed(travelAuthorization)

--- a/api/src/controllers/travel-authorizations/expenses/prefill-controller.ts
+++ b/api/src/controllers/travel-authorizations/expenses/prefill-controller.ts
@@ -40,12 +40,6 @@ export class PrefillController extends BaseController {
     return TravelAuthorization.findByPk(this.params.travelAuthorizationId, {
       include: [
         {
-          association: "expenses",
-          where: {
-            type: Expense.Types.ESTIMATE,
-          },
-        },
-        {
           association: "travelSegments",
           order: [["segmentNumber", "ASC"]],
         }

--- a/api/src/db/migrations/20240119220015_make-denial-reason-field-larger.ts
+++ b/api/src/db/migrations/20240119220015_make-denial-reason-field-larger.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("travel_authorizations", (table) => {
+    table.string("denial_reason", 2000).alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("travel_authorizations", (table) => {
+    table.string("denial_reason", 255).alter()
+  })
+}

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -392,7 +392,7 @@ TravelAuthorization.init(
       allowNull: true,
     },
     denialReason: {
-      type: DataTypes.STRING(255),
+      type: DataTypes.STRING(2000),
       allowNull: true,
     },
     // TODO: replace with string enum field using TripTypes

--- a/api/src/policies/expenses-policy.ts
+++ b/api/src/policies/expenses-policy.ts
@@ -31,7 +31,7 @@ export class ExpensesPolicy extends BasePolicy<Expense> {
       // state checks, that supersede roles
       // maybe shouldn't be in a policy?
       if (this.travelAuthorization?.status !== TravelAuthorization.Statuses.APPROVED) return false
-      if (!this.isAfterTravelStartDate) return false
+      if (!this.isAfterTravelStartDate()) return false
 
       if (this.user.roles.includes(User.Roles.ADMIN)) return true
       if (this.travelAuthorization.supervisorEmail === this.user.email) return true
@@ -65,7 +65,7 @@ export class ExpensesPolicy extends BasePolicy<Expense> {
     return new TravelAuthorizationsPolicy(this.user, this.travelAuthorization)
   }
 
-  private get isAfterTravelStartDate(): boolean {
+  private isAfterTravelStartDate(): boolean {
     if (this.travelSegments === undefined) return false
 
     const firstTravelSegment = this.travelSegments[0]

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -83,6 +83,7 @@ router
   .post(TravelAuthorizations.Expenses.PrefillController.create)
 
 router.route("/api/locations").get(LocationsController.index)
+router.route("/api/locations/:locationId").get(LocationsController.show)
 router.route("/api/pre-approved-travelers").get(PreApprovedTravelersController.index)
 router.route("/api/pre-approved-travel-requests").get(PreApprovedTravelRequestsController.index)
 

--- a/api/src/services/travel-authorizations/deny-service.ts
+++ b/api/src/services/travel-authorizations/deny-service.ts
@@ -5,11 +5,13 @@ import { TravelAuthorization, TravelAuthorizationActionLog, User } from "@/model
 
 export class DenyService extends BaseService {
   private travelAuthorization: TravelAuthorization
+  private denialReason: string | null
   private denier: User
 
-  constructor(travelAuthorization: TravelAuthorization, denier: User) {
+  constructor(travelAuthorization: TravelAuthorization, denialReason: string | null, denier: User) {
     super()
     this.travelAuthorization = travelAuthorization
+    this.denialReason = denialReason
     this.denier = denier
   }
 
@@ -17,8 +19,7 @@ export class DenyService extends BaseService {
     if (this.travelAuthorization.status === TravelAuthorization.Statuses.SUBMITTED) {
       await db.transaction(async () => {
         await this.travelAuthorization.update({
-          // TODO: add support for denial reason
-          // denialReason: "???",
+          denialReason: this.denialReason,
           status: TravelAuthorization.Statuses.DENIED,
         })
         await TravelAuthorizationActionLog.create({
@@ -33,8 +34,7 @@ export class DenyService extends BaseService {
     ) {
       await db.transaction(async () => {
         await this.travelAuthorization.update({
-          // TODO: add support for denial reason
-          // denialReason: "???",
+          denialReason: this.denialReason,
           status: TravelAuthorization.Statuses.EXPENSE_CLAIM_DENIED,
         })
         await TravelAuthorizationActionLog.create({

--- a/web/src/api/locations-api.js
+++ b/web/src/api/locations-api.js
@@ -2,8 +2,13 @@ import http from "@/api/http-client"
 
 export const locationsApi = {
   // TODO: support pagination and filtering
-  list() {
-    return http.get("/api/locations").then(({ data }) => data)
+  async list() {
+    const { data } = await http.get("/api/locations")
+    return data
+  },
+  async fetch(locationId) {
+    const { data } = await http.get(`/api/locations/${locationId}`)
+    return data
   },
 }
 

--- a/web/src/api/travel-authorizations-api.js
+++ b/web/src/api/travel-authorizations-api.js
@@ -51,10 +51,11 @@ export const travelAuthorizationsApi = {
       .post(`/api/travel-authorizations/${travelAuthorizationId}/approve`)
       .then(({ data }) => data)
   },
-  deny(travelAuthorizationId) {
-    return http
-      .post(`/api/travel-authorizations/${travelAuthorizationId}/deny`)
-      .then(({ data }) => data)
+  async deny(travelAuthorizationId, { denialReason } = {}) {
+    const { data } = await http.post(`/api/travel-authorizations/${travelAuthorizationId}/deny`, {
+      denialReason,
+    })
+    return data
   },
   expenseClaim(travelAuthorizationId, attributes) {
     return http

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ApproveTravelRequestDialogButton.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ApproveTravelRequestDialogButton.vue
@@ -1,0 +1,137 @@
+<template>
+  <v-dialog
+    v-model="showDialog"
+    width="500"
+  >
+    <template #activator="{ on, attrs }">
+      <v-btn
+        :loading="isLoading"
+        :disabled="isDisabled"
+        :class="buttonClasses"
+        color="success"
+        v-bind="attrs"
+        v-on="on"
+      >
+        Approve
+      </v-btn>
+    </template>
+
+    <v-form
+      ref="form"
+      @submit.prevent="denyAndClose"
+    >
+      <v-card>
+        <v-card-title class="text-h5"> Approve Request </v-card-title>
+
+        <v-card-text :loading="isLoading">
+          <p>
+            Approve travel of {{ requestorDisplayName }} to
+            <v-progress-circular
+              v-if="isLoadingLocation"
+              indeterminate
+              size="10"
+              width="1"
+              class="mx-2"
+            /><span v-else>{{ locationName }}</span
+            >?
+          </p>
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            :loading="isLoading"
+            color="secondary"
+            @click="close"
+            >Cancel</v-btn
+          >
+          <v-btn
+            :loading="isLoading"
+            color="success"
+            type="submit"
+            >Approve</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script setup>
+import { computed, ref, nextTick, watch } from "vue"
+import { useRoute, useRouter } from "vue2-helpers/vue-router"
+
+import { useSnack } from "@/plugins/snack-plugin"
+import { useTravelAuthorization } from "@/use/travel-authorization"
+import { useLocation } from "@/use/use-location"
+
+const props = defineProps({
+  travelAuthorizationId: {
+    type: Number,
+    required: true,
+  },
+  isDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  travelLocationId: {
+    type: Number,
+    required: true,
+  },
+  requestorDisplayName: {
+    type: String,
+    required: true,
+  },
+  buttonClasses: {
+    type: [String, Array, Object],
+    default: null,
+  },
+})
+
+const emit = defineEmits(["approved"])
+
+const route = useRoute()
+const router = useRouter()
+const snack = useSnack()
+const { isLoading, approve } = useTravelAuthorization(props.travelAuthorizationId)
+const { location, isLoading: isLoadingLocation } = useLocation(props.travelLocationId)
+
+const locationName = computed(() => {
+  const { city, province } = location.value
+  return `${city} (${province})`
+})
+
+const form = ref(null)
+const showDialog = ref(route.query.showApprove === "true")
+
+function close() {
+  showDialog.value = false
+  form.value.resetValidation()
+}
+
+async function denyAndClose() {
+  try {
+    await approve()
+    close()
+    snack("Travel authorization approved!", { color: "success" })
+    nextTick(() => {
+      emit("approved")
+    })
+  } catch (error) {
+    snack(error.message, { color: "error" })
+  }
+}
+
+watch(
+  () => showDialog.value,
+  (newShowDialog) => {
+    if (newShowDialog) {
+      router.push({ query: { showApprove: newShowDialog } })
+    } else {
+      router.push({ query: { showApprove: undefined } })
+    }
+  }
+)
+</script>

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/DenyTravelRequestDialogButton.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/DenyTravelRequestDialogButton.vue
@@ -62,7 +62,8 @@
 </template>
 
 <script setup>
-import { ref } from "vue"
+import { ref, nextTick, watch } from "vue"
+import { useRoute, useRouter } from "vue2-helpers/vue-router"
 
 import { required } from "@/utils/validators"
 
@@ -86,11 +87,13 @@ const props = defineProps({
 
 const emit = defineEmits(["denied"])
 
+const route = useRoute()
+const router = useRouter()
 const snack = useSnack()
 const { isLoading, deny } = useTravelAuthorization(props.travelAuthorizationId)
 
 const form = ref(null)
-const showDialog = ref(false)
+const showDialog = ref(route.query.showDeny === "true")
 const denialReason = ref(null)
 
 function close() {
@@ -105,9 +108,22 @@ async function denyAndClose() {
     })
     close()
     snack("Travel authorization denied.", { color: "success" })
-    emit("denied")
+    nextTick(() => {
+      emit("denied")
+    })
   } catch (error) {
     snack(error.message, { color: "error" })
   }
 }
+
+watch(
+  () => showDialog.value,
+  (newShowDialog) => {
+    if (newShowDialog) {
+      router.push({ query: { showDeny: newShowDialog } })
+    } else {
+      router.push({ query: { showDeny: undefined } })
+    }
+  }
+)
 </script>

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/DenyTravelRequestDialogButton.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/DenyTravelRequestDialogButton.vue
@@ -1,0 +1,106 @@
+<template>
+  <v-dialog
+    v-model="showDialog"
+    width="500"
+  >
+    <template #activator="{ on, attrs }">
+      <v-btn
+        :loading="isLoading"
+        :disabled="isDisabled"
+        :class="buttonClasses"
+        color="error"
+        v-bind="attrs"
+        v-on="on"
+      >
+        Deny
+      </v-btn>
+    </template>
+
+    <v-card>
+      <v-card-title class="text-h5"> Deny Request </v-card-title>
+
+      <v-card-text :loading="isLoading">
+        <p>Please provide a reason for denying this request.</p>
+        <v-row>
+          <v-col>
+            <v-textarea
+              v-model="denialReason"
+              :rules="[required]"
+              label="Denial reason"
+              rows="5"
+              required
+              outlined
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="secondary"
+          :loading="isLoading"
+          @click="close"
+          >Cancel</v-btn
+        >
+        <v-btn
+          color="error"
+          :loading="isLoading"
+          @click="denyAndClose"
+          >Deny</v-btn
+        >
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref } from "vue"
+
+import { required } from "@/utils/validators"
+
+import { useSnack } from "@/plugins/snack-plugin"
+import { useTravelAuthorization } from "@/use/travel-authorization"
+
+const props = defineProps({
+  travelAuthorizationId: {
+    type: Number,
+    required: true,
+  },
+  isDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  buttonClasses: {
+    type: [String, Array, Object],
+    default: null,
+  },
+})
+
+const emit = defineEmits(["denied"])
+
+const snack = useSnack()
+const { isLoading, deny } = useTravelAuthorization(props.travelAuthorizationId)
+
+const showDialog = ref(false)
+const denialReason = ref(null)
+
+function close() {
+  showDialog.value = false
+}
+
+async function denyAndClose() {
+  try {
+    await deny({
+      denialReason: denialReason.value,
+    })
+    close()
+    snack("Travel authorization denied.", { color: "success" })
+    emit("denied")
+  } catch (error) {
+    snack(error.message, { color: "error" })
+  }
+}
+</script>

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/DenyTravelRequestDialogButton.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/DenyTravelRequestDialogButton.vue
@@ -16,43 +16,48 @@
       </v-btn>
     </template>
 
-    <v-card>
-      <v-card-title class="text-h5"> Deny Request </v-card-title>
+    <v-form
+      ref="form"
+      @submit.prevent="denyAndClose"
+    >
+      <v-card>
+        <v-card-title class="text-h5"> Deny Request </v-card-title>
 
-      <v-card-text :loading="isLoading">
-        <p>Please provide a reason for denying this request.</p>
-        <v-row>
-          <v-col>
-            <v-textarea
-              v-model="denialReason"
-              :rules="[required]"
-              label="Denial reason"
-              rows="5"
-              required
-              outlined
-            />
-          </v-col>
-        </v-row>
-      </v-card-text>
+        <v-card-text :loading="isLoading">
+          <p>Please provide a reason for denying this request.</p>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="denialReason"
+                :rules="[required]"
+                label="Denial reason"
+                rows="5"
+                required
+                outlined
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
 
-      <v-divider></v-divider>
+        <v-divider></v-divider>
 
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn
-          color="secondary"
-          :loading="isLoading"
-          @click="close"
-          >Cancel</v-btn
-        >
-        <v-btn
-          color="error"
-          :loading="isLoading"
-          @click="denyAndClose"
-          >Deny</v-btn
-        >
-      </v-card-actions>
-    </v-card>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            :loading="isLoading"
+            color="secondary"
+            @click="close"
+            >Cancel</v-btn
+          >
+          <v-btn
+            :loading="isLoading"
+            color="error"
+            type="submit"
+            >Deny</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+    </v-form>
   </v-dialog>
 </template>
 
@@ -84,11 +89,13 @@ const emit = defineEmits(["denied"])
 const snack = useSnack()
 const { isLoading, deny } = useTravelAuthorization(props.travelAuthorizationId)
 
+const form = ref(null)
 const showDialog = ref(false)
 const denialReason = ref(null)
 
 function close() {
   showDialog.value = false
+  form.value.resetValidation()
 }
 
 async function denyAndClose() {

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
@@ -15,13 +15,13 @@
             :requestor-display-name="requestorDisplayName"
             :is-disabled="isDisabled"
             :travel-location-id="travelLocationId"
-            @approved="emit('approved')"
+            @approved="refreshAndEmit('approved')"
           />
           <DenyTravelRequestDialogButton
             :travel-authorization-id="props.travelAuthorizationId"
             :is-disabled="isDisabled"
             button-classes="ml-2"
-            @denied="emit('denied')"
+            @denied="refreshAndEmit('denied')"
           />
         </v-col>
       </v-row>
@@ -71,8 +71,13 @@ const requestorDisplayName = computed(() => {
 watch(
   () => props.travelAuthorizationId,
   async () => {
-    await fetch(props.travelAuthorizationId)
+    await fetch()
   },
   { immediate: true }
 )
+
+async function refreshAndEmit(eventName) {
+  await fetch()
+  emit(eventName)
+}
 </script>

--- a/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
+++ b/web/src/modules/travel-authorizations/components/manage-travel-authorization-details-page/ManagementCard.vue
@@ -13,15 +13,12 @@
           >
             Approve
           </v-btn>
-          <v-btn
-            :loading="isLoading"
-            :disabled="isDisabled"
-            class="ml-2"
-            color="error"
-            @click="denyWrapper"
-          >
-            Deny
-          </v-btn>
+          <DenyTravelRequestDialogButton
+            :travel-authorization-id="props.travelAuthorizationId"
+            :is-disabled="isDisabled"
+            button-classes="ml-2"
+            @denied="emit('denied')"
+          />
         </v-col>
       </v-row>
     </v-card-text>
@@ -30,6 +27,8 @@
 
 <script setup>
 import { computed, watch, onMounted } from "vue"
+
+import DenyTravelRequestDialogButton from "./DenyTravelRequestDialogButton.vue"
 
 import { useSnack } from "@/plugins/snack-plugin"
 import { useTravelAuthorization } from "@/use/travel-authorization"
@@ -44,7 +43,7 @@ const props = defineProps({
 const emit = defineEmits(["approved", "denied"])
 
 const snack = useSnack()
-const { travelAuthorization, isLoading, fetch, approve, deny, STATUSES } = useTravelAuthorization(
+const { travelAuthorization, isLoading, fetch, approve, STATUSES } = useTravelAuthorization(
   props.travelAuthorizationId
 )
 
@@ -57,17 +56,6 @@ async function approveWrapper() {
     .then(() => {
       snack("Travel authorization approved!", { color: "success" })
       emit("approved")
-    })
-    .catch((error) => {
-      snack(error.message, { color: "error" })
-    })
-}
-
-async function denyWrapper() {
-  return deny()
-    .then(() => {
-      snack("Travel authorization denied.", { color: "success" })
-      emit("denied")
     })
     .catch((error) => {
       snack(error.message, { color: "error" })

--- a/web/src/use/travel-authorization.js
+++ b/web/src/use/travel-authorization.js
@@ -72,11 +72,12 @@ export function useTravelAuthorization(travelAuthorizationId) {
     }
   }
 
-  async function deny() {
+  async function deny({ denialReason } = {}) {
     state.isLoading = true
     try {
       const { travelAuthorization } = await travelAuthorizationsApi.deny(
-        unref(travelAuthorizationId)
+        unref(travelAuthorizationId),
+        { denialReason }
       )
       state.isErrored = false
       state.travelAuthorization = travelAuthorization

--- a/web/src/use/use-location.js
+++ b/web/src/use/use-location.js
@@ -1,0 +1,45 @@
+import { reactive, toRefs, unref, watch } from "vue"
+
+import locationsApi from "@/api/locations-api"
+
+export function useLocation(locationId) {
+  const state = reactive({
+    location: {},
+    isLoading: false,
+    isErrored: false,
+  })
+
+  async function fetch() {
+    state.isLoading = true
+    try {
+      const { location } = await locationsApi.fetch(unref(locationId))
+      state.isErrored = false
+      state.location = location
+      return location
+    } catch (error) {
+      console.error("Failed to fetch location:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  watch(
+    () => unref(locationId),
+    async () => {
+      await fetch()
+    },
+    {
+      immediate: true,
+    }
+  )
+
+  return {
+    ...toRefs(state),
+    fetch,
+    refresh: fetch,
+  }
+}
+
+export default useLocation


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/164

Relates to:
- https://github.com/icefoganalytics/travel-authorization/issues/62

# Context

Give the Supervisor role the ability to provide a reason when declining a travel authorization.

Setup:
1. Create a new travel request from the http://localhost:8080/my-travel-requests page.
2. Fill in the "Details" section.
3. Generate an estimate.
4. Submit to a supervisor.
5. Go to the "Manager View" from the top drop down menu.
6. Find the travel request in the Pending Approvals dashboard widget and click on it.
7. Find the "Deny" button in the bottom right corner of the manage page.

The Deny button should gain a dialog and provide the Supervisor an opportunity to provide a reason.
The Approve button should also gain a confirmation dialog.

# Implementation

Add ability to provide denial

# Screenshots

Deny request dialog
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/e9db78e1-b258-4c19-b177-851d787987bd)

Approve request dialog
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/cd565786-411d-4a10-beb2-14b20b756aea)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create a new travel request from the http://localhost:8080/my-travel-requests page.
2. Fill in the "Details" section.
3. Generate an estimate.
5. Submit to a supervisor.
6. Go to the "Manager View" from the top drop down menu.
7. Find the travel request in the Pending Approvals dashboard widget and click on it.
8. Find the "Deny" button in the bottom right corner of the manage page.
9. Repeat the above steps and click the "Approve" button this time.
