### PR TITLE
Setting dateBackToWork on Travel Authorization Causes a 500 in Travel Desk Travel Request Serializer

### DIFF
--- a/api/src/controllers/travel-desk-travel-requests-controller.ts
+++ b/api/src/controllers/travel-desk-travel-requests-controller.ts
@@ -1,5 +1,6 @@
 import { isNil } from "lodash"
 
+import logger from "@/utils/logger"
 import { TravelDeskTravelRequest } from "@/models"
 import { TravelDeskTravelRequestsPolicy } from "@/policies"
 import { UpdateService } from "@/services/travel-desk-travel-requests"
@@ -48,8 +49,9 @@ export class TravelDeskTravelRequestsController extends BaseController<TravelDes
         totalCount,
       })
     } catch (error) {
+      logger.error(`Failed to retrieve travel desk requests: ${error}`, { error })
       return this.response
-        .status(500)
+        .status(400)
         .json({ message: `Failed to retrieve travel desk requests: ${error}` })
     }
   }

--- a/api/src/models/expense.ts
+++ b/api/src/models/expense.ts
@@ -40,7 +40,7 @@ export class Expense extends Model<InferAttributes<Expense>, InferCreationAttrib
   declare id: CreationOptional<number>
   declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>
   declare description: string
-  declare date: Date | null
+  declare date: Date | string | null // DATEONLY accepts Date or string, but returns string
   declare cost: number
   declare currency: string
   declare type: Types

--- a/api/src/models/stop.ts
+++ b/api/src/models/stop.ts
@@ -34,7 +34,7 @@ export class Stop extends Model<InferAttributes<Stop>, InferCreationAttributes<S
   declare id: CreationOptional<number>
   declare travelAuthorizationId: ForeignKey<TravelAuthorization["id"]>
   declare locationId: ForeignKey<Location["id"]>
-  declare departureDate: Date | null
+  declare departureDate: Date | string | null // DATEONLY accepts Date or string, but returns string
   declare departureTime: string | null
   declare transport: string | null
   declare accommodationType: string | null

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -21,6 +21,7 @@ import {
   Model,
   NonAttribute,
 } from "sequelize"
+import { DateTime } from "luxon"
 
 import sequelize from "@/db/db-client"
 
@@ -97,6 +98,15 @@ export class TravelAuthorization extends Model<
   declare allTravelWithinTerritory: boolean | null
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
+
+  // Magic methods
+  get dateBackToWorkAsString(): NonAttribute<string | null> {
+    if (this.dateBackToWork instanceof Date) {
+      return DateTime.fromJSDate(this.dateBackToWork).toFormat("yyyy-LL-dd")
+    }
+
+    return this.dateBackToWork
+  }
 
   // Associations
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage

--- a/api/src/models/travel-authorization.ts
+++ b/api/src/models/travel-authorization.ts
@@ -79,7 +79,7 @@ export class TravelAuthorization extends Model<
   declare email: string | null
   declare mailcode: string | null
   declare daysOffTravelStatus: number | null
-  declare dateBackToWork: Date | null
+  declare dateBackToWork: Date | string | null // DATEONLY accepts Date or string, but returns string
   declare travelDuration: number | null
   declare travelAdvance: number | null
   declare eventName: string | null

--- a/api/src/models/travel-desk-hotel.ts
+++ b/api/src/models/travel-desk-hotel.ts
@@ -38,8 +38,8 @@ export class TravelDeskHotel extends Model<
   declare isDedicatedConferenceHotelAvailable: boolean
   declare conferenceName: string
   declare conferenceHotelName: string
-  declare checkIn: Date
-  declare checkOut: Date
+  declare checkIn: Date | string // DATEONLY accepts Date or string, but returns string
+  declare checkOut: Date | string // DATEONLY accepts Date or string, but returns string
   declare additionalInformation: CreationOptional<string | null>
   declare status: string
   declare reservedHotelInfo: CreationOptional<string | null>

--- a/api/src/models/travel-desk-other-transportation.ts
+++ b/api/src/models/travel-desk-other-transportation.ts
@@ -47,7 +47,7 @@ export class TravelDeskOtherTransportation extends Model<
   declare depart: string
   declare arrive: string
   declare transportationType: string
-  declare date: Date
+  declare date: Date | string // DATEONLY accepts Date or string, but returns string
   declare additionalNotes: CreationOptional<string | null>
   declare status: string
   // NOTE: reserved_transportation_info, and booking do not appear to be used in the codebase.

