### PR TITLE
ytgov/issue#96: Preapproved Submission Not Working Properly

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,7 +4,7 @@ import path from "path"
 import helmet from "helmet"
 import fileUpload from "express-fileupload"
 
-import { FRONTEND_URL, NODE_ENV } from "@/config"
+import { DB_HOST, DB_NAME, DB_USER, FRONTEND_URL, NODE_ENV } from "@/config"
 import { requestLoggerMiddleware } from "@/middleware"
 import logger from "@/utils/logger"
 import router from "@/routes"
@@ -51,10 +51,10 @@ app.use(
 app.use(fileUpload())
 
 if (NODE_ENV !== "test") {
-  logger.info("host: ", process.env.DB_HOST)
-  logger.info("user: ", process.env.DB_USER)
-  logger.info("psss: ", "*********")
-  logger.info("db name: ", process.env.DB_NAME)
+  logger.info(`host: ${DB_HOST}`)
+  logger.info(`user: ${DB_USER}`)
+  logger.info("psss: *********")
+  logger.info(`db name: ${DB_NAME}`)
 }
 
 app.use(router)

--- a/api/src/db/migrations/20240614190238_fix-submission-date-column-default.ts
+++ b/api/src/db/migrations/20240614190238_fix-submission-date-column-default.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex"
+import moment from "moment"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("preapprovedSubmissions", (table) => {
+    table.date("submissionDate").defaultTo(knex.raw("CURRENT_DATE")).alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const format = "YYYY-MM-DD"
+  await knex.schema.alterTable("preapprovedSubmissions", (table) => {
+    table.date("submissionDate").defaultTo(moment(new Date()).format(format)).alter()
+  })
+}

--- a/api/src/initializers/10-create-database.ts
+++ b/api/src/initializers/10-create-database.ts
@@ -25,7 +25,7 @@ async function createDatabase(): Promise<void> {
 
   logger.info(`Database ${DB_NAME} does not exist: creating...`)
   return db.raw(`CREATE DATABASE ${DB_NAME}`).catch((error) => {
-    logger.error("Failed to create database:", error)
+    logger.error(`Failed to create database: ${error}`, { error })
   })
 }
 

--- a/api/src/initializers/20-run-migrations.ts
+++ b/api/src/initializers/20-run-migrations.ts
@@ -20,7 +20,7 @@ async function runMigrations(): Promise<void> {
       logger.info("All migrations completed successfully.")
     })
     .catch((error) => {
-      logger.error("Error running migrations:", error)
+      logger.error(`Error running migrations: ${error}`, { error })
       throw error
     })
 }

--- a/api/src/initializers/30-run-seeds.ts
+++ b/api/src/initializers/30-run-seeds.ts
@@ -17,7 +17,7 @@ async function runSeeds(): Promise<void> {
       logger.info("All seeds completed successfully.")
     })
     .catch((error) => {
-      logger.error("Error running seeds:", error)
+      logger.error(`Error running seeds: ${error}`, { error })
       throw error
     })
 }

