### PR TITLE
Ytgov issue 92: Travel Desk Popup Enhancements

### DIFF
--- a/api/src/controllers/travel-desk-hotels-controller.ts
+++ b/api/src/controllers/travel-desk-hotels-controller.ts
@@ -1,5 +1,6 @@
 import { isNil } from "lodash"
 
+import logger from "@/utils/logger"
 import { TravelDeskHotel, TravelDeskTravelRequest } from "@/models"
 import { TravelDeskHotelsPolicy } from "@/policies"
 import { CreateService, UpdateService } from "@/services/travel-desk-hotels"
@@ -29,9 +30,38 @@ export class TravelDeskHotelsController extends BaseController<TravelDeskHotel> 
         totalCount,
       })
     } catch (error) {
-      return this.response
-        .status(500)
-        .json({ message: `Failed to retrieve travel desk hotels: ${error}` })
+      logger.error(`Error retrieving travel desk hotels: ${error}`, { error })
+      return this.response.status(400).json({
+        message: `Failed to retrieve travel desk hotels: ${error}`,
+      })
+    }
+  }
+
+  async show() {
+    try {
+      const travelDeskHotel = await this.loadTravelDeskHotel()
+      if (isNil(travelDeskHotel)) {
+        return this.response.status(404).json({
+          message: "Travel desk hotel not found.",
+        })
+      }
+
+      const policy = this.buildPolicy(travelDeskHotel)
+      if (!policy.show()) {
+        return this.response.status(403).json({
+          message: "You are not authorized to view this travel desk hotel.",
+        })
+      }
+
+      return this.response.json({
+        travelDeskHotel,
+        policy,
+      })
+    } catch (error) {
+      logger.error(`Error retrieving travel desk hotel: ${error}`, { error })
+      return this.response.status(400).json({
+        message: `Failed to retrieve travel desk hotel: ${error}`,
+      })
     }
   }
 
@@ -40,16 +70,22 @@ export class TravelDeskHotelsController extends BaseController<TravelDeskHotel> 
       const travelDeskHotel = await this.buildTravelDeskHotel()
       const policy = this.buildPolicy(travelDeskHotel)
       if (!policy.create()) {
-        return this.response
-          .status(403)
-          .json({ message: "You are not authorized to create this hotel." })
+        return this.response.status(403).json({
+          message: "You are not authorized to create this hotel.",
+        })
       }
 
       const permittedAttributes = policy.permitAttributesForCreate(this.request.body)
       const newTravelDeskHotel = await CreateService.perform(permittedAttributes, this.currentUser)
-      return this.response.status(201).json({ travelDeskHotel: newTravelDeskHotel })
+      return this.response.status(201).json({
+        travelDeskHotel: newTravelDeskHotel,
+        policy,
+      })
     } catch (error) {
-      return this.response.status(422).json({ message: `Hotel creation failed: ${error}` })
+      logger.error(`Error creating travel desk hotel: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `Hotel creation failed: ${error}`,
+      })
     }
   }
 
@@ -57,14 +93,16 @@ export class TravelDeskHotelsController extends BaseController<TravelDeskHotel> 
     try {
       const travelDeskHotel = await this.loadTravelDeskHotel()
       if (isNil(travelDeskHotel)) {
-        return this.response.status(404).json({ message: "Hotel not found." })
+        return this.response.status(404).json({
+          message: "Travel desk hotel not found.",
+        })
       }
 
       const policy = this.buildPolicy(travelDeskHotel)
       if (!policy.update()) {
-        return this.response
-          .status(403)
-          .json({ message: "You are not authorized to update this hotel." })
+        return this.response.status(403).json({
+          message: "You are not authorized to update this travel desk hotel.",
+        })
       }
 
       const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
@@ -73,9 +111,15 @@ export class TravelDeskHotelsController extends BaseController<TravelDeskHotel> 
         permittedAttributes,
         this.currentUser
       )
-      return this.response.status(200).json({ travelDeskHotel: updatedTravelDeskHotel })
+      return this.response.json({
+        travelDeskHotel: updatedTravelDeskHotel,
+        policy,
+      })
     } catch (error) {
-      return this.response.status(422).json({ message: `Hotel update failed: ${error}` })
+      logger.error(`Error updating travel desk hotel: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `Travel desk hotel update failed: ${error}`,
+      })
     }
   }
 
