### PR TITLE
Fix Bug In Flight Expense Sync From TravCom

### DIFF
--- a/api/src/integrations/trav-com-integration/README.md
+++ b/api/src/integrations/trav-com-integration/README.md
@@ -2,3 +2,13 @@
 
 Represents an external database integration for TravCom.
 This access is read-only.
+
+## Development
+
+### Initializers
+
+This is how you would run initializers, and by extension migrations.
+
+```bash
+dev ts-node ./src/initializers/40-initialize-trav-com-development.ts
+```

--- a/api/src/integrations/trav-com-integration/db/db-client.ts
+++ b/api/src/integrations/trav-com-integration/db/db-client.ts
@@ -11,6 +11,8 @@ import {
 } from "@/config"
 import { compactSql } from "@/integrations/trav-com-integration/utils/compact-sql"
 
+export * as MssqlTypeExtensions from "@/integrations/trav-com-integration/db/mssql-type-extensions"
+
 export const transactionManager = createNamespace("transaction-manager-trav-com")
 Sequelize.useCLS(transactionManager)
 

--- a/api/src/integrations/trav-com-integration/db/migrations/20250311223656_fix-trav-com-integration-datetime-field-types.ts
+++ b/api/src/integrations/trav-com-integration/db/migrations/20250311223656_fix-trav-com-integration-datetime-field-types.ts
@@ -1,0 +1,35 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("ARInvoicesNoHealth", (table) => {
+    table.specificType("BookingDate", "datetime").nullable().alter()
+    table.specificType("SystemDate", "datetime").nullable().alter()
+  })
+
+  await knex.schema.alterTable("ARInvoiceDetailsNoHealth", (table) => {
+    table.specificType("TravelDate", "datetime").nullable().alter()
+    table.specificType("ReturnDate", "datetime").nullable().alter()
+  })
+
+  await knex.schema.alterTable("segmentsNoHealth", (table) => {
+    table.specificType("DepartureInfo", "datetime").nullable().alter()
+    table.specificType("ArrivalInfo", "datetime").nullable().alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("ARInvoicesNoHealth", (table) => {
+    table.specificType("BookingDate", "datetime2").nullable().alter()
+    table.specificType("SystemDate", "datetime2").nullable().alter()
+  })
+
+  await knex.schema.alterTable("ARInvoiceDetailsNoHealth", (table) => {
+    table.specificType("TravelDate", "datetime2").nullable().alter()
+    table.specificType("ReturnDate", "datetime2").nullable().alter()
+  })
+
+  await knex.schema.alterTable("segmentsNoHealth", (table) => {
+    table.specificType("DepartureInfo", "datetime2").nullable().alter()
+    table.specificType("ArrivalInfo", "datetime2").nullable().alter()
+  })
+}

--- a/api/src/integrations/trav-com-integration/db/mssql-type-extensions/abstract.ts
+++ b/api/src/integrations/trav-com-integration/db/mssql-type-extensions/abstract.ts
@@ -1,0 +1,91 @@
+import logger from "@/utils/logger"
+
+const warnings: Record<string, boolean> = {}
+
+/**
+ * @see https://github.com/sequelize/sequelize/blob/v6.37.6/src/data-types.js
+ */
+export class ABSTRACT {
+  options: Record<string, unknown> = {}
+
+  constructor(options: Record<string, unknown> = {}) {
+    this.options = options
+  }
+
+  static warn(link: string, text: string): void {
+    if (!warnings[text]) {
+      warnings[text] = true
+      logger.warn(`${text} \n>> Check: ${link}`)
+    }
+  }
+
+  static extend(oldType: ABSTRACT) {
+    return new this(oldType.options)
+  }
+
+  static get dialectTypes() {
+    return new this().dialectTypes
+  }
+
+  get dialectTypes() {
+    return ""
+  }
+
+  static get key() {
+    return new this().key
+  }
+
+  get key() {
+    return ""
+  }
+
+  static toString(options: Record<string, unknown>) {
+    return new this(options).toString(options)
+  }
+
+  toString(options: Record<string, unknown>) {
+    return this.toSql(options)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static toSql(options?: Record<string, unknown>) {
+    return new this(options).toSql(options)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  toSql(options?: Record<string, unknown>) {
+    return this.key
+  }
+
+  static stringify(value: unknown, options: Record<string, unknown>): string {
+    return new this(options).stringify(value, options)
+  }
+
+  stringify(value: unknown, options: Record<string, unknown>): string {
+    if (this._stringify) {
+      return this._stringify(value, options)
+    }
+    return String(value)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static _stringify(value: unknown, options: Record<string, unknown>): string {
+    return new this(options)._stringify(value, options)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _stringify(value: unknown, options: Record<string, unknown>): string {
+    return String(value)
+  }
+
+  bindParam(value: unknown, options: { bindParam: (val: unknown) => unknown }) {
+    if (this._bindParam) {
+      return this._bindParam(value, options)
+    }
+    return options.bindParam(this.stringify(value, options))
+  }
+
+  _bindParam?: (value: unknown, options: unknown) => unknown
+}
+
+export default ABSTRACT

--- a/api/src/integrations/trav-com-integration/db/mssql-type-extensions/datetime.ts
+++ b/api/src/integrations/trav-com-integration/db/mssql-type-extensions/datetime.ts
@@ -1,0 +1,28 @@
+import { Utils } from "sequelize"
+import { DateTime } from "luxon"
+
+import ABSTRACT from "@/integrations/trav-com-integration/db/mssql-type-extensions/abstract"
+
+class MSSQL_DATETIME extends ABSTRACT {
+  toSql() {
+    return "DATETIME"
+  }
+
+  stringify(value: Date | string | number): string {
+    if (typeof value === "string") {
+      return value
+    } else if (typeof value === "number") {
+      const date = new Date(value)
+      const datetime = DateTime.fromJSDate(date)
+      return datetime.toFormat("yyyy-MM-dd HH:mm:ss")
+    }
+
+    const datetime = DateTime.fromJSDate(value)
+    return datetime.toFormat("yyyy-MM-dd HH:mm:ss")
+  }
+}
+
+// Wrap it on `Utils.classToInvokable` to be able to use this datatype directly without having to call `new` on it.
+export const DATETIME = Utils.classToInvokable(MSSQL_DATETIME)
+
+export default DATETIME

--- a/api/src/integrations/trav-com-integration/db/mssql-type-extensions/index.ts
+++ b/api/src/integrations/trav-com-integration/db/mssql-type-extensions/index.ts
@@ -1,0 +1,1 @@
+export { DATETIME } from "./datetime"

--- a/api/src/integrations/trav-com-integration/models/accounts-receivable-invoice-detail.ts
+++ b/api/src/integrations/trav-com-integration/models/accounts-receivable-invoice-detail.ts
@@ -13,7 +13,7 @@ import { sortBy } from "lodash"
 
 import BaseModel from "@/models/base-model"
 import { FlightReconciliation } from "@/models"
-import sequelize from "@/integrations/trav-com-integration/db/db-client"
+import sequelize, { MssqlTypeExtensions } from "@/integrations/trav-com-integration/db/db-client"
 
 import AccountsReceivableInvoice from "@/integrations/trav-com-integration/models/accounts-receivable-invoice"
 import City from "@/integrations/trav-com-integration/models/city"
@@ -197,12 +197,12 @@ AccountsReceivableInvoiceDetail.init(
       allowNull: true,
     },
     travelDate: {
-      type: DataTypes.DATE,
+      type: MssqlTypeExtensions.DATETIME,
       field: "TravelDate",
       allowNull: true,
     },
     returnDate: {
-      type: DataTypes.DATE,
+      type: MssqlTypeExtensions.DATETIME,
       field: "ReturnDate",
       allowNull: true,
     },

--- a/api/src/integrations/trav-com-integration/models/accounts-receivable-invoice.ts
+++ b/api/src/integrations/trav-com-integration/models/accounts-receivable-invoice.ts
@@ -9,7 +9,7 @@ import {
   Op,
 } from "sequelize"
 
-import sequelize from "@/integrations/trav-com-integration/db/db-client"
+import sequelize, { MssqlTypeExtensions } from "@/integrations/trav-com-integration/db/db-client"
 
 import AccountsReceivableInvoiceDetail from "@/integrations/trav-com-integration/models/accounts-receivable-invoice-detail"
 import Segment from "@/integrations/trav-com-integration/models/segment"
@@ -90,12 +90,12 @@ AccountsReceivableInvoice.init(
       field: "Department",
     },
     bookingDate: {
-      type: DataTypes.DATE,
+      type: MssqlTypeExtensions.DATETIME,
       allowNull: true,
       field: "BookingDate",
     },
     systemDate: {
-      type: DataTypes.DATE,
+      type: MssqlTypeExtensions.DATETIME,
       allowNull: true,
       field: "SystemDate",
     },

--- a/api/src/integrations/trav-com-integration/models/segment.ts
+++ b/api/src/integrations/trav-com-integration/models/segment.ts
@@ -9,7 +9,7 @@ import {
   NonAttribute,
 } from "sequelize"
 
-import sequelize from "@/integrations/trav-com-integration/db/db-client"
+import sequelize, { MssqlTypeExtensions } from "@/integrations/trav-com-integration/db/db-client"
 
 import AccountsReceivableInvoice from "@/integrations/trav-com-integration/models/accounts-receivable-invoice"
 import AccountsReceivableInvoiceDetail from "@/integrations/trav-com-integration/models/accounts-receivable-invoice-detail"
@@ -116,7 +116,7 @@ Segment.init(
       field: "DepartureCityCode",
     },
     departureInfo: {
-      type: DataTypes.DATE,
+      type: MssqlTypeExtensions.DATETIME,
       allowNull: true,
       field: "DepartureInfo",
     },
@@ -126,7 +126,7 @@ Segment.init(
       field: "ArrivalCityCode",
     },
     arrivalInfo: {
-      type: DataTypes.DATE,
+      type: MssqlTypeExtensions.DATETIME,
       allowNull: true,
       field: "ArrivalInfo",
     },

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -8,6 +8,10 @@ x-default-environment: &default-environment
   DB_PASS: &default-db-password itsallgood
   DB_USER: &default-db-user app
   DB_PORT: 5432
+  DB_HEALTH_CHECK_INTERVAL_SECONDS: 5
+  DB_HEALTH_CHECK_TIMEOUT_SECONDS: 10
+  DB_HEALTH_CHECK_RETRIES: 3
+  DB_HEALTH_CHECK_START_PERIOD_SECONDS: 5
   TRAVCOM_DB_HOST: db_trav_com
   TRAVCOM_DB_USER: sa
   TRAVCOM_DB_PASS: &default-trav-com-db-password "DevPwd99!"


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/274

Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/264

# Context

**Describe the bug**
When I view the "Flight Expenses" sidebar item (https://travel-auth-dev.ynet.gov.yk.ca/flight-expenses/all) I see an error in the network pane that relates to querying the TravCom database.

**To Reproduce**
Steps to reproduce the behavior:
1. Open the Network panel of Developer tools in your browser.
2. Go to Flight Expenses from the sidebar.
3. Note the error in the console.
> https://travel-auth-dev.ynet.gov.yk.ca/api/trav-com/accounts-receivable-invoice-details?filters%5BinvoiceBookingDateBetween%5D%5B0%5D=2025-03-03&filters%5BinvoiceBookingDateBetween%5D%5B1%5D=2025-03-02&perPage=1
> Failed to retrieve accounts receivable invoice details: SequelizeDatabaseError: Conversion failed when converting date and/or time from character string.

**Expected behavior**
Sync from TravCom should display the correct number of records for the day, and sync should work.

**Screenshots**
![Image](https://github.com/user-attachments/assets/50e01244-dffd-468c-9253-77b559799fc4)

![Image](https://github.com/user-attachments/assets/0c110577-1660-4648-b9a2-4d6ef636ba7e)
![Image](https://github.com/user-attachments/assets/fecf6279-82a1-4ef8-9a87-a5290f4f9aa1)

# Implementation

1. Update the `ARInvoicesNoHealth`, `ARInvoiceDetailsNoHealth`, and `segmentsNoHealth` tables to use specific type `datetime` for time related fields (not to be confused with default datetime type of `datetime2`).
2. Add custom Sequelize type that correctly serializes down to `datetime` (1) format. This was quite difficult as the Seqeulize 6 documentation for this is non-functional. Apparently Sequelize 7 is better, so might be a reason to upgrade.
3. Add default database health check environment variables to make database check for TravCom a bit more stable.

# Screenshots

Generate SQL now looks like this
```sql
SELECT count(*) AS [count] FROM [dbo].[ARInvoiceDetailsNoHealth] AS [AccountsReceivableInvoiceDetail] INNER JOIN [dbo].[ARInvoicesNoHealth] AS [invoice] ON [AccountsReceivableInvoiceDetail].[InvoiceID] = [invoice].[InvoiceID] AND ([invoice].[BookingDate] >= N'2025-03-11' AND [invoice].[BookingDate] <= N'2025-03-12');
```
previously it looked like:
```sql
SELECT count(*) AS [count] FROM [dbo].[ARInvoiceDetailsNoHealth] AS [AccountsReceivableInvoiceDetail] INNER JOIN [dbo].[ARInvoicesNoHealth] AS [invoice] ON [AccountsReceivableInvoiceDetail].[InvoiceID] = [invoice].[InvoiceID] AND ([invoice].[BookingDate] >= N'2025-03-10 00:00:00.000 +00:00' AND [invoice].[BookingDate] <= N'2025-03-11 00:00:00.000 +00:00');
```

Note the difference in date generation `N'2025-03-11'` vs. `N'2025-03-10 00:00:00.000 +00:00'` the real issue was the `+00:00`. This is a known issue in Sequelize for MSSQL.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Open the network pane in your browser dev tools.
5. Select Flight Expenses from the left sidebar.
6. Check that the `accounts-receivable-invoice-details` query works correctly.
     > Note this query worked in development mode prior to this PR as we where using `datetime2` which safely handles `N'2025-03-10 00:00:00.000 +00:00'` formatted date-times. 