--- a/api/src/middleware/authz.middleware.ts
+++ b/api/src/middleware/authz.middleware.ts
@@ -9,7 +9,7 @@ import logger from "@/utils/logger"
 import { User } from "@/models"
 
 if (NODE_ENV !== "test") {
-  logger.info("AUTH0_DOMAIN", `${AUTH0_DOMAIN}/.well-known/jwks.json`)
+  logger.info("AUTH0_DOMAIN=${AUTH0_DOMAIN}/.well-known/jwks.json")
 }
 
 export type AuthorizationRequest = JwtRequest & {

--- a/api/src/models/travel-authorization-pre-approval-submission.ts
+++ b/api/src/models/travel-authorization-pre-approval-submission.ts
@@ -16,6 +16,7 @@ import {
   InferCreationAttributes,
   Model,
   NonAttribute,
+  literal,
 } from "sequelize"
 
 import sequelize from "@/db/db-client"
@@ -166,9 +167,7 @@ TravelAuthorizationPreApprovalSubmission.init(
     submissionDate: {
       type: DataTypes.DATE,
       allowNull: true,
-      // TODO: update to use current date
-      defaultValue: "2023-12-21",
-      // defaultValue: DataTypes.NOW,
+      defaultValue: literal("CURRENT_DATE"),
     },
     approvalDate: {
       type: DataTypes.DATE,

--- a/api/src/models/travel-authorization-pre-approval-submission.ts
+++ b/api/src/models/travel-authorization-pre-approval-submission.ts
@@ -12,9 +12,6 @@ import {
   HasManyRemoveAssociationMixin,
   HasManyRemoveAssociationsMixin,
   HasManySetAssociationsMixin,
-  HasOneCreateAssociationMixin,
-  HasOneGetAssociationMixin,
-  HasOneSetAssociationMixin,
   InferAttributes,
   InferCreationAttributes,
   Model,
@@ -52,13 +49,6 @@ export class TravelAuthorizationPreApprovalSubmission extends Model<
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
   // https://sequelize.org/api/v7/types/_sequelize_core.index.belongstocreateassociationmixin
-  declare getPreApproval: HasOneGetAssociationMixin<TravelAuthorizationPreApproval>
-  declare setPreApproval: HasOneSetAssociationMixin<
-    TravelAuthorizationPreApproval,
-    TravelAuthorizationPreApproval["submissionId"]
-  >
-  declare createPreApproval: HasOneCreateAssociationMixin<TravelAuthorizationPreApproval>
-
   declare getDocuments: HasManyGetAssociationsMixin<TravelAuthorizationPreApprovalDocument>
   declare setDocuments: HasManySetAssociationsMixin<
     TravelAuthorizationPreApprovalDocument,
@@ -91,30 +81,62 @@ export class TravelAuthorizationPreApprovalSubmission extends Model<
   declare countDocuments: HasManyCountAssociationsMixin
   declare createDocument: HasManyCreateAssociationMixin<TravelAuthorizationPreApprovalDocument>
 
-  declare preApproval?: NonAttribute<TravelAuthorizationPreApproval>
+  declare getPreApprovals: HasManyGetAssociationsMixin<TravelAuthorizationPreApproval>
+  declare setPreApprovals: HasManySetAssociationsMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare hasPreApproval: HasManyHasAssociationMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare hasPreApprovals: HasManyHasAssociationsMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare addPreApproval: HasManyAddAssociationMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare addPreApprovals: HasManyAddAssociationsMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare removePreApproval: HasManyRemoveAssociationMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare removePreApprovals: HasManyRemoveAssociationsMixin<
+    TravelAuthorizationPreApproval,
+    TravelAuthorizationPreApproval["submissionId"]
+  >
+  declare countPreApprovals: HasManyCountAssociationsMixin
+  declare createPreApproval: HasManyCreateAssociationMixin<TravelAuthorizationPreApproval>
+
   declare documents?: NonAttribute<TravelAuthorizationPreApprovalDocument[]>
+  declare preApprovals?: NonAttribute<TravelAuthorizationPreApproval>
 
   declare static associations: {
-    preApproval: Association<
-      TravelAuthorizationPreApprovalSubmission,
-      TravelAuthorizationPreApproval
-    >
     documents: Association<
       TravelAuthorizationPreApprovalSubmission,
       TravelAuthorizationPreApprovalDocument
     >
+    preApprovals: Association<
+      TravelAuthorizationPreApprovalSubmission,
+      TravelAuthorizationPreApproval
+    >
   }
 
   static establishAssociations() {
-    this.hasOne(TravelAuthorizationPreApproval, {
-      sourceKey: "preTSubID",
-      foreignKey: "submissionId",
-      as: "preApproval",
-    })
     this.hasMany(TravelAuthorizationPreApprovalDocument, {
       sourceKey: "preTSubID",
       foreignKey: "preTSubID",
       as: "documents",
+    })
+    this.hasMany(TravelAuthorizationPreApproval, {
+      sourceKey: "preTSubID",
+      foreignKey: "submissionId",
+      as: "preApprovals",
     })
   }
 }

--- a/api/src/routes/form-router.ts
+++ b/api/src/routes/form-router.ts
@@ -346,7 +346,7 @@ formRouter.delete("/:formId", ReturnValidationErrors, async function (req: Reque
         status: TravelAuthorization.Statuses.DELETED,
       })
       .then(async () => {
-        logger.info("Delete successful", req.params.id)
+        logger.info(`Delete successful ${req.params.id}`)
         await auditService.log(user.id, form.id, "Delete", "Deteled form")
         res.status(200).json("Delete successful")
       })

--- a/api/src/routes/preapproved-router.ts
+++ b/api/src/routes/preapproved-router.ts
@@ -16,13 +16,13 @@ export const preapprovedRouter = express.Router()
 
 preapprovedRouter.get("/submissions", RequiresAuth, async function (req: Request, res: Response) {
   const applyScope = (scope: ModelStatic<TravelAuthorizationPreApprovalSubmission>, user: User) => {
-    if (req?.user?.roles?.indexOf(User.Roles.ADMIN) >= 0) {
+    if (user.roles?.indexOf(User.Roles.ADMIN) >= 0) {
       return scope
     }
 
     return scope.scope({
       where: {
-        department: req.user.department,
+        department: user.department,
       },
     })
   }

--- a/api/src/routes/preapproved-router.ts
+++ b/api/src/routes/preapproved-router.ts
@@ -31,7 +31,7 @@ preapprovedRouter.get("/submissions", RequiresAuth, async function (req: Request
   const submissionList = await scopedSubmissions.findAll({
     include: [
       {
-        association: "preApproval",
+        association: "preApprovals",
         include: ["profiles"],
       },
     ],

--- a/web/src/modules/preapproved/views/Preapproved.vue
+++ b/web/src/modules/preapproved/views/Preapproved.vue
@@ -64,8 +64,9 @@
 
 <script>
 import http from "@/api/http-client"
-import { PREAPPROVED_URL, LOOKUP_URL, PROFILE_URL } from "@/urls"
+import { PREAPPROVED_URL, LOOKUP_URL } from "@/urls"
 
+import usersApi from "@/api/users-api"
 import travelPurposesApi from "@/api/travel-purposes-api"
 import travelAuthorizationPreApprovalsApi, {
   STATUSES,
@@ -91,7 +92,7 @@ export default {
   },
   async mounted() {
     this.loadingData = true
-    // await this.getUserAuth()
+    await this.getUserAuth()
     await this.getEmployees()
     await this.getDepartmentBranch()
     await this.getTravelPurposes()
@@ -110,13 +111,13 @@ export default {
     },
 
     async getUserAuth() {
-      return http
-        .get(`${PROFILE_URL}`)
-        .then((resp) => {
-          this.$store.commit("auth/setUser", resp.data.user)
+      return usersApi
+        .me()
+        .then(({ user }) => {
+          this.$store.commit("auth/setUser", user)
         })
-        .catch((e) => {
-          console.log(e)
+        .catch((error) => {
+          console.error(error)
         })
     },
 

--- a/web/src/modules/preapproved/views/Requests/PreapprovedRequests.vue
+++ b/web/src/modules/preapproved/views/Requests/PreapprovedRequests.vue
@@ -100,11 +100,12 @@
 </template>
 
 <script>
-import Vue from "vue"
+import Vue, { ref } from "vue"
 import { ExportToCsv } from "export-to-csv"
 import { isNil } from "lodash"
 
 import { STATUSES } from "@/api/travel-authorization-pre-approvals-api"
+import useCurrentUser from "@/use/use-current-user"
 
 import NewTravelRequest from "./NewTravelRequest.vue"
 import PrintReport from "../Common/PrintReport.vue"
@@ -123,9 +124,11 @@ export default {
       default: () => [],
     },
   },
-  data() {
+  setup() {
+    const { isAdmin } = useCurrentUser()
+
     return {
-      headers: [
+      headers: ref([
         {
           text: "Name",
           value: "name",
@@ -174,10 +177,10 @@ export default {
           sortable: false,
           width: "1rem",
         },
-      ],
-      admin: false,
-      selectedRequests: [],
-      firstSelectionDept: "",
+      ]),
+      admin: isAdmin,
+      selectedRequests: ref([]),
+      firstSelectionDept: ref(""),
     }
   },
   computed: {
@@ -192,9 +195,6 @@ export default {
         })
       return travelRequests
     },
-  },
-  mounted() {
-    this.admin = Vue.filter("isAdmin")()
   },
   methods: {
     isNil,

--- a/web/src/modules/preapproved/views/Requests/PreapprovedRequests.vue
+++ b/web/src/modules/preapproved/views/Requests/PreapprovedRequests.vue
@@ -103,6 +103,7 @@
 import Vue, { ref } from "vue"
 import { ExportToCsv } from "export-to-csv"
 import { isNil } from "lodash"
+import { DateTime } from "luxon"
 
 import { STATUSES } from "@/api/travel-authorization-pre-approvals-api"
 import useCurrentUser from "@/use/use-current-user"
@@ -228,34 +229,27 @@ export default {
       })
     },
     exportToExcel() {
-      // console.log(this.selectedRequests)
+      // The object keys must match the headers option.
+      // In future versions of the library, the headers can be customized independently.
       const csvInfo = this.selectedRequests.map((req) => {
         return {
-          profiles: req.profiles
-            ?.map((profile) => profile.profileName.replace(".", " "))
-            ?.join(", "),
-          department: req.department,
-          branch: req.branch ? req.branch : "",
-          travelDate: req.isOpenForAnyDate ? req.month : req.startDate + " " + req.endDate,
-          location: req.location,
-          purpose: req.purpose ? req.purpose : "",
-          estimatedCost: req.estimatedCost,
-          reason: req.reason ? req.reason : "",
-          status: req.status ? req.status : "",
-          travelerNotes: req.travelerNotes ? req.travelerNotes : "",
+          Name: req.profiles?.map((profile) => profile.profileName.replace(".", " "))?.join(", "),
+          Department: req.department,
+          Branch: req.branch ? req.branch : "",
+          "Travel Date": req.isOpenForAnyDate ? req.month : req.startDate + " " + req.endDate,
+          Location: req.location,
+          Purpose: req.purpose ? req.purpose : "",
+          "Estimated Cost": req.estimatedCost,
+          Reason: req.reason ? req.reason : "",
+          Status: req.status ? req.status : "",
+          Notes: req.travelerNotes ? req.travelerNotes : "",
         }
       })
+      const currentDate = DateTime.now().toFormat("yyyy-MM-dd")
       const options = {
-        fieldSeparator: ",",
-        quoteStrings: '"',
-        decimalSeparator: ".",
+        filename: `Travel Requests, Pre-Approved, ${currentDate}`,
+        decimalSeparator: "locale",
         showLabels: true,
-        showTitle: false,
-        title: "",
-        filename: "Preapproved-Travel-Requests",
-        useTextFile: false,
-        useBom: true,
-        useKeysAsHeaders: false,
         headers: [
           "Name",
           "Department",

--- a/web/src/modules/preapproved/views/Submissions/Submissions.vue
+++ b/web/src/modules/preapproved/views/Submissions/Submissions.vue
@@ -11,7 +11,9 @@
         <!-- eslint-disable-next-line vue/no-parsing-error -->
         {{ item.submissionDate | beautifyDate }}
       </template>
-      <template #item.location="{ item }"> {{ item.preApproval?.location }} </template>
+      <template #item.location="{ item }">
+        {{ item.preApprovals.map((p) => p.location).join(" - ") }}
+      </template>
       <template #item.edit="{ item }">
         <v-row>
           <div style="width: 4.5rem">
@@ -21,14 +23,14 @@
               :edit-button="true"
               button-name="Edit"
               :travel-requests="travelRequests"
-              :selected-requests="[item.preApproval]"
+              :selected-requests="item.preApprovals"
               @updateTable="updateTable"
             />
           </div>
           <div style="width: 6.75rem">
             <ApproveTravel
               v-if="item.status === STATUSES.SUBMITTED && admin"
-              :travel-requests="[item.preApproval]"
+              :travel-requests="item.preApprovals"
               :submission-id="item.preTSubID"
               @updateTable="updateTable"
             />
@@ -37,7 +39,7 @@
             <PrintReport
               v-if="admin"
               :id="item.preTSubID"
-              :travel-requests="[item.preApproval]"
+              :travel-requests="item.preApprovals"
               :button-inside-table="true"
               button-name="Print"
             />


### PR DESCRIPTION
Fixes https://github.com/ytgov/travel-authorization/issues/96

# Context

**Is your feature request related to a problem? Please describe.** on the request tab. Selected all (2) the requests I wanted to include in my submission. Selected "Submit Selected Travel" and hit save. The submissions got moved over to the submission tab. But only one of the two requests came over.
 
 **Describe the solution you'd like** I want both selected requests to be included in the submissions.

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/df6b7f3a-4e1a-441c-a6b8-07b48fb02cf6)
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/eed68f56-96cf-493c-90b1-73c5853b8a55)
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/a983b02c-2e90-4c67-a216-c2bf81e6effe)

Submission date is wrong I made a submission June 13, 2024 and June 12, 2024
Location should have a comma seperate list of locations of all the request selected

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/c81decdd-d192-4198-8e1d-3592511e4daf)

The print button shows that only 1 of the 3 requests were submitted.

![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/3423f89b-4c8f-466c-85e1-1d5a1cd544a5)

 only shows 1 of 3 requests submitted.

# Implementation

1. Page load failure identified as user lookup being commented out in https://github.com/ytgov/travel-authorization/pull/41, (specifically [074a3fffc8b480](https://github.com/ytgov/travel-authorization/pull/41/commits/074a3fffc8b480551996815d413113f7b70b6b71#diff-242054ea7b3a9a1378bc22fcc6e3a2eb677978e3a182e6469d784bf37ee7c95c)) and was introduced by removing user lookup after route change https://github.com/icefoganalytics/travel-authorization/pull/196 (specifically https://github.com/icefoganalytics/travel-authorization/commit/379c6c9e2853d81659f309bc0546a3133c2be02e)
   The code could be replaced by global useCurrentUser composable; which loads user once during sign-in.

2. Identified further issues do to data modeling mismatch. Introduced in https://github.com/ytgov/travel-authorization/commit/db9194308725e908b79f9587a201d70ab48101c5.

   Relationship between preapprovedSubmissions and travel_authorization_pre_approvals is one-to-many not one-to-one.

3. UI changes referring to .preApproval as singular need to be reverted; one example is https://github.com/icefoganalytics/travel-authorization/commit/dc55491d934aad0bef555f1dde7e11c2d39507d6. Probably other similar issues in https://github.com/icefoganalytics/travel-authorization/pull/179.

4. Identified issue with submission date being incorrect introduced in https://github.com/ytgov/travel-authorization/commit/98f86b1134b2650a23ec315566955bfc23a21670. Migrating sets default date to date that the migration ran at, rather than CURRENT_TIMESTAMP.

   This issue was probably suppressed by someone manually setting submittedDate on submission; although, I can't find where after digging through the git history. Or maybe by us regularly dropping the database in production?

## Key Takeaways

1. Variable naming consistency is important.
2. Setting dynamic database level defaults should use database functions, not static values.

# Screenshots

Print multiple selected requests
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/aa4885c2-cc31-4b43-bb33-bfc8a2e860aa)

Print Submission with multiple references
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/800f2478-afaf-4198-b540-3c970e0ea751)

Submission Approval with multiple references
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/d0b3ccaf-697f-4df1-88f4-50c7a287bba2)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
4. Boot the app via `dev up`
5. Log in to the app at http://localhost:8080
6. Go to the http://localhost:8080/preapproved page via the top drop down nav.
7. Add a new travel request via the "Add new travel button". Pick the `Highways and Public Works` department.
8. Add a second travel request with the same department.
9. Check the boxes, to the left of the table, by _both_ submissions to select them both.
10. Click the "Print Report" button, and check that both submission show up.
11. Click the "Export to Excel" button and check that the export shows the correct data.
    > Note that the file name is manged by the `export-to-csv` library; see https://github.com/icefoganalytics/travel-authorization/issues/198
12. Re-select the submissions, and then click the "Submit Selected Travel" button.
13. Go to the "Submissions" tab and find your new submission.
14. Location should include both locations from the two submissions.
15. Click the Print button, both submissions will now show up.
16. Click the "Approve" button, both submissions will now show up.
