### PR TITLE
Fix Expense Prefill Not Working At All

### DIFF
--- a/api/src/controllers/travel-authorizations/expenses/prefill-controller.ts
+++ b/api/src/controllers/travel-authorizations/expenses/prefill-controller.ts
@@ -40,9 +40,16 @@ export class PrefillController extends BaseController {
     return TravelAuthorization.findByPk(this.params.travelAuthorizationId, {
       include: [
         {
+          association: "expenses",
+          where: {
+            type: Expense.Types.ESTIMATE,
+          },
+          required: false
+        },
+        {
           association: "travelSegments",
           order: [["segmentNumber", "ASC"]],
-        }
+        },
       ],
       order: [["expenses", "date", "ASC"]],
     })


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/174

Relates to:

- Introduced in https://github.com/icefoganalytics/travel-authorization/commit/10d40de4269d7b4239becc02bd6938feb99cb62e

# Context

Unable to execute the prefill function.

![image](https://github.com/icefoganalytics/travel-authorization/assets/89539008/d76ff0a1-6dbd-41b5-a38c-b9a1616d861e)

# Implementation


Can't order by expenses if there aren't any.

Bug introduced in https://github.com/icefoganalytics/travel-authorization/commit/10d40de4269d7b4239becc02bd6938feb99cb62e

Added `required: false` so that Travel authorization can now still be found, even if no estimates are listed.

Note that eager loading with a "where" clause switches the query from an outer join to an inner join. See https://sequelize.org/docs/v6/advanced-association-concepts/eager-loading/#eager-loading-filtered-at-the-associated-model-level.

This kind of bug make me think that its time to set up some end-to-end tests?

# Screenshots

N/A now prefill works again.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the "My Travel Requests" page via the top drop down nav.
5. Add a new travel authorization via the call-to-action button.
6. Fill in all required fields.
7. Generate an estimate.
8. Submit to yourself.
9. Go to the "Manager View" via the top drop-down nav.
10. Select your new request in the Pending Approvals widget in the top left of the page.
11. Scroll down and approve the request.
12. Go back to the travel request as a user by changing `http://localhost:8080/travel-requests/xxx/details/manage` to `http://localhost:8080/my-travel-requests/xxx/details`.
13. Go to the "Expense" tab.
14. Prefill your expenses via the call-to-action button. It will now work again.