@@ -83,20 +127,25 @@ export class TravelDeskHotelsController extends BaseController<TravelDeskHotel> 
     try {
       const travelDeskHotel = await this.loadTravelDeskHotel()
       if (isNil(travelDeskHotel)) {
-        return this.response.status(404).json({ message: "Hotel not found." })
+        return this.response.status(404).json({
+          message: "Travel desk hotel not found.",
+        })
       }
 
       const policy = this.buildPolicy(travelDeskHotel)
       if (!policy.destroy()) {
-        return this.response
-          .status(403)
-          .json({ message: "You are not authorized to delete this hotel." })
+        return this.response.status(403).json({
+          message: "You are not authorized to delete this travel desk hotel.",
+        })
       }
 
       await travelDeskHotel.destroy()
       return this.response.status(204).send()
     } catch (error) {
-      return this.response.status(422).json({ message: `Hotel deletion failed: ${error}` })
+      logger.error(`Error deleting travel desk hotel: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `Travel desk hotel deletion failed: ${error}`,
+      })
     }
   }
 

--- a/api/src/controllers/travel-desk-hotels-controller.ts
+++ b/api/src/controllers/travel-desk-hotels-controller.ts
@@ -1,4 +1,3 @@
-import { WhereOptions } from "sequelize"
 import { isNil } from "lodash"
 
 import { TravelDeskHotel, TravelDeskTravelRequest } from "@/models"
@@ -8,19 +7,19 @@ import { IndexSerializer } from "@/serializers/travel-desk-hotels"
 
 import BaseController from "@/controllers/base-controller"
 
-export class TravelDeskHotelsController extends BaseController {
+export class TravelDeskHotelsController extends BaseController<TravelDeskHotel> {
   async index() {
     try {
-      const where = this.query.where as WhereOptions<TravelDeskHotel>
+      const where = this.buildWhere()
+      const scopes = this.buildFilterScopes()
+      const order = this.buildOrder()
 
-      const scopedTravelDeskHotels = TravelDeskHotelsPolicy.applyScope(
-        TravelDeskHotel,
-        this.currentUser
-      )
+      const scopedTravelDeskHotels = TravelDeskHotelsPolicy.applyScope(scopes, this.currentUser)
 
       const totalCount = await scopedTravelDeskHotels.count({ where })
       const travelDeskHotels = await scopedTravelDeskHotels.findAll({
         where,
+        order,
         limit: this.pagination.limit,
         offset: this.pagination.offset,
       })

--- a/api/src/db/migrations/20250126210332_make-conference-name-and-hotel-name-fields-optional-in-travel-desk-hotels-table.ts
+++ b/api/src/db/migrations/20250126210332_make-conference-name-and-hotel-name-fields-optional-in-travel-desk-hotels-table.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("travel_desk_hotels", (table) => {
+    table.string("conference_name", 255).nullable().alter()
+    table.string("conference_hotel_name", 255).nullable().alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(/* sql */ `
+    UPDATE travel_desk_hotels
+    SET conference_name = '',
+        conference_hotel_name = ''
+  `)
+
+  await knex.schema.alterTable("travel_desk_hotels", (table) => {
+    table.string("conference_name", 255).notNullable().alter()
+    table.string("conference_hotel_name", 255).notNullable().alter()
+  })
+}

--- a/api/src/policies/travel-desk-hotels-policy.ts
+++ b/api/src/policies/travel-desk-hotels-policy.ts
@@ -8,6 +8,10 @@ import { allRecordsScope } from "@/policies/base-policy"
 import PolicyFactory from "@/policies/policy-factory"
 
 export class TravelDeskHotelsPolicy extends PolicyFactory(TravelDeskHotel) {
+  show(): boolean {
+    return this.travelDeskTravelRequestsPolicy.show()
+  }
+
   create(): boolean {
     return this.travelDeskTravelRequestsPolicy.update()
   }

--- a/api/src/policies/travel-desk-hotels-policy.ts
+++ b/api/src/policies/travel-desk-hotels-policy.ts
@@ -1,13 +1,13 @@
-import { ModelStatic, Op } from "sequelize"
+import { Attributes, FindOptions, Op } from "sequelize"
 import { isUndefined } from "lodash"
 
 import { Path } from "@/utils/deep-pick"
 import { User, TravelDeskHotel, TravelDeskTravelRequest } from "@/models"
 import TravelDeskTravelRequestsPolicy from "@/policies/travel-desk-travel-requests-policy"
+import { allRecordsScope } from "@/policies/base-policy"
+import PolicyFactory from "@/policies/policy-factory"
 
-import BasePolicy from "@/policies/base-policy"
-
-export class TravelDeskHotelsPolicy extends BasePolicy<TravelDeskHotel> {
+export class TravelDeskHotelsPolicy extends PolicyFactory(TravelDeskHotel) {
   create(): boolean {
     return this.travelDeskTravelRequestsPolicy.update()
   }
@@ -18,37 +18,6 @@ export class TravelDeskHotelsPolicy extends BasePolicy<TravelDeskHotel> {
 
   destroy(): boolean {
     return this.travelDeskTravelRequestsPolicy.update()
-  }
-
-  static applyScope(
-    modelClass: ModelStatic<TravelDeskHotel>,
-    currentUser: User
-  ): ModelStatic<TravelDeskHotel> {
-    if (currentUser.roles.includes(User.Roles.ADMIN)) {
-      return modelClass
-    }
-
-    return modelClass.scope({
-      // @ts-expect-error - Bad types in sequelize, all FindOptions are valid.
-      include: [
-        {
-          association: "travelRequest",
-          include: [
-            {
-              association: "travelAuthorization",
-              where: {
-                [Op.or]: [
-                  {
-                    supervisorEmail: currentUser.email,
-                  },
-                  { userId: currentUser.id },
-                ],
-              },
-            },
-          ],
-        },
-      ],
-    })
   }
 
   permittedAttributesForUpdate(): Path[] {
@@ -67,6 +36,33 @@ export class TravelDeskHotelsPolicy extends BasePolicy<TravelDeskHotel> {
 
   permittedAttributesForCreate(): Path[] {
     return ["travelRequestId", ...this.permittedAttributesForUpdate()]
+  }
+
+  static policyScope(user: User): FindOptions<Attributes<TravelDeskHotel>> {
+    if (user.isAdmin) {
+      return allRecordsScope
+    }
+
+    return {
+      include: [
+        {
+          association: "travelRequest",
+          include: [
+            {
+              association: "travelAuthorization",
+              where: {
+                [Op.or]: [
+                  {
+                    supervisorEmail: user.email,
+                  },
+                  { userId: user.id },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    }
   }
 
   private get travelDeskTravelRequest(): TravelDeskTravelRequest {

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -184,6 +184,7 @@ router
   .post(TravelDeskHotelsController.create)
 router
   .route("/api/travel-desk-hotels/:travelDeskHotelId")
+  .get(TravelDeskHotelsController.show)
   .patch(TravelDeskHotelsController.update)
   .delete(TravelDeskHotelsController.destroy)
 

--- a/api/src/services/travel-desk-hotels/create-service.ts
+++ b/api/src/services/travel-desk-hotels/create-service.ts
@@ -7,7 +7,10 @@ import BaseService from "@/services/base-service"
 type Attributes = Partial<TravelDeskHotel>
 
 export class CreateService extends BaseService {
-  constructor(protected attributes: Attributes, protected currentUser: User) {
+  constructor(
+    protected attributes: Attributes,
+    protected currentUser: User
+  ) {
     super()
   }
 
@@ -16,8 +19,6 @@ export class CreateService extends BaseService {
       travelRequestId,
       city,
       isDedicatedConferenceHotelAvailable,
-      conferenceName,
-      conferenceHotelName,
       checkIn,
       checkOut,
       ...optionalAttributes
@@ -35,14 +36,6 @@ export class CreateService extends BaseService {
       throw new Error("Is dedicated conference hotel available is required.")
     }
 
-    if (isNil(conferenceName)) {
-      throw new Error("Conference name is required.")
-    }
-
-    if (isNil(conferenceHotelName)) {
-      throw new Error("Conference hotel name is required.")
-    }
-
     if (isNil(checkIn)) {
       throw new Error("Check-in date is required.")
     }
@@ -55,8 +48,6 @@ export class CreateService extends BaseService {
       travelRequestId,
       city,
       isDedicatedConferenceHotelAvailable,
-      conferenceName,
-      conferenceHotelName,
       checkIn,
       checkOut,
       ...optionalAttributes,

--- a/web/src/api/travel-desk-hotels-api.js
+++ b/web/src/api/travel-desk-hotels-api.js
@@ -1,5 +1,7 @@
 import http from "@/api/http-client"
 
+/** @typedef {import('@/api/base-api.js').Policy} Policy */
+
 /** Keep in sync with api/src/models/travel-desk-hotel.ts */
 export const TRAVEL_DESK_HOTEL_STATUSES = Object.freeze({
   REQUESTED: "Requested",
@@ -7,28 +9,111 @@ export const TRAVEL_DESK_HOTEL_STATUSES = Object.freeze({
   RESERVED: "Reserved", // Uncofirmed, but seems likely.
 })
 
+/** @typedef {TRAVEL_DESK_HOTEL_STATUSES[keyof TRAVEL_DESK_HOTEL_STATUSES]} TravelDeskHotelStatuses */
+
+/**
+ * @typedef {{
+ *   id: number
+ *   travelRequestId: number
+ *   city: string
+ *   isDedicatedConferenceHotelAvailable: boolean
+ *   conferenceName: string | null
+ *   conferenceHotelName: string | null
+ *   checkIn: string
+ *   checkOut: string
+ *   additionalInformation: string | null
+ *   status: string
+ *   reservedHotelInfo: string | null
+ *   booking: string | null
+ *   createdAt: string
+ *   updatedAt: string
+ * }} TravelDeskHotel
+ */
+
+/**
+ * @typedef {{
+ *   id?: number
+ *   travelRequestId?: number
+ *   city?: string
+ *   isDedicatedConferenceHotelAvailable?: boolean
+ *   conferenceName?: string
+ *   conferenceHotelName?: string
+ *   checkIn?: string
+ *   checkOut?: string
+ *   status?: TravelDeskHotelStatuses
+ *   booking?: string
+ * }} TravelDeskHotelWhereOptions
+ */
+
+/**
+ * // match with model scopes signatures
+ * @typedef {{
+ * }} TravelDeskHotelFiltersOptions
+ */
+
+/**
+ * @typedef {{
+ *   where?: TravelDeskHotelWhereOptions;
+ *   filters?: TravelDeskHotelFiltersOptions;
+ *   order?: string;
+ *   page?: number;
+ *   perPage?: number
+ * }} TravelDeskHotelsQueryOptions
+ */
+
 export const travelDeskHotelsApi = {
-  async list({ where, page, perPage, ...otherParams } = {}) {
+  /**
+   * @param {TravelDeskHotelsQueryOptions} [params={}]
+   * @returns {Promise<{
+   *   travelDeskHotels: TravelDeskHotel[];
+   *   totalCount: number;
+   * }>}
+   */
+  async list(params = {}) {
     const { data } = await http.get("/api/travel-desk-hotels", {
-      params: { where, page, perPage, ...otherParams },
-    })
-    return data
-  },
-  // TODO: build back-end endpoint
-  async get(travelDeskHotelId, params = {}) {
-    const { data } = await http.get(`/api/travel-desk-hotels/${travelDeskHotelId}`, {
       params,
     })
     return data
   },
+  // TODO: build back-end endpoint
+  /**
+   * @param {number} travelDeskHotelId
+   * @returns {Promise<{
+   *   travelDeskHotel: TravelDeskHotel;
+   *   policy: Policy;
+   * }>}
+   */
+  async get(travelDeskHotelId) {
+    const { data } = await http.get(`/api/travel-desk-hotels/${travelDeskHotelId}`)
+    return data
+  },
+  /**
+   * @param {Partial<TravelDeskHotel>} attributes
+   * @returns {Promise<{
+   *   travelDeskHotel: TravelDeskHotel;
+   *   policy: Policy;
+   * }>}
+   */
   async create(attributes) {
     const { data } = await http.post("/api/travel-desk-hotels", attributes)
     return data
   },
+  /**
+   * @param {number} travelDeskHotelId
+   * @param {Partial<TravelDeskHotel>} attributes
+   * @returns {Promise<{
+   *   travelDeskHotel: TravelDeskHotel;
+   *   policy: Policy;
+   * }>}
+   */
   async update(travelDeskHotelId, attributes) {
     const { data } = await http.patch(`/api/travel-desk-hotels/${travelDeskHotelId}`, attributes)
     return data
   },
+  /**
+   * @param {number} travelDeskHotelId
+   * @returns {Promise<void>}
+   */
   async delete(travelDeskHotelId) {
     const { data } = await http.delete(`/api/travel-desk-hotels/${travelDeskHotelId}`)
     return data

--- a/web/src/components/common/wizards/StateStepper.vue
+++ b/web/src/components/common/wizards/StateStepper.vue
@@ -4,7 +4,7 @@
     :value="currentStepNumber"
     vertical
     outlined
-    :width="$vuetify.breakpoint.mdAndUp ? 300 : undefined"
+    :width="$vuetify.breakpoint.mdAndUp ? 250 : undefined"
   >
     <v-stepper-step
       v-for="(step, index) in steps"

--- a/web/src/components/travel-authorizations/manage/TravelAuthorizationsSupervisorDataTable.vue
+++ b/web/src/components/travel-authorizations/manage/TravelAuthorizationsSupervisorDataTable.vue
@@ -37,7 +37,7 @@ import { useRouter } from "vue2-helpers/vue-router"
 import { useI18n } from "@/plugins/vue-i18n-plugin"
 
 import formatDate from "@/utils/format-date"
-import useRouteQuery from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
 import useCurrentUser from "@/use/use-current-user"
 import useTravelAuthorizations from "@/use/use-travel-authorizations"
 
@@ -90,12 +90,10 @@ const headers = ref([
 ])
 
 const page = useRouteQuery(`page${props.routeQuerySuffix}`, 1, {
-  get: (value) => parseInt(value, 10),
-  set: (value) => value.toString(),
+  transform: integerTransformer,
 })
 const perPage = useRouteQuery(`perPage${props.routeQuerySuffix}`, 10, {
-  get: (value) => parseInt(value, 10),
-  set: (value) => value.toString(),
+  transform: integerTransformer,
 })
 
 const { currentUser } = useCurrentUser()

--- a/web/src/components/travel-desk-flight-options/TravelDeskFlightOptionEditDialog.vue
+++ b/web/src/components/travel-desk-flight-options/TravelDeskFlightOptionEditDialog.vue
@@ -116,7 +116,7 @@ import { required } from "@/utils/validators"
 
 import travelDeskFlightOptionsApi from "@/api/travel-desk-flight-options-api"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 import useTravelDeskFlightOption from "@/use/use-travel-desk-flight-option"
 import useTravelDeskFlightSegments from "@/use/use-travel-desk-flight-segments"
@@ -127,7 +127,7 @@ import TravelDeskFlightSegmentAttributesCard from "@/components/travel-desk-flig
 const emit = defineEmits(["saved"])
 
 const travelDeskFlightOptionId = useRouteQuery("showFlightOptionEdit", undefined, {
-  transformer: integerTransformer,
+  transformer: integerTransformerLegacy,
 })
 
 const { travelDeskFlightOption, isLoading } = useTravelDeskFlightOption(travelDeskFlightOptionId)

--- a/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestEditDialog.vue
+++ b/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestEditDialog.vue
@@ -135,7 +135,7 @@ import { required } from "@/utils/validators"
 
 import travelDeskFlightRequestsApi from "@/api/travel-desk-flight-requests-api"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 import useTraveDeskFlightRequest from "@/use/use-travel-desk-flight-request"
 
@@ -156,7 +156,7 @@ defineProps({
 const emit = defineEmits(["saved"])
 
 const travelDeskFlightRequestId = useRouteQuery("showFlightRequestEdit", undefined, {
-  transformer: integerTransformer,
+  transformer: integerTransformerLegacy,
 })
 
 const { travelDeskFlightRequest, isLoading } = useTraveDeskFlightRequest(travelDeskFlightRequestId)

--- a/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestsDataTable.vue
+++ b/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestsDataTable.vue
@@ -19,7 +19,7 @@ import { computed } from "vue"
 
 import formatDate from "@/utils/format-date"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useTravelDeskFlightRequests from "@/use/use-travel-desk-flight-requests"
 
 const props = defineProps({
@@ -61,10 +61,10 @@ const headers = [
 ]
 
 const page = useRouteQuery(`page${props.routeQuerySuffix}`, "1", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 const perPage = useRouteQuery(`perPage${props.routeQuerySuffix}`, props.defaultPerPage, {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const travelDeskFlightRequestsQuery = computed(() => ({

--- a/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestsEditTable.vue
+++ b/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestsEditTable.vue
@@ -59,7 +59,7 @@ import formatDate from "@/utils/format-date"
 
 import travelDeskFlightRequestsApi from "@/api/travel-desk-flight-requests-api"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 import useTravelDeskFlightRequests from "@/use/use-travel-desk-flight-requests"
 
@@ -119,10 +119,10 @@ const headers = [
 ]
 
 const page = useRouteQuery(`page${props.routeQuerySuffix}`, "1", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 const perPage = useRouteQuery(`perPage${props.routeQuerySuffix}`, "5", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const travelDeskFlightRequestsQuery = computed(() => ({

--- a/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestsManageTable.vue
+++ b/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestsManageTable.vue
@@ -27,7 +27,7 @@
 <script setup>
 import { computed, ref } from "vue"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 
 import TravelDeskFlightOptionsDataIterator from "@/components/travel-desk-flight-options/TravelDeskFlightOptionsDataIterator.vue"
 import TravelDeskFlightRequestsEditTable from "@/components/travel-desk-flight-requests/TravelDeskFlightRequestsEditTable.vue"
@@ -40,7 +40,7 @@ const props = defineProps({
 })
 
 const expandTravelDeskFlightRequest = useRouteQuery("expandTravelDeskFlightRequest", undefined, {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 function expandItem(travelDeskFlightRequestId) {

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue
@@ -90,7 +90,10 @@
             </v-col>
           </v-row>
 
-          <v-row class="mt-0 mx-3">
+          <v-row
+            v-if="hotel.isDedicatedConferenceHotelAvailable"
+            class="mt-0 mx-3"
+          >
             <v-col
               cols="12"
               md="4"

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue
@@ -3,11 +3,12 @@
     v-model="showDialog"
     persistent
     max-width="80%"
+    @keydown.esc="close"
   >
     <template #activator="{ on, attrs }">
       <v-btn
         color="primary"
-        v-bind="attrs"
+        v-bind="merge(attrs, activatorProps)"
         v-on="on"
       >
         Add Hotel
@@ -142,7 +143,7 @@
 <script setup>
 import { ref, nextTick, watch, watchEffect } from "vue"
 import { useRoute, useRouter } from "vue2-helpers/vue-router"
-import { isNil } from "lodash"
+import { isNil, merge } from "lodash"
 
 import { required } from "@/utils/validators"
 import { useSnack } from "@/plugins/snack-plugin"
@@ -151,6 +152,10 @@ import travelDeskHotelsApi from "@/api/travel-desk-hotels-api"
 import LocationsAutocomplete from "@/components/locations/LocationsAutocomplete.vue"
 
 const props = defineProps({
+  activatorProps: {
+    type: Object,
+    default: () => ({}),
+  },
   travelDeskTravelRequestId: {
     type: Number,
     required: true,

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue
@@ -31,7 +31,7 @@
               md="4"
             >
               <v-text-field
-                v-model="hotel.checkIn"
+                v-model="travelDeskHotelAttributes.checkIn"
                 label="Check-in Date *"
                 type="date"
                 :rules="[required]"
@@ -41,7 +41,7 @@
                 required
               />
               <v-text-field
-                v-model="hotel.checkOut"
+                v-model="travelDeskHotelAttributes.checkOut"
                 label="Check-out Date *"
                 type="date"
                 :rules="[required]"
@@ -51,7 +51,7 @@
                 required
               />
               <LocationsAutocomplete
-                v-model="hotel.city"
+                v-model="travelDeskHotelAttributes.city"
                 label="City *"
                 item-value="city"
                 :rules="[required]"
@@ -59,7 +59,7 @@
                 required
               />
               <v-radio-group
-                v-model="hotel.isDedicatedConferenceHotelAvailable"
+                v-model="travelDeskHotelAttributes.isDedicatedConferenceHotelAvailable"
                 label="Conference/Meeting Hotel? *"
                 :rules="[required]"
                 outlined
@@ -81,7 +81,7 @@
               md="8"
             >
               <v-textarea
-                v-model="hotel.additionalInformation"
+                v-model="travelDeskHotelAttributes.additionalInformation"
                 label="Additional Information"
                 rows="8"
                 outlined
@@ -91,7 +91,7 @@
           </v-row>
 
           <v-row
-            v-if="hotel.isDedicatedConferenceHotelAvailable"
+            v-if="travelDeskHotelAttributes.isDedicatedConferenceHotelAvailable"
             class="mt-0 mx-3"
           >
             <v-col
@@ -99,7 +99,7 @@
               md="4"
             >
               <v-text-field
-                v-model="hotel.conferenceName"
+                v-model="travelDeskHotelAttributes.conferenceName"
                 label="Conference/Meeting Name *"
                 :rules="[required]"
                 outlined
@@ -111,7 +111,7 @@
               md="8"
             >
               <v-text-field
-                v-model="hotel.conferenceHotelName"
+                v-model="travelDeskHotelAttributes.conferenceHotelName"
                 label="Conference/Meeting Hotel *"
                 :rules="[required]"
                 outlined
@@ -184,7 +184,7 @@ const props = defineProps({
 
 const emit = defineEmits(["created"])
 
-const hotel = ref({
+const travelDeskHotelAttributes = ref({
   travelRequestId: props.travelDeskTravelRequestId,
   checkIn: props.flightStart,
   checkOut: props.flightEnd,
@@ -209,14 +209,14 @@ watch(
 )
 
 watchEffect(() => {
-  if (isNil(hotel.value.checkIn)) {
-    hotel.value.checkIn = props.flightStart
+  if (isNil(travelDeskHotelAttributes.value.checkIn)) {
+    travelDeskHotelAttributes.value.checkIn = props.flightStart
   }
 })
 
 watchEffect(() => {
-  if (isNil(hotel.value.checkOut)) {
-    hotel.value.checkOut = props.flightEnd
+  if (isNil(travelDeskHotelAttributes.value.checkOut)) {
+    travelDeskHotelAttributes.value.checkOut = props.flightEnd
   }
 })
 
@@ -243,9 +243,16 @@ async function createAndClose() {
     return
   }
 
+  if (travelDeskHotelAttributes.value.isDedicatedConferenceHotelAvailable === false) {
+    travelDeskHotelAttributes.value.conferenceName = undefined
+    travelDeskHotelAttributes.value.conferenceHotelName = undefined
+  }
+
   isLoading.value = true
   try {
-    const { travelDeskHotel: newHotel } = await travelDeskHotelsApi.create(hotel.value)
+    const { travelDeskHotel: newHotel } = await travelDeskHotelsApi.create(
+      travelDeskHotelAttributes.value
+    )
     close()
 
     await nextTick()
@@ -260,7 +267,7 @@ async function createAndClose() {
 }
 
 function resetState() {
-  hotel.value = {
+  travelDeskHotelAttributes.value = {
     travelRequestId: props.travelDeskTravelRequestId,
     checkIn: props.flightStart,
     checkOut: props.flightEnd,

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue
@@ -88,7 +88,10 @@
             </v-col>
           </v-row>
 
-          <v-row class="mt-0 mx-3">
+          <v-row
+            v-if="travelDeskHotel.isDedicatedConferenceHotelAvailable"
+            class="mt-0 mx-3"
+          >
             <v-col
               cols="12"
               md="4"

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue
@@ -218,6 +218,11 @@ async function updateAndHide() {
     return
   }
 
+  if (travelDeskHotel.value.isDedicatedConferenceHotelAvailable === false) {
+    travelDeskHotel.value.conferenceName = undefined
+    travelDeskHotel.value.conferenceHotelName = undefined
+  }
+
   isLoading.value = true
   try {
     const { travelDeskHotel: newTravelDeskHotel } = await travelDeskHotelsApi.update(

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelsDataTable.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelsDataTable.vue
@@ -1,0 +1,135 @@
+<template>
+  <v-data-table
+    :page.sync="page"
+    :items-per-page.sync="perPage"
+    :sort-by.sync="vuetify2SortBy"
+    :sort-desc.sync="vuetify2SortDesc"
+    :headers="headers"
+    :items="travelDeskHotels"
+    :server-items-length="totalCount"
+    :loading="isLoading"
+  >
+    <template #top="slotProps"
+      ><slot
+        name="top"
+        v-bind="slotProps"
+      ></slot
+    ></template>
+    <template #item.isDedicatedConferenceHotelAvailable="{ item }">
+      {{ item.isDedicatedConferenceHotelAvailable ? "Yes" : "No" }}
+    </template>
+
+    <template #item.checkIn="{ item }">
+      {{ formatDate(item.checkIn) }}
+    </template>
+
+    <template #item.checkOut="{ item }">
+      {{ formatDate(item.checkOut) }}
+    </template>
+
+    <!-- TODO: add "view" action -->
+    <template #item.actions="slotProps"
+      ><slot
+        name="item.actions"
+        v-bind="slotProps"
+      ></slot
+    ></template>
+  </v-data-table>
+</template>
+
+<script setup>
+import { computed, ref } from "vue"
+
+import formatDate from "@/utils/format-date"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
+import useVuetifySortByToSafeRouteQuery from "@/use/utils/use-vuetify-sort-by-to-safe-route-query"
+import useVuetifySortByToSequelizeSafeOrder from "@/use/utils/use-vuetify-sort-by-to-sequelize-safe-order"
+import useVuetify2SortByShim from "@/use/utils/use-vuetify2-sort-by-shim"
+import useTravelDeskHotels from "@/use/use-travel-desk-hotels"
+
+const props = defineProps({
+  where: {
+    type: Object,
+    default: () => ({}),
+  },
+  filters: {
+    type: Object,
+    default: () => ({}),
+  },
+  routeQuerySuffix: {
+    type: String,
+    default: "",
+  },
+})
+
+const headers = ref([
+  {
+    text: "Check-in",
+    value: "checkIn",
+  },
+  {
+    text: "Check-out",
+    value: "checkOut",
+  },
+  {
+    text: "City",
+    value: "city",
+    sortable: false,
+  },
+  {
+    text: "Conference Hotel?",
+    value: "isDedicatedConferenceHotelAvailable",
+    sortable: false,
+  },
+  {
+    text: "Conference/Meeting Name",
+    value: "conferenceName",
+    sortable: false,
+  },
+  {
+    text: "Conference/Meeting Hotel",
+    value: "conferenceHotelName",
+    sortable: false,
+  },
+  {
+    text: "Additional Information",
+    value: "additionalInformation",
+    sortable: false,
+  },
+  {
+    text: "Actions",
+    value: "actions",
+    align: "end",
+    sortable: false,
+  },
+])
+
+const page = useRouteQuery(`page${props.routeQuerySuffix}`, 1, {
+  transform: integerTransformerLegacy,
+})
+const perPage = useRouteQuery(`perPage${props.routeQuerySuffix}`, 5, {
+  transform: integerTransformerLegacy,
+})
+const sortBy = useVuetifySortByToSafeRouteQuery("sortBy", [
+  {
+    key: "checkIn",
+    order: "asc",
+  },
+])
+const { vuetify2SortBy, vuetify2SortDesc } = useVuetify2SortByShim(sortBy)
+const order = useVuetifySortByToSequelizeSafeOrder(sortBy)
+
+const travelDeskHotelsQuery = computed(() => ({
+  where: props.where,
+  filters: props.filters,
+  order: order.value,
+  page: page.value,
+  perPage: perPage.value,
+}))
+const { travelDeskHotels, totalCount, isLoading, refresh } =
+  useTravelDeskHotels(travelDeskHotelsQuery)
+
+defineExpose({
+  refresh,
+})
+</script>

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelsEditCard.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelsEditCard.vue
@@ -15,40 +15,14 @@
       />
     </v-card-title>
     <v-card-text>
-      <TravelDeskHotelsDataTable
-        ref="travelDeskHotelsDataTable"
+      <TravelDeskHotelsEditDataTable
+        ref="travelDeskHotelsEditDataTable"
         :where="whereClause"
-      >
-        <template #top>
-          <TravelDeskHotelEditDialog
-            ref="editDialog"
-            :min-date="minDate"
-            :max-date="maxDate"
-            :flight-start="earliestFlightDate"
-            :flight-end="latestFlightDate"
-            @saved="refreshTravelDeskHotels"
-          />
-        </template>
-        <template #item.actions="{ item }">
-          <div class="d-flex justify-end">
-            <v-btn
-              title="Edit"
-              icon
-              color="blue"
-              @click="showEditDialog(item)"
-              ><v-icon>mdi-pencil</v-icon></v-btn
-            >
-            <v-btn
-              :loading="isLoading"
-              title="Delete"
-              icon
-              color="red"
-              @click="deleteHotel(item)"
-              ><v-icon>mdi-close</v-icon></v-btn
-            >
-          </div>
-        </template>
-      </TravelDeskHotelsDataTable>
+        :min-date="minDate"
+        :max-date="maxDate"
+        :flight-start="earliestFlightDate"
+        :flight-end="latestFlightDate"
+      />
     </v-card-text>
   </v-card>
 </template>
@@ -56,14 +30,11 @@
 <script setup>
 import { computed, ref, toRefs } from "vue"
 
-import blockedToTrueConfirm from "@/utils/blocked-to-true-confirm"
-import travelDeskHotelsApi from "@/api/travel-desk-hotels-api"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 import useTravelDeskFlightRequests from "@/use/use-travel-desk-flight-requests"
 
 import TravelDeskHotelCreateDialog from "@/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue"
-import TravelDeskHotelEditDialog from "@/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue"
-import TravelDeskHotelsDataTable from "@/components/travel-desk-hotels/TravelDeskHotelsDataTable.vue"
+import TravelDeskHotelsEditDataTable from "@/components/travel-desk-hotels/TravelDeskHotelsEditDataTable.vue"
 
 const props = defineProps({
   travelDeskTravelRequestId: {
@@ -99,33 +70,11 @@ const {
   refresh: refreshFlightRequests,
 } = useTravelDeskFlightRequests(travelDeskFlightRequestsQuery)
 
-/** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelEditDialog> | null>} */
-const editDialog = ref(null)
-
-function showEditDialog(hotel) {
-  editDialog.value?.show(hotel)
-}
-
-const isLoading = ref(false)
 /** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelsDataTable> | null>} */
-const travelDeskHotelsDataTable = ref(null)
+const travelDeskHotelsEditDataTable = ref(null)
 
 async function refreshTravelDeskHotels() {
-  return travelDeskHotelsDataTable.value?.refresh()
-}
-
-async function deleteHotel(hotel) {
-  if (!blockedToTrueConfirm("Are you sure you want to remove this hotel?")) return
-
-  isLoading.value = true
-  try {
-    await travelDeskHotelsApi.delete(hotel.id)
-    await refreshTravelDeskHotels()
-  } catch (error) {
-    console.error(error)
-  } finally {
-    isLoading.value = false
-  }
+  return travelDeskHotelsEditDataTable.value?.refresh()
 }
 
 defineExpose({

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelsEditCard.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelsEditCard.vue
@@ -1,62 +1,56 @@
 <template>
-  <div>
-    <TitleCard class="mt-10">
-      <template #title>
-        <div>Hotel Request</div>
-      </template>
-      <template #body>
-        <div class="d-flex justify-end pr-4">
-          <TravelDeskHotelCreateDialog
-            class="ml-auto mr-3"
-            :travel-desk-travel-request-id="travelDeskTravelRequestId"
+  <v-card>
+    <v-card-title class="d-flex justify-space-between align-center">
+      <h3>Hotel Requests</h3>
+      <TravelDeskHotelCreateDialog
+        :activator-props="{
+          class: 'my-0',
+        }"
+        :travel-desk-travel-request-id="travelDeskTravelRequestId"
+        :min-date="minDate"
+        :max-date="maxDate"
+        :flight-start="earliestFlightDate"
+        :flight-end="latestFlightDate"
+        @created="refreshTravelDeskHotels"
+      />
+    </v-card-title>
+    <v-card-text>
+      <TravelDeskHotelsDataTable
+        ref="travelDeskHotelsDataTable"
+        :where="whereClause"
+      >
+        <template #top>
+          <TravelDeskHotelEditDialog
+            ref="editDialog"
             :min-date="minDate"
             :max-date="maxDate"
             :flight-start="earliestFlightDate"
             :flight-end="latestFlightDate"
-            @created="refreshTravelDeskHotels"
+            @saved="refreshTravelDeskHotels"
           />
-        </div>
-        <v-row class="mb-3 mx-3">
-          <v-col cols="12">
-            <TravelDeskHotelsDataTable
-              ref="travelDeskHotelsDataTable"
-              :where="whereClause"
+        </template>
+        <template #item.actions="{ item }">
+          <div class="d-flex justify-end">
+            <v-btn
+              title="Edit"
+              icon
+              color="blue"
+              @click="showEditDialog(item)"
+              ><v-icon>mdi-pencil</v-icon></v-btn
             >
-              <template #top>
-                <TravelDeskHotelEditDialog
-                  ref="editDialog"
-                  :min-date="minDate"
-                  :max-date="maxDate"
-                  :flight-start="earliestFlightDate"
-                  :flight-end="latestFlightDate"
-                  @saved="refreshTravelDeskHotels"
-                />
-              </template>
-              <template #item.actions="{ item }">
-                <div class="d-flex justify-end">
-                  <v-btn
-                    title="Edit"
-                    icon
-                    color="blue"
-                    @click="showEditDialog(item)"
-                    ><v-icon>mdi-pencil</v-icon></v-btn
-                  >
-                  <v-btn
-                    :loading="isLoading"
-                    title="Delete"
-                    icon
-                    color="red"
-                    @click="deleteHotel(item)"
-                    ><v-icon>mdi-close</v-icon></v-btn
-                  >
-                </div>
-              </template>
-            </TravelDeskHotelsDataTable>
-          </v-col>
-        </v-row>
-      </template>
-    </TitleCard>
-  </div>
+            <v-btn
+              :loading="isLoading"
+              title="Delete"
+              icon
+              color="red"
+              @click="deleteHotel(item)"
+              ><v-icon>mdi-close</v-icon></v-btn
+            >
+          </div>
+        </template>
+      </TravelDeskHotelsDataTable>
+    </v-card-text>
+  </v-card>
 </template>
 
 <script setup>
@@ -67,7 +61,6 @@ import travelDeskHotelsApi from "@/api/travel-desk-hotels-api"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 import useTravelDeskFlightRequests from "@/use/use-travel-desk-flight-requests"
 
-import TitleCard from "@/modules/travelDesk/views/Common/TitleCard.vue"
 import TravelDeskHotelCreateDialog from "@/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue"
 import TravelDeskHotelEditDialog from "@/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue"
 import TravelDeskHotelsDataTable from "@/components/travel-desk-hotels/TravelDeskHotelsDataTable.vue"

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelsEditDataTable.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelsEditDataTable.vue
@@ -1,0 +1,108 @@
+<template>
+  <TravelDeskHotelsDataTable
+    ref="travelDeskHotelsDataTable"
+    :where="where"
+    :filters="filters"
+  >
+    <template #top>
+      <TravelDeskHotelEditDialog
+        ref="editDialog"
+        :min-date="minDate"
+        :max-date="maxDate"
+        :flight-start="earliestFlightDate"
+        :flight-end="latestFlightDate"
+        @saved="refreshTravelDeskHotels"
+      />
+    </template>
+    <template #item.actions="{ item }">
+      <div class="d-flex justify-end">
+        <v-btn
+          title="Edit"
+          icon
+          color="blue"
+          @click="showEditDialog(item)"
+          ><v-icon>mdi-pencil</v-icon></v-btn
+        >
+        <v-btn
+          :loading="isLoading"
+          title="Delete"
+          icon
+          color="red"
+          @click="deleteHotel(item)"
+          ><v-icon>mdi-close</v-icon></v-btn
+        >
+      </div>
+    </template>
+  </TravelDeskHotelsDataTable>
+</template>
+
+<script setup>
+import { ref } from "vue"
+
+import blockedToTrueConfirm from "@/utils/blocked-to-true-confirm"
+import travelDeskHotelsApi from "@/api/travel-desk-hotels-api"
+
+import TravelDeskHotelsDataTable from "@/components/travel-desk-hotels/TravelDeskHotelsDataTable.vue"
+import TravelDeskHotelEditDialog from "@/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue"
+
+defineProps({
+  where: {
+    type: Object,
+    default: () => ({}),
+  },
+  filters: {
+    type: Object,
+    default: () => ({}),
+  },
+  minDate: {
+    type: String,
+    required: true,
+  },
+  maxDate: {
+    type: String,
+    required: true,
+  },
+  earliestFlightDate: {
+    type: String,
+    required: true,
+  },
+  latestFlightDate: {
+    type: String,
+    required: true,
+  },
+})
+
+/** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelEditDialog> | null>} */
+const editDialog = ref(null)
+
+function showEditDialog(hotel) {
+  editDialog.value?.show(hotel)
+}
+
+/** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelsDataTable> | null>} */
+const travelDeskHotelsDataTable = ref(null)
+
+async function refreshTravelDeskHotels() {
+  return travelDeskHotelsDataTable.value?.refresh()
+}
+
+const isLoading = ref(false)
+
+async function deleteHotel(hotel) {
+  if (!blockedToTrueConfirm("Are you sure you want to remove this hotel?")) return
+
+  isLoading.value = true
+  try {
+    await travelDeskHotelsApi.delete(hotel.id)
+    await refreshTravelDeskHotels()
+  } catch (error) {
+    console.error(error)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+defineExpose({
+  refresh: refreshTravelDeskHotels,
+})
+</script>

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelsEditDataTable.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelsEditDataTable.vue
@@ -20,7 +20,7 @@
           title="Edit"
           icon
           color="blue"
-          @click="showEditDialog(item)"
+          @click="showEditDialog(item.id)"
           ><v-icon>mdi-pencil</v-icon></v-btn
         >
         <v-btn
@@ -56,27 +56,27 @@ defineProps({
   },
   minDate: {
     type: String,
-    required: true,
+    default: null,
   },
   maxDate: {
     type: String,
-    required: true,
+    default: null,
   },
   earliestFlightDate: {
     type: String,
-    required: true,
+    default: null,
   },
   latestFlightDate: {
     type: String,
-    required: true,
+    default: null,
   },
 })
 
 /** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelEditDialog> | null>} */
 const editDialog = ref(null)
 
-function showEditDialog(hotel) {
-  editDialog.value?.show(hotel)
+function showEditDialog(travelDeskHotelId) {
+  editDialog.value?.show(travelDeskHotelId)
 }
 
 /** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelsDataTable> | null>} */

--- a/web/src/components/travel-desk-hotels/TravelDeskHotelsEditTable.vue
+++ b/web/src/components/travel-desk-hotels/TravelDeskHotelsEditTable.vue
@@ -13,16 +13,14 @@
             :max-date="maxDate"
             :flight-start="earliestFlightDate"
             :flight-end="latestFlightDate"
-            @created="refresh"
+            @created="refreshTravelDeskHotels"
           />
         </div>
         <v-row class="mb-3 mx-3">
           <v-col cols="12">
-            <v-data-table
-              :headers="headers"
-              :items="travelDeskHotels"
-              hide-default-footer
-              class="elevation-1"
+            <TravelDeskHotelsDataTable
+              ref="travelDeskHotelsDataTable"
+              :where="whereClause"
             >
               <template #top>
                 <TravelDeskHotelEditDialog
@@ -31,21 +29,9 @@
                   :max-date="maxDate"
                   :flight-start="earliestFlightDate"
                   :flight-end="latestFlightDate"
-                  @saved="refresh"
+                  @saved="refreshTravelDeskHotels"
                 />
               </template>
-              <template #item.isDedicatedConferenceHotelAvailable="{ item }">
-                {{ item.isDedicatedConferenceHotelAvailable ? "Yes" : "No" }}
-              </template>
-
-              <template #item.checkIn="{ item }">
-                {{ formatDate(item.checkIn) }}
-              </template>
-
-              <template #item.checkOut="{ item }">
-                {{ formatDate(item.checkOut) }}
-              </template>
-
               <template #item.actions="{ item }">
                 <div class="d-flex justify-end">
                   <v-btn
@@ -65,7 +51,7 @@
                   >
                 </div>
               </template>
-            </v-data-table>
+            </TravelDeskHotelsDataTable>
           </v-col>
         </v-row>
       </template>
@@ -74,20 +60,17 @@
 </template>
 
 <script setup>
-import { computed, ref, toRefs, watch } from "vue"
-import { DateTime } from "luxon"
-import { isNil } from "lodash"
-import { useRoute } from "vue2-helpers/vue-router"
+import { computed, ref, toRefs } from "vue"
 
 import blockedToTrueConfirm from "@/utils/blocked-to-true-confirm"
 import travelDeskHotelsApi from "@/api/travel-desk-hotels-api"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 import useTravelDeskFlightRequests from "@/use/use-travel-desk-flight-requests"
-import useTravelDeskHotels from "@/use/use-travel-desk-hotels"
 
 import TitleCard from "@/modules/travelDesk/views/Common/TitleCard.vue"
 import TravelDeskHotelCreateDialog from "@/components/travel-desk-hotels/TravelDeskHotelCreateDialog.vue"
 import TravelDeskHotelEditDialog from "@/components/travel-desk-hotels/TravelDeskHotelEditDialog.vue"
+import TravelDeskHotelsDataTable from "@/components/travel-desk-hotels/TravelDeskHotelsDataTable.vue"
 
 const props = defineProps({
   travelDeskTravelRequestId: {
@@ -100,51 +83,9 @@ const props = defineProps({
   },
 })
 
-const headers = ref([
-  { text: "Check-in", value: "checkIn", class: "blue-grey lighten-4" },
-  { text: "Check-out", value: "checkOut", class: "blue-grey lighten-4" },
-  { text: "City", value: "city", class: "blue-grey lighten-4", sortable: false },
-  {
-    text: "Conference Hotel?",
-    value: "isDedicatedConferenceHotelAvailable",
-    class: "blue-grey lighten-4",
-    sortable: false,
-  },
-  {
-    text: "Conference/Meeting Name",
-    value: "conferenceName",
-    class: "blue-grey lighten-4",
-    sortable: false,
-  },
-  {
-    text: "Conference/Meeting Hotel",
-    value: "conferenceHotelName",
-    class: "blue-grey lighten-4",
-    sortable: false,
-  },
-  {
-    text: "Additional Information",
-    value: "additionalInformation",
-    class: "blue-grey lighten-4",
-    sortable: false,
-  },
-  {
-    text: "",
-    value: "actions",
-    class: "blue-grey lighten-4",
-    width: "4rem",
-    sortable: false,
-  },
-])
-
-const route = useRoute()
-
-const travelDeskHotelsQuery = computed(() => ({
-  where: {
-    travelRequestId: props.travelDeskTravelRequestId,
-  },
+const whereClause = computed(() => ({
+  travelRequestId: props.travelDeskTravelRequestId,
 }))
-const { travelDeskHotels, isLoading, refresh } = useTravelDeskHotels(travelDeskHotelsQuery)
 
 const { travelAuthorizationId } = toRefs(props)
 const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)
@@ -168,41 +109,29 @@ const {
 /** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelEditDialog> | null>} */
 const editDialog = ref(null)
 
-function formatDate(date) {
-  return DateTime.fromISO(date, { zone: "utc" }).toFormat("MMM dd yyyy")
-}
-
 function showEditDialog(hotel) {
   editDialog.value?.show(hotel)
 }
 
-function showEditDialogForRouteQuery() {
-  const hotelId = parseInt(route.query.showHotelEdit)
-  if (isNaN(hotelId)) return
+const isLoading = ref(false)
+/** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelsDataTable> | null>} */
+const travelDeskHotelsDataTable = ref(null)
 
-  const hotel = travelDeskHotels.value.find((hotel) => hotel.id === hotelId)
-  if (isNil(hotel)) return
-
-  showEditDialog(hotel)
+async function refreshTravelDeskHotels() {
+  return travelDeskHotelsDataTable.value?.refresh()
 }
-
-watch(
-  () => travelDeskHotels.value,
-  (hotels) => {
-    if (hotels.length === 0) return
-
-    showEditDialogForRouteQuery()
-  }
-)
 
 async function deleteHotel(hotel) {
   if (!blockedToTrueConfirm("Are you sure you want to remove this hotel?")) return
 
+  isLoading.value = true
   try {
     await travelDeskHotelsApi.delete(hotel.id)
-    await refresh()
+    await refreshTravelDeskHotels()
   } catch (error) {
     console.error(error)
+  } finally {
+    isLoading.value = false
   }
 }
 

--- a/web/src/components/travel-desk-questions/TravelDeskQuestionEditDialog.vue
+++ b/web/src/components/travel-desk-questions/TravelDeskQuestionEditDialog.vue
@@ -87,7 +87,7 @@ import travelDeskQuestionsApi from "@/api/travel-desk-questions-api"
 
 import { required } from "@/utils/validators"
 import useSnack from "@/use/use-snack"
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useTravelDeskQuestion from "@/use/use-travel-desk-question"
 
 import RequestTypeSelect from "@/components/travel-desk-questions/RequestTypeSelect.vue"
@@ -95,7 +95,7 @@ import RequestTypeSelect from "@/components/travel-desk-questions/RequestTypeSel
 const emit = defineEmits(["saved"])
 
 const travelDeskQuestionId = useRouteQuery("showQuestionEdit", undefined, {
-  transformer: integerTransformer,
+  transformer: integerTransformerLegacy,
 })
 
 const { travelDeskQuestion, isLoading } = useTravelDeskQuestion(travelDeskQuestionId)

--- a/web/src/components/travel-desk-questions/TravelDeskQuestionsDataTable.vue
+++ b/web/src/components/travel-desk-questions/TravelDeskQuestionsDataTable.vue
@@ -22,7 +22,7 @@ import { computed } from "vue"
 
 import { useI18n } from "@/plugins/vue-i18n-plugin"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useTravelDeskQuestions from "@/use/use-travel-desk-questions"
 
 const props = defineProps({
@@ -62,10 +62,10 @@ const headers = [
 const { t } = useI18n()
 
 const page = useRouteQuery(`page${props.routeQuerySuffix}`, "1", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 const perPage = useRouteQuery(`perPage${props.routeQuerySuffix}`, props.defaultPerPage, {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const travelDeskQuestionsQuery = computed(() => ({

--- a/web/src/components/travel-desk-questions/TravelDeskQuestionsEditDataTable.vue
+++ b/web/src/components/travel-desk-questions/TravelDeskQuestionsEditDataTable.vue
@@ -53,7 +53,7 @@ import { useI18n } from "@/plugins/vue-i18n-plugin"
 
 import travelDeskQuestionsApi from "@/api/travel-desk-questions-api"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 import useTravelDeskQuestions from "@/use/use-travel-desk-questions"
 import TravelDeskQuestionEditDialog from "@/components/travel-desk-questions/TravelDeskQuestionEditDialog.vue"
@@ -100,10 +100,10 @@ const headers = [
 const { t } = useI18n()
 
 const page = useRouteQuery(`page${props.routeQuerySuffix}`, "1", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 const perPage = useRouteQuery(`perPage${props.routeQuerySuffix}`, props.defaultPerPage, {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const travelDeskQuestionsQuery = computed(() => ({

--- a/web/src/components/travel-desk-travel-requests/TravelDeskTravelRequestConfirmBookingDialog.vue
+++ b/web/src/components/travel-desk-travel-requests/TravelDeskTravelRequestConfirmBookingDialog.vue
@@ -41,7 +41,7 @@ import { isNil } from "lodash"
 
 import { useSnack } from "@/plugins/snack-plugin"
 import travelDeskTravelRequestsApi from "@/api/travel-desk-travel-requests-api"
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 
 const emit = defineEmits({
   booked: null,
@@ -51,7 +51,7 @@ const confirmBookingDialog = ref(false)
 const isLoading = ref(false)
 const travelDeskTravelRequestId = useRouteQuery("showConfirmBooking", null, {
   mode: "push",
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const snack = useSnack()

--- a/web/src/components/travel-desk-travel-requests/TravelDeskTravelRequestEditCard.vue
+++ b/web/src/components/travel-desk-travel-requests/TravelDeskTravelRequestEditCard.vue
@@ -18,8 +18,9 @@
         :travel-desk-travel-request-id="travelDeskTravelRequestId"
         :travel-authorization-id="travelAuthorizationId"
       />
-      <TravelDeskHotelsEditTable
-        ref="travelDeskHotelEditTable"
+      <TravelDeskHotelsEditCard
+        ref="travelDeskHotelEditCard"
+        class="mt-6"
         :travel-desk-travel-request-id="travelDeskTravelRequestId"
         :travel-authorization-id="travelAuthorizationId"
       />
@@ -38,7 +39,7 @@ import { isNil } from "lodash"
 import useTravelDeskTravelRequest from "@/use/use-travel-desk-travel-request"
 
 import TravelDeskFlightRequestsEditCard from "@/components/travel-desk-flight-requests/TravelDeskFlightRequestsEditCard.vue"
-import TravelDeskHotelsEditTable from "@/components/travel-desk-hotels/TravelDeskHotelsEditTable.vue"
+import TravelDeskHotelsEditCard from "@/components/travel-desk-hotels/TravelDeskHotelsEditCard.vue"
 import TravelDeskOtherTransportationsEditTable from "@/components/travel-desk-other-transportations/TravelDeskOtherTransportationsEditTable.vue"
 import TravelDeskRentalCarsEditTable from "@/components/travel-desk-rental-cars/TravelDeskRentalCarsEditTable.vue"
 
@@ -56,12 +57,12 @@ const travelAuthorizationId = computed(() => travelDeskTravelRequest.value?.trav
 
 /** @type {import("vue").Ref<InstanceType<typeof TravelDeskRentalCarsEditTable> | null>} */
 const travelDeskRentalCarsEditTable = ref(null)
-/** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelsEditTable> | null>} */
-const travelDeskHotelEditTable = ref(null)
+/** @type {import("vue").Ref<InstanceType<typeof TravelDeskHotelsEditCard> | null>} */
+const travelDeskHotelEditCard = ref(null)
 
 function refreshTablesUsingFlightInfo() {
   travelDeskRentalCarsEditTable.value?.refresh()
-  travelDeskHotelEditTable.value?.refresh()
+  travelDeskHotelEditCard.value?.refresh()
 }
 </script>
 

--- a/web/src/components/travel-desk-travel-requests/TravelDeskTravelRequestsManageDataTable.vue
+++ b/web/src/components/travel-desk-travel-requests/TravelDeskTravelRequestsManageDataTable.vue
@@ -140,7 +140,7 @@ import { isNil, isEmpty } from "lodash"
 import { useI18n } from "@/plugins/vue-i18n-plugin"
 import formatDate from "@/utils/format-date"
 
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useVuetifySortByToSequelizeSafeOrder from "@/use/utils/use-vuetify-sort-by-to-sequelize-safe-order"
 import useVuetifySortByToSafeRouteQuery from "@/use/utils/use-vuetify-sort-by-to-safe-route-query"
 import useVuetify2SortByShim from "@/use/utils/use-vuetify2-sort-by-shim"
@@ -167,8 +167,8 @@ const headers = ref([
 
 const { t } = useI18n()
 
-const page = useRouteQuery("page", "1", { transform: integerTransformer })
-const perPage = useRouteQuery("perPage", "15", { transform: integerTransformer })
+const page = useRouteQuery("page", "1", { transform: integerTransformerLegacy })
+const perPage = useRouteQuery("perPage", "15", { transform: integerTransformerLegacy })
 
 const sortBy = useVuetifySortByToSafeRouteQuery("sortBy", [
   {

--- a/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
+++ b/web/src/modules/travel-authorizations/components/MyTravelAuthorizationsTable.vue
@@ -77,7 +77,7 @@ import { isNil, isEmpty } from "lodash"
 
 import { useI18n } from "@/plugins/vue-i18n-plugin"
 import formatDate from "@/utils/format-date"
-import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
 import useCurrentUser from "@/use/use-current-user"
 import useTravelAuthorizations from "@/use/use-travel-authorizations"
 
@@ -121,11 +121,11 @@ const headers = ref([
 ])
 
 const page = useRouteQuery("page", "1", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const perPage = useRouteQuery("perPage", "10", {
-  transform: integerTransformer,
+  transform: integerTransformerLegacy,
 })
 
 const { currentUser } = useCurrentUser()

--- a/web/src/pages/my-travel-requests/request/RequestEditTravelDetailsPage.vue
+++ b/web/src/pages/my-travel-requests/request/RequestEditTravelDetailsPage.vue
@@ -3,14 +3,20 @@
     v-if="isNil(travelDeskTravelRequest)"
     type="card"
   />
-  <TravelerDetailsFormCard
-    v-else
-    ref="travelerDetailsFormCard"
-    v-model="travelDeskTravelRequest"
-    :is-saving="isLoading"
-    class="mt-4"
-    @save-requested="saveAndNotify"
-  />
+  <v-card v-else>
+    <v-card-title>
+      <h2>Traveller Desk Request</h2>
+    </v-card-title>
+    <v-card-text>
+      <TravelerDetailsFormCard
+        ref="travelerDetailsFormCard"
+        v-model="travelDeskTravelRequest"
+        :is-saving="isLoading"
+        class="mt-4"
+        @save-requested="saveAndNotify"
+      />
+    </v-card-text>
+  </v-card>
 </template>
 
 <script setup>

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -23,7 +23,7 @@ const routes = [
       {
         name: "DashboardPage",
         path: "dashboard",
-        component: () => import("@/pages/DashboardPage"),
+        component: () => import("@/pages/DashboardPage.vue"),
       },
       {
         // TODO: push readcrumbs into higher layout
@@ -140,12 +140,12 @@ const routes = [
       {
         path: "qa/scenarios",
         name: "Qa-Scenarios",
-        component: () => import("@/pages/qa/ScenariosListPage"),
+        component: () => import("@/pages/qa/ScenariosListPage.vue"),
       },
       {
         path: "health-check",
         name: "HealthCheck",
-        component: () => import("@/pages/HealthCheckPage"),
+        component: () => import("@/pages/HealthCheckPage.vue"),
         meta: { requiresAuth: false },
       },
     ],
@@ -227,20 +227,20 @@ const routes = [
               {
                 path: "request",
                 name: "my-travel-requests/request/RequestPage",
-                component: () => import("@/pages/my-travel-requests/request/RequestPage"),
+                component: () => import("@/pages/my-travel-requests/request/RequestPage.vue"),
                 props: true,
               },
               {
                 path: "request/edit-travel-details",
                 name: "my-travel-requests/request/RequestEditTravelDetailsPage",
                 component: () =>
-                  import("@/pages/my-travel-requests/request/RequestEditTravelDetailsPage"),
+                  import("@/pages/my-travel-requests/request/RequestEditTravelDetailsPage.vue"),
                 props: true,
               },
               {
                 path: "request/edit",
                 name: "my-travel-requests/request/RequestEditPage",
-                component: () => import("@/pages/my-travel-requests/request/RequestEditPage"),
+                component: () => import("@/pages/my-travel-requests/request/RequestEditPage.vue"),
                 props: true,
               },
               {
@@ -303,7 +303,7 @@ const routes = [
   {
     path: "*",
     name: "Not Found",
-    component: () => import("@/pages/NotFoundPage"),
+    component: () => import("@/pages/NotFoundPage.vue"),
     meta: { requiresAuth: false },
   },
 ]

--- a/web/src/use/use-travel-desk-hotel.js
+++ b/web/src/use/use-travel-desk-hotel.js
@@ -1,0 +1,71 @@
+import { reactive, toRefs, unref, watch } from "vue"
+import { isNil } from "lodash"
+
+import travelDeskHotelsApi from "@/api/travel-desk-hotels-api"
+
+/**
+ * @template [T=any]
+ * @typedef {import('vue').Ref<T>} Ref
+ */
+/** @typedef {import('@/api/base-api.js').Policy} Policy */
+/** @typedef {import('@/api/travel-desk-hotels-api.js').TravelDeskHotel} TravelDeskHotel */
+
+/**
+ * @callback UseTravelDeskHotel
+ * @param {Ref<number | null | undefined>} id
+ * @returns {{
+ *   travelDeskHotel: Ref<TravelDeskHotel | null>,
+ *   policy: Ref<Policy | null>,
+ *   isLoading: Ref<boolean>,
+ *   isErrored: Ref<boolean>,
+ *   fetch: () => Promise<TravelDeskHotel>,
+ *   refresh: () => Promise<TravelDeskHotel>,
+ * }}
+ */
+
+/** @type {UseTravelDeskHotel} */
+export function useTravelDeskHotel(id) {
+  const state = reactive({
+    travelDeskHotel: null,
+    policy: null,
+    isLoading: false,
+    isErrored: false,
+  })
+
+  async function fetch() {
+    state.isLoading = true
+    try {
+      const { travelDeskHotel, policy } = await travelDeskHotelsApi.get(unref(id))
+      state.isErrored = false
+      state.travelDeskHotel = travelDeskHotel
+      state.policy = policy
+      return travelDeskHotel
+    } catch (error) {
+      console.error("Failed to fetch travel desk hotel:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  watch(
+    () => unref(id),
+    async (newId) => {
+      if (isNil(newId)) return
+
+      await fetch()
+    },
+    {
+      immediate: true,
+    }
+  )
+
+  return {
+    ...toRefs(state),
+    fetch,
+    refresh: fetch,
+  }
+}
+
+export default useTravelDeskHotel

--- a/web/src/use/utils/use-route-query.js
+++ b/web/src/use/utils/use-route-query.js
@@ -2,7 +2,7 @@ import { customRef, nextTick, watch } from "vue-demi"
 import { toValue, tryOnScopeDispose } from "@vueuse/shared"
 import { useRoute, useRouter } from "vue2-helpers/vue-router"
 
-export { integerTransformer } from "@/utils/use-route-query-transformers"
+export { integerTransformerLegacy } from "@/utils/use-route-query-transformers"
 
 /** @typedef {import("vue-router").RouteParamValueRaw | string[]} RouteQueryValueRaw */
 

--- a/web/src/use/utils/use-route-query.js
+++ b/web/src/use/utils/use-route-query.js
@@ -2,6 +2,7 @@ import { customRef, nextTick, watch } from "vue-demi"
 import { toValue, tryOnScopeDispose } from "@vueuse/shared"
 import { useRoute, useRouter } from "vue2-helpers/vue-router"
 
+export { integerTransformer } from "@/utils/use-route-query-transformers"
 export { integerTransformerLegacy } from "@/utils/use-route-query-transformers"
 
 /** @typedef {import("vue-router").RouteParamValueRaw | string[]} RouteQueryValueRaw */

--- a/web/src/utils/use-route-query-transformers/index.js
+++ b/web/src/utils/use-route-query-transformers/index.js
@@ -1,1 +1,1 @@
-export { integerTransformer } from "./integer-transformer.js"
+export { integerTransformerLegacy } from "./integer-transformer-legacy.js"

--- a/web/src/utils/use-route-query-transformers/index.js
+++ b/web/src/utils/use-route-query-transformers/index.js
@@ -1,1 +1,2 @@
+export { integerTransformer } from "./integer-transformer.js"
 export { integerTransformerLegacy } from "./integer-transformer-legacy.js"

--- a/web/src/utils/use-route-query-transformers/integer-transformer-legacy.js
+++ b/web/src/utils/use-route-query-transformers/integer-transformer-legacy.js
@@ -1,0 +1,15 @@
+import { isNil } from "lodash"
+
+/**
+ * Transforms a string to an integer or returns null if the value is nil.
+ *
+ * @param {string | null | undefined} value - The value to transform.
+ * @returns {number | null} - The transformed integer or null if the value is nil.
+ */
+export function integerTransformerLegacy(value) {
+  if (isNil(value)) return null
+
+  return parseInt(value)
+}
+
+export default integerTransformerLegacy

--- a/web/src/utils/use-route-query-transformers/integer-transformer.js
+++ b/web/src/utils/use-route-query-transformers/integer-transformer.js
@@ -6,8 +6,17 @@ import { isNil } from "lodash"
  * @param {string | null | undefined} value - The value to transform.
  * @returns {number | null} - The transformed integer or null if the value is nil.
  */
-export function integerTransformer(value) {
-  if (isNil(value)) return null
+export const integerTransformer = {
+  get(value) {
+    if (isNil(value)) return null
 
-  return parseInt(value)
+    return parseInt(value, 10)
+  },
+  set(value) {
+    if (isNil(value)) return null
+
+    return value.toString()
+  },
 }
+
+export default integerTransformer


### PR DESCRIPTION
Fixes https://github.com/ytgov/travel-authorization/issues/92

Relates to:
- Travel Desk Request

# Context

**Is your feature request related to a problem? Please describe.**
Updates required to the travel desk request pop-up on page http://localhost:8080/my-travel-requests/21/request/edit

See 
![image](https://github.com/user-attachments/assets/132eb6b3-8ef4-4e6c-b236-0f68a702a1b5)

**Describe the solution you'd like**
Travel Desk Request (submit travel desk request pop-up)
- make birthdate mandatory
- Change the blue header to match the rest of the app

**Add Flight pop-up**
- Update colour to match rest of application
- Should limit flight requests to fall within the approved travel dates
- Default dates to travel dates.

**Add rental car**
- Update pop-up header to match the rest of the application
- Pick-up/drop off selector is greyed out.
- Default dates to travel dates

**Add Hotel**
- Update pop-up header to match the rest of the application
- Default checkin and out dates based on travel
- Pull conference name from Travel Auth form if there is one
- If conference hotel = NO don’t show hotel conference and meeting names and don’t make them mandatory

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