--- a/api/src/serializers/travel-desk-travel-requests/index-serializer.ts
+++ b/api/src/serializers/travel-desk-travel-requests/index-serializer.ts
@@ -59,7 +59,7 @@ export class IndexSerializer extends BaseSerializer<TravelDeskTravelRequest> {
     const travelStartDate = this.determineStartDate(this.travelSegments)
     const travelEndDate = this.determineEndDate(
       this.travelSegments,
-      this.travelAuthorization.dateBackToWork
+      this.travelAuthorization.dateBackToWorkAsString
     )
     const locationsTraveled = this.determineLocationsTraveled(this.travelSegments)
     const requestedOptions = this.determineRequestedOptions(this.record)
@@ -147,9 +147,9 @@ export class IndexSerializer extends BaseSerializer<TravelDeskTravelRequest> {
     return departureOnAsString
   }
 
-  private determineEndDate(travelSegments: TravelSegment[], dateBackToWork: Date | null): string {
+  private determineEndDate(travelSegments: TravelSegment[], dateBackToWork: string | null): string {
     if (!isNil(dateBackToWork)) {
-      return dateBackToWork.toISOString().slice(0, 10)
+      return dateBackToWork
     }
 
     const lastTravelSegment = last(travelSegments)


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/233

Relates to:

- https://governmentofyukon.slack.com/archives/C04ETKKJS1X/p1728687674306649

# Context

**Describe the bug**
When you set a date back to work for the travel authorization if 500s when you go to the Travel Auth -> Request tab due to a bug in the serializer.

![image](https://github.com/user-attachments/assets/24560f8a-9ed5-4d13-a2b3-65cdb877b63f)

**To Reproduce**
Steps to reproduce the behavior:

1. From the Dashboard page, select "My Travel Requests" from the top dropdown nav.
2. Create a travel authorization via the "+ Travel Authorization" button.
3. Create a travel request between Vancouver and Whitehorse.
4. Pick the travel dates as a short window of 3 days.
5. Generate the estimate.
6. Submit the travel authorization to your email as the supervisor.
7. From the top dropdown nav, select "Manager View".
8. Find your request in the "Pending Approval" card.
9. Approve the request.
10. Return to the "My Travel Requests" page via the top dropdown nav.
11. Find your approved request in the table, and click on the "Submit travel desk request" call-to-action button.

**Expected behavior**
Page should not 500.

**Additional context**
This bug is caused by a bug in Sequelize 6 where fields of type DATEONLY supposedly return js Date, but actually return "string".

This issue in a bunch of models, and will need to be fixed everywhere.
There will be a lot of type errors that will need to be handled after it gets fixed.

Error as text
```
App is running > Object
main.js:52

Failed to load resource: the server responded with a status of 500 ()
api/travel-desk-trav...%5D=237&perPage=1:1

Failed to fetch
use-travel-desk-travel-requests.js:60

travelDeskTravelRequests:
Error: Failed to retrieve travel desk requests: TypeError:
dateBackToWork.toISOString is not a function
at http-client.js:36:11
at async Le.request (Axios.js:40:7)
at async Object.list (travel-desk-travel-requests-api.js:91:13)
at async n (use-travel-desk-travel-requests.js:52:41)
at async deep (use-travel-desk-travel-requests.js:71:11)

vue.runtime.esm.js:3065
Error: Failed to retrieve travel desk requests: TypeError:
dateBackToWork.toISOString is not a function
at http-client.js:36:11
at async Le.request (Axios.js:40:7)
at async Object.list (travel-desk-travel-requests-api.js:91:13)
at async n (use-travel-desk-travel-requests.js:52:41)
at async deep (use-travel-desk-travel-requests.js:71:11)
```

# Implementation

Fix types around Sequelize DATEONLY fields, now returns Date | string \[| null\]; This is an issue with Sequelize 6. The expected types should probably be string?
Use better error logging in controller that through the error before; All controllers should have a better way of logging errors.

# Screenshots

![image](https://github.com/user-attachments/assets/af232af3-331c-4ddc-b1a3-b29ea359f0b1)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
1. From the Dashboard page, select "My Travel Requests" from the top dropdown nav.
2. Create a travel authorization via the "+ Travel Authorization" button.
3. Create a travel request between Vancouver and Whitehorse.
4. Pick the travel dates as a short window of 3 days.
5. Generate the estimate.
6. Submit the travel authorization to your email as the supervisor.
7. From the top dropdown nav, select "Manager View".
8. Find your request in the "Pending Approval" card.
9. Approve the request.
10. Return to the "My Travel Requests" page via the top dropdown nav.
11. Find your approved request in the table, and click on the "Submit travel desk request" call-to-action button.

