### PR TITLE
Hotfix: Migrations That Failed in Production Due to Null Ids

### DIFF
--- a/api/src/db/migrations/20250319170414_standardize-preapproved-submissions-table.ts
+++ b/api/src/db/migrations/20250319170414_standardize-preapproved-submissions-table.ts
@@ -23,14 +23,30 @@ export async function up(knex: Knex): Promise<void> {
   })
 
   await knex.schema.alterTable("preapprovedDocuments", (table) => {
-    table.dropForeign("preTSubID")
-    table.dropColumn("preTSubID")
-
-    table.integer("submission_id").notNullable()
+    table.integer("submission_id")
     table
       .foreign("submission_id")
       .references("travel_authorization_pre_approval_submissions.id")
       .onDelete("CASCADE")
+  })
+
+  await knex.raw(/* sql */ `
+    UPDATE "preapprovedDocuments"
+    SET
+      submission_id = "preTSubID"
+  `)
+
+  await knex.raw(/* sql */ `
+    DELETE FROM "preapprovedDocuments"
+    WHERE
+      submission_id IS NULL
+  `)
+
+  await knex.schema.alterTable("preapprovedDocuments", (table) => {
+    table.dropForeign("preTSubID")
+    table.dropColumn("preTSubID")
+
+    table.integer("submission_id").notNullable().alter()
   })
 
   // NOTE: I think this relationship was backwards?

--- a/api/src/db/migrations/20250320214039_enforce-one-to-one-relationship-between-pre-approval-and-submission.ts
+++ b/api/src/db/migrations/20250320214039_enforce-one-to-one-relationship-between-pre-approval-and-submission.ts
@@ -10,10 +10,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.alterTable("travel_authorization_pre_approval_submissions", (table) => {
-    table.dropIndex(
-      ["pre_approval_id"],
-      "travel_authorization_pre_approval_submissions_pre_approval_id_u"
-    )
-  })
+  await knex.raw(`
+    DROP INDEX IF EXISTS "travel_authorization_pre_approval_submissions_pre_approval_id_u"
+  `)
 }

--- a/api/src/db/migrations/20250327215059_fix-relationship-between-pre-approval-request-and-pre-approval-submission.ts
+++ b/api/src/db/migrations/20250327215059_fix-relationship-between-pre-approval-request-and-pre-approval-submission.ts
@@ -33,7 +33,7 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   await knex.schema.alterTable("travel_authorization_pre_approval_submissions", (table) => {
-    table.integer("pre_approval_id").notNullable()
+    table.integer("pre_approval_id")
     table
       .foreign("pre_approval_id")
       .references("travel_authorization_pre_approvals.id")
@@ -47,8 +47,18 @@ export async function down(knex: Knex): Promise<void> {
     FROM
       travel_authorization_pre_approvals
     WHERE
-      travel_authorization_pre_approvals.id = travel_authorization_pre_approval_submissions.pre_approval_id
+      travel_authorization_pre_approvals.submission_id = travel_authorization_pre_approval_submissions.id
   `)
+
+  await knex.raw(/* sql */ `
+    DELETE FROM travel_authorization_pre_approval_submissions
+    WHERE
+      pre_approval_id IS NULL
+  `)
+
+  await knex.schema.alterTable("travel_authorization_pre_approval_submissions", (table) => {
+    table.integer("pre_approval_id").notNullable().alter()
+  })
 
   await knex.schema.alterTable("travel_authorization_pre_approvals", (table) => {
     table.dropForeign("submission_id")


### PR DESCRIPTION
Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/283

# Context

Bug in production run of migration cause some tables not to be created
```
migration file "20250319170414_standardize-preapproved-submissions-table.js" failed
migration failed with error: alter table "preapprovedDocuments" add column "submission_id" integer not null - column "submission_id" of relation "preapprovedDocuments" contains null values
Executing: update "public"."knex_migrations_lock" set "is_locked" = $1
```
and
```
name: 'SequelizeDatabaseError',
  parent: error: relation "public.yg_employee_groups" does not exist
      at Parser.parseErrorMessage (/home/node/app/node_modules/pg-protocol/dist/parser.js:283:98)
      at Parser.handlePacket (/home/node/app/node_modules/pg-protocol/dist/parser.js:122:29)
```

# Implementation

1. Patch bad up migration, re-work a couple of down migrations to adjust to current data.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Run 
    ```bash
    for i in {1..11}; do dev migrate down; done
    ```
5. Run 
    ```bash
    for i in {1..12}; do dev migrate up; done
    ```
    > running up one extra time so shows "no more migrations"
