### PR TITLE
Hotfix: Fix Broken Transaction Management

### DIFF
--- a/api/src/integrations/trav-com-integration/db/db-client.ts
+++ b/api/src/integrations/trav-com-integration/db/db-client.ts
@@ -1,5 +1,4 @@
 import { Sequelize, Options } from "sequelize"
-import { createNamespace } from "cls-hooked"
 
 import {
   TRAVCOM_DB_NAME,
@@ -13,8 +12,10 @@ import { compactSql } from "@/integrations/trav-com-integration/utils/compact-sq
 
 export * as MssqlTypeExtensions from "@/integrations/trav-com-integration/db/mssql-type-extensions"
 
-export const transactionManager = createNamespace("transaction-manager-trav-com")
-Sequelize.useCLS(transactionManager)
+// NOTE: you cannot use multiple transaction managers for the same Sequelize instance until Sequelize 7
+// So the following code should not be used, as it will break transactions everywhere.
+// export const transactionManager = createNamespace("transaction-manager-trav-com")
+// Sequelize.useCLS(transactionManager)
 
 if (TRAVCOM_DB_NAME === undefined) throw new Error("database name is unset.")
 if (TRAVCOM_DB_USER === undefined) throw new Error("database username is unset.")

--- a/api/tests/controllers/travel-authorizations-controller.test.ts
+++ b/api/tests/controllers/travel-authorizations-controller.test.ts
@@ -1,0 +1,63 @@
+import { Stop, User } from "@/models"
+import { travelAuthorizationFactory, userFactory } from "@/factories"
+
+import { mockCurrentUser, request } from "@/support"
+
+describe("api/src/controllers/travel-authorizations-controller.ts", () => {
+  let user: User
+
+  beforeEach(async () => {
+    user = await userFactory.create({
+      roles: [User.Roles.USER],
+    })
+    mockCurrentUser(user)
+  })
+
+  describe("TravelAuthorizationsController", () => {
+    describe("#create - POST /api/travel-authorizations", () => {
+      test("when authorized and travel authorization creation is successful", async () => {
+        // Arrange
+        const newTravelAuthorizationAttributes = {
+          ...travelAuthorizationFactory.attributesFor({
+            userId: user.id,
+            wizardStepName: "edit-purpose-details",
+          }),
+          stopsAttributes: [
+            {
+              accommodationType: Stop.AccommodationTypes.HOTEL,
+              transport: Stop.TravelMethods.AIRCRAFT,
+            },
+            {
+              transport: Stop.TravelMethods.AIRCRAFT,
+              accommodationType: null,
+            },
+          ],
+        }
+
+        // Act
+        const response = await request()
+          .post("/api/travel-authorizations")
+          .send(newTravelAuthorizationAttributes)
+
+        // Assert
+        expect(response.status).toEqual(201)
+        expect(response.body).toEqual({
+          travelAuthorization: expect.objectContaining({
+            userId: user.id,
+            wizardStepName: "edit-purpose-details",
+            stops: expect.arrayContaining([
+              expect.objectContaining({
+                accommodationType: "Hotel",
+                transport: "Aircraft",
+              }),
+              expect.objectContaining({
+                transport: "Aircraft",
+                accommodationType: null,
+              }),
+            ]),
+          }),
+        })
+      })
+    })
+  })
+})

--- a/api/tests/factories/travel-authorization-factory.ts
+++ b/api/tests/factories/travel-authorization-factory.ts
@@ -1,8 +1,8 @@
 import { Includeable } from "sequelize"
-import { Factory } from "fishery"
 import { faker } from "@faker-js/faker"
 
 import { TravelAuthorization } from "@/models"
+import BaseFactory from "@/factories/base-factory"
 import { travelPurposeFactory, userFactory } from "@/factories"
 import { nestedSaveAndAssociateIfNew } from "@/factories/helpers"
 
@@ -10,7 +10,9 @@ type TransientParam = {
   include?: Includeable | Includeable[]
 }
 
-export const travelAuthorizationFactory = Factory.define<TravelAuthorization, TransientParam>(
+class TravelAuthorizationFactory extends BaseFactory<TravelAuthorization, TransientParam> {}
+
+export const travelAuthorizationFactory = TravelAuthorizationFactory.define(
   ({ associations, transientParams, onCreate }) => {
     onCreate(async (travelAuthorization) => {
       try {


### PR DESCRIPTION
Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/264
- https://github.com/sequelize/sequelize/issues/14698

# Context

Trav Com integration database setup broken transaction management for the entire app.
Apparently you cannot set up transaction management for multiple databases in Sequelize 6. See https://github.com/sequelize/sequelize/issues/14698

Given that I can't set up auto nesting transaction management against two databases using Sequelize 6, though I could if I was using Sequelize 7.

With the TravelAuth project I can only have auto nested transactions on the primary "travel_development" database, but not against the TravCom database. If anyone tries to use transactions with TravCom it'll likely blow up. Or if you do anything TravCom related inside a TravelAuth transaction.

Option 1: Do nothing. Currently the TravCom integration does not do anything that requires transactions, since its ready only.

Option 2: is to migrate the TravCom integration to using Sequelize 7 via npm aliases, but leave the main app using Sequelize 6.

Option 3: is to migrate the whole app to Sequelize 7, which supports this out-of-the-box, and also has a better interface overall.

# Implementation

1. Avoid setting up TravCom integration with with managed transactions. I have not found a good way to stop future developers from using transactions for TravCom. If they do, they will likely get very hard to debug errors. 
2. Add test for travel authorization creation endpoint

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
3. Boot the app via `dev up`
4. Log in to the app at http://localhost:8080
5. Click on My Travel Requests in the sidebar.
6. Attempt to create a new travel request via the call-to-action button. It will now succeed again.
