### PR TITLE
Issue 265: Fix Logic Around Send to Traveller Status Should be "submitted"

### DIFF
--- a/web/src/pages/travel-desk/TravelDeskEditPage.vue
+++ b/web/src/pages/travel-desk/TravelDeskEditPage.vue
@@ -120,7 +120,7 @@
         />
 
         <v-btn
-          v-if="isOptionsProvidedState"
+          v-if="isSubmittedState"
           class="mr-2 px-5"
           color="primary"
           :loading="isLoading"
@@ -219,9 +219,8 @@ const {
   save: saveTravelDeskTravelRequest,
 } = useTravelDeskTravelRequest(travelDeskTravelRequestId)
 
-const isOptionsProvidedState = computed(
-  () =>
-    travelDeskTravelRequest.value?.status === TRAVEL_DESK_TRAVEL_REQUEST_STATUSES.OPTIONS_PROVIDED
+const isSubmittedState = computed(
+  () => travelDeskTravelRequest.value?.status === TRAVEL_DESK_TRAVEL_REQUEST_STATUSES.SUBMITTED
 )
 const hasInvoiceNumber = computed(
   () => !isNil(travelDeskTravelRequest.value?.travelDeskPassengerNameRecordDocument?.invoiceNumber)


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/265

Relates to:
- https://github.com/icefoganalytics/travel-authorization/pull/263
- https://github.com/icefoganalytics/travel-authorization/pull/257
- https://github.com/icefoganalytics/travel-authorization/pull/240

# Context

The "Send to Traveller" button is missing from the Travel Desk page. See https://github.com/icefoganalytics/travel-authorization/pull/240 -> Testing Instructions -> step 22.

Step showing this is missing from https://github.com/icefoganalytics/travel-authorization/pull/263, but would have been between Part 1 -> step 12 and step 13.

Button should show "Send to Traveller" when travel desk request is in "submitted" state.
https://travel-auth-dev.ynet.gov.yk.ca/travel-desk/41/edit
![Image](https://github.com/user-attachments/assets/4ef134ba-42bf-4d69-b948-35f585d371fc)

# Implementation

1. Fix state check so correct button shows up given correct state.
2. Handle all current states, and show an error component if state is new and unhandled.

# Screenshots

Travel Desk Request in "submitted" state, about to send back to traveller with flight options.
http://localhost:8080/travel-desk/9/edit
![image](https://github.com/user-attachments/assets/c1eb1096-9129-4aed-a593-8645693e2ead)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080 as a regular user.
4. Go to the "My Travel Requests" page from the left sidebar.
5. Click on the "New Travel Request" button to create a new travel request.
6. Complete the first 7 steps of the wizard.
    i. Submit to an admin account you control.
    ii. Make sure to have at least one travel segment by aircraft.
7. In a private browser window, log in as the supervisor you submitted the request to.
8. Go to the "Manage Travel Requests" page from the left sidebar.
9. Approve the request.
10. Back as your regular user, complete the steps up to step 11 "Awaiting flight options"
11. Back as your supervisor, click on the "Travel Desk" link in the sidebar.
12. Edit the travel desk request and supply flight options. See https://github.com/icefoganalytics/travel-authorization/pull/257 for some parsable examples.
    ```
    WestJet WS3566 - Operated By: WESTJET ENCORE
    Departure: 03 Dec 06:25 Cranbrook Municipal (YXC) Terminal:
    Arrival:   03 Dec 07:09 Calgary Intl Arpt (YYC) Terminal:
    Duration:  0 Hour(s) 44 Minutes
    Status:    Sold
    Class:     B
    
    WestJet WS107
    Departure: 03 Dec 09:00 Calgary Intl Arpt (YYC) Terminal:
    Arrival:   03 Dec 09:47 Vancouver Intl Arpt (YVR) Terminal: M
    Duration:  1 Hour(s) 47 Minutes
    Status:    Sold
    Class:     B
    ```
13. After supplying flight options, scroll to the bottom of the Travel Desk request, and find the "Send to Traveler" button. Click it to mark the Travel Desk request as having had "options provided" 
14. Back as your regular user, complete the steps up to step 13 "Waiting for booking confirmation".
15. Back as your supervisor, review the travel desk request again.
16. Upload the PNR (passenger name record) from the travel desk, and mark the travel as booked.
17. Back as your regular user, complete the steps up to step 16 "Waiting for travel to start".
18. Use your travel has started, complete the remaining steps.
