### PR TITLE
Ytgov issue 91: Dashboard Update Manager View

### DIFF
--- a/api/src/serializers/travel-authorizations/index-serializer.ts
+++ b/api/src/serializers/travel-authorizations/index-serializer.ts
@@ -18,9 +18,10 @@ import {
 
 export type TravelAuthorizationIndexView = Pick<
   TravelAuthorization,
-  "id" | "eventName" | "tripType" | "wizardStepName" | "status" | "createdAt" | "updatedAt"
+  "id" | "eventName" | "purposeId" | "wizardStepName" | "status" | "createdAt" | "updatedAt"
 > & {
   // computed fields
+  purposeText: string
   finalDestination?: Pick<Location, "id" | "city" | "province" | "createdAt" | "updatedAt">
   departingAt?: string | null
   returningAt?: string | null
@@ -48,13 +49,14 @@ export class IndexSerializer extends BaseSerializer<TravelAuthorization> {
       ...pick(this.record, [
         "id",
         "eventName",
-        "tripType",
+        "purposeId",
         "wizardStepName",
         "status",
         "createdAt",
         "updatedAt",
       ]),
       // computed fields
+      purposeText: this.record.purpose?.purpose ?? "",
       finalDestination:
         this.lastStop?.location &&
         pick(this.lastStop?.location, ["id", "city", "province", "createdAt", "updatedAt"]),

--- a/web/src/components/travel-authorizations/manage/TravelAuthorizationsSupervisorDataTable.vue
+++ b/web/src/components/travel-authorizations/manage/TravelAuthorizationsSupervisorDataTable.vue
@@ -14,8 +14,8 @@
     <template #item.name="{ item }">
       <span>{{ item.firstName }} {{ item.lastName }}</span>
     </template>
-    <template #item.tripType="{ value }">
-      <span>{{ formatTripType(value) }}</span>
+    <template #item.purposeText="{ value }">
+      <span>{{ value }}</span>
     </template>
     <template #item.finalDestination="{ value }">
       <span>{{ formatFinalDestination(value) }}</span>
@@ -33,8 +33,6 @@
 import { computed, ref } from "vue"
 import { isNil } from "lodash"
 import { useRouter } from "vue2-helpers/vue-router"
-
-import { useI18n } from "@/plugins/vue-i18n-plugin"
 
 import formatDate from "@/utils/format-date"
 import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
@@ -74,7 +72,7 @@ const headers = ref([
   },
   {
     text: "Type",
-    value: "tripType",
+    value: "purposeText",
     sortable: false,
   },
   {
@@ -112,19 +110,11 @@ const travelAuthorizationsQuery = computed(() => {
 const { travelAuthorizations, totalCount, isLoading, refresh } =
   useTravelAuthorizations(travelAuthorizationsQuery)
 
-const { t } = useI18n()
-
 function formatFinalDestination(value) {
   if (isNil(value)) return ""
 
   const { city, province } = value
   return `${city} (${province})`
-}
-
-function formatTripType(value) {
-  if (isNil(value)) return ""
-
-  return t(`travel_authorization.trip_type.${value}`, { $default: value })
 }
 
 const router = useRouter()


### PR DESCRIPTION
Fixes https://github.com/ytgov/travel-authorization/issues/91

Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/261

# Context

Should show "Purpose" (conference, etc) rather than Type.

# Implementation

`. Display purpose text instead of trip type in "Type" column of Travel Authorizations Supervisor View tables.

# Screenshots

Manage Travel Requests (update Type column value)
http://localhost:8080/manage-travel-requests
![image](https://github.com/user-attachments/assets/b0705e29-6302-48ba-8732-08ca6654fdfd)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080 as a system admin (or supervisor)
4. Go to the "Manage Travel Requests" via the left side navbar.
5. Check that the Type column in the tables now show matches the travel authorization "Purpose" field.
6. If you don't have any content here, create a travel authorization and submit it to yourself.
