### PR TITLE
Estimates: Personal Vehicle Estimate Only Working In One Direction

### DIFF
--- a/api/src/services/estimates/bulk-generate-service.ts
+++ b/api/src/services/estimates/bulk-generate-service.ts
@@ -252,7 +252,12 @@ export class BulkGenerateService extends BaseService {
     toCity: string
   ): Promise<number> {
     const distanceMatrix = await DistanceMatrix.findOne({
-      where: { origin: fromCity, destination: toCity },
+      where: {
+        [Op.or]: [
+          { origin: fromCity, destination: toCity },
+          { origin: toCity, destination: fromCity },
+        ],
+      },
     })
     if (isNil(distanceMatrix) || isNil(distanceMatrix.kilometers)) return 0
 

--- a/api/tests/factories/distance-matrix-factory.ts
+++ b/api/tests/factories/distance-matrix-factory.ts
@@ -1,0 +1,25 @@
+import { Factory } from "fishery"
+import { faker } from "@faker-js/faker/locale/en_CA"
+
+import { DistanceMatrix } from "@/models"
+
+export const distanceMatrixFactory = Factory.define<DistanceMatrix>(({ onCreate }) => {
+  onCreate((distanceMatrix) => {
+    try {
+      return distanceMatrix.save()
+    } catch (error) {
+      console.error(error)
+      throw new Error(
+        `Could not create DistanceMatrix with attributes: ${JSON.stringify(distanceMatrix.dataValues, null, 2)}`
+      )
+    }
+  })
+
+  return DistanceMatrix.build({
+    origin: faker.location.city(),
+    destination: faker.location.city(),
+    kilometers: faker.number.int({ min: 10, max: 10000 }),
+  })
+})
+
+export default distanceMatrixFactory

--- a/api/tests/factories/index.ts
+++ b/api/tests/factories/index.ts
@@ -1,4 +1,5 @@
 // Factories
+export { distanceMatrixFactory } from "./distance-matrix-factory"
 export { expenseFactory } from "./expense-factory"
 export { locationFactory } from "./location-factory"
 export { perDiemFactory } from "./per-diem-factory"

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -1,6 +1,7 @@
 import { BulkGenerateService } from "@/services/estimates"
 
 import {
+  distanceMatrixFactory,
   locationFactory,
   perDiemFactory,
   travelAllowanceFactory,
@@ -351,6 +352,137 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
             description: "Breakfast/Lunch/Dinner/Incidentals",
             date: "2025-02-01",
             cost: 123.40,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Meals & Incidentals",
+          }),
+        ])
+      })
+
+      test("when travel method is personal vehicle, and trip type is round-trip, correctly generates the transportantion allowance from the distance matrix", async () => {
+        await perDiemFactory.create({
+          claimType: PerDiem.ClaimTypes.BREAKFAST,
+          travelRegion: PerDiem.TravelRegions.YUKON,
+          amount: 23.2,
+          currency: PerDiem.CurrencyTypes.CAD,
+        })
+        await perDiemFactory.create({
+          claimType: PerDiem.ClaimTypes.LUNCH,
+          travelRegion: PerDiem.TravelRegions.YUKON,
+          amount: 21.3,
+          currency: PerDiem.CurrencyTypes.CAD,
+        })
+        await perDiemFactory.create({
+          claimType: PerDiem.ClaimTypes.DINNER,
+          travelRegion: PerDiem.TravelRegions.YUKON,
+          amount: 61.45,
+          currency: PerDiem.CurrencyTypes.CAD,
+        })
+
+        await distanceMatrixFactory.create({
+          origin: "Faro",
+          destination: "Whitehorse",
+          kilometers: 359,
+        })
+
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          tripType: TravelAuthorization.TripTypes.ROUND_TRIP,
+        })
+        const whitehorse = await locationFactory.create({ city: "Whitehorse", province: "YT" })
+        const faro = await locationFactory.create({ city: "Faro", province: "YT" })
+        const travelSegment1 = await travelSegmentFactory
+          .associations({
+            travelAuthorization,
+            departureLocation: whitehorse,
+            arrivalLocation: faro,
+          })
+          .create({
+            segmentNumber: 1,
+            departureOn: new Date("2022-06-05"),
+            departureTime: "10:00:00",
+            modeOfTransport: Stop.TravelMethods.PERSONAL_VEHICLE,
+            accommodationType: Stop.AccommodationTypes.HOTEL,
+          })
+        const travelSegment2 = await travelSegmentFactory
+          .associations({
+            travelAuthorization,
+            departureLocation: faro,
+            arrivalLocation: whitehorse,
+          })
+          .create({
+            segmentNumber: 2,
+            departureOn: new Date("2022-06-07"),
+            departureTime: "15:00:00",
+            modeOfTransport: Stop.TravelMethods.PERSONAL_VEHICLE,
+            accommodationType: null,
+          })
+
+        const expenses = await BulkGenerateService.perform(
+          travelAuthorization.id,
+          [travelSegment1, travelSegment2],
+          { daysOffTravelStatus: 0 }
+        )
+
+        expect(expenses).toEqual([
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Personal Vehicle from Whitehorse to Faro",
+            date: "2022-06-05",
+            cost: 217.195,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Transportation",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Hotel in Faro",
+            date: "2022-06-05",
+            cost: 250.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Accommodations",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Hotel in Faro",
+            date: "2022-06-06",
+            cost: 250.0,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Accommodations",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Personal Vehicle from Faro to Whitehorse",
+            date: "2022-06-07",
+            cost: 217.195,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Transportation",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Lunch/Dinner",
+            date: "2022-06-05",
+            cost: 82.75,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Meals & Incidentals",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Breakfast/Lunch/Dinner/Incidentals",
+            date: "2022-06-06",
+            cost: 105.95,
+            currency: "CAD",
+            type: "Estimate",
+            expenseType: "Meals & Incidentals",
+          }),
+          expect.objectContaining({
+            travelAuthorizationId: travelAuthorization.id,
+            description: "Breakfast/Lunch/Incidentals",
+            date: "2022-06-07",
+            cost: 44.5,
             currency: "CAD",
             type: "Estimate",
             expenseType: "Meals & Incidentals",

--- a/api/tests/services/estimates/bulk-generate-service.test.ts
+++ b/api/tests/services/estimates/bulk-generate-service.test.ts
@@ -361,12 +361,6 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
 
       test("when travel method is personal vehicle, and trip type is round-trip, correctly generates the transportantion allowance from the distance matrix", async () => {
         await perDiemFactory.create({
-          claimType: PerDiem.ClaimTypes.BREAKFAST,
-          travelRegion: PerDiem.TravelRegions.YUKON,
-          amount: 23.2,
-          currency: PerDiem.CurrencyTypes.CAD,
-        })
-        await perDiemFactory.create({
           claimType: PerDiem.ClaimTypes.LUNCH,
           travelRegion: PerDiem.TravelRegions.YUKON,
           amount: 21.3,
@@ -423,7 +417,7 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           { daysOffTravelStatus: 0 }
         )
 
-        expect(expenses).toEqual([
+        expect(expenses).toEqual(expect.arrayContaining([
           expect.objectContaining({
             travelAuthorizationId: travelAuthorization.id,
             description: "Personal Vehicle from Whitehorse to Faro",
@@ -435,24 +429,6 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
           }),
           expect.objectContaining({
             travelAuthorizationId: travelAuthorization.id,
-            description: "Hotel in Faro",
-            date: "2022-06-05",
-            cost: 250.0,
-            currency: "CAD",
-            type: "Estimate",
-            expenseType: "Accommodations",
-          }),
-          expect.objectContaining({
-            travelAuthorizationId: travelAuthorization.id,
-            description: "Hotel in Faro",
-            date: "2022-06-06",
-            cost: 250.0,
-            currency: "CAD",
-            type: "Estimate",
-            expenseType: "Accommodations",
-          }),
-          expect.objectContaining({
-            travelAuthorizationId: travelAuthorization.id,
             description: "Personal Vehicle from Faro to Whitehorse",
             date: "2022-06-07",
             cost: 217.195,
@@ -460,34 +436,7 @@ describe("api/src/services/estimates/bulk-generate-service.ts", () => {
             type: "Estimate",
             expenseType: "Transportation",
           }),
-          expect.objectContaining({
-            travelAuthorizationId: travelAuthorization.id,
-            description: "Lunch/Dinner",
-            date: "2022-06-05",
-            cost: 82.75,
-            currency: "CAD",
-            type: "Estimate",
-            expenseType: "Meals & Incidentals",
-          }),
-          expect.objectContaining({
-            travelAuthorizationId: travelAuthorization.id,
-            description: "Breakfast/Lunch/Dinner/Incidentals",
-            date: "2022-06-06",
-            cost: 105.95,
-            currency: "CAD",
-            type: "Estimate",
-            expenseType: "Meals & Incidentals",
-          }),
-          expect.objectContaining({
-            travelAuthorizationId: travelAuthorization.id,
-            description: "Breakfast/Lunch/Incidentals",
-            date: "2022-06-07",
-            cost: 44.5,
-            currency: "CAD",
-            type: "Estimate",
-            expenseType: "Meals & Incidentals",
-          }),
-        ])
+        ]))
       })
     })
   })


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/236

# Context

The estimates calculation for a private vehicle from whitehorse to Faro is not calculating properly. It shows up as $0 but should be the same amount of the return trip.

![Image](https://github.com/user-attachments/assets/5f5fa665-7d76-4225-8406-d08c67a94519)

![Image](https://github.com/user-attachments/assets/6f619e20-9498-4855-b036-5d7439e4ca65)

# Implementation

1. Update estimate generation travel distance lookup to look in either direction. Distance matrix only shows distance in one direction, likely to avoid data duplication.
2. Add test to estimate generation service for this edge case.

# Screenshots

My Travel Request Wizard Estimate Generation (fixed)
http://localhost:8080/my-travel-requests/82/wizard/generate-estimate
![image](https://github.com/user-attachments/assets/1d5e7c61-f151-4dad-ad62-00da23b3565b)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Select "My Travel Requests" from the left side nav.
5. Create a new travel request.
6. Fill in the trip purpose step and continue.
7. On the trip details step, select a round trip type, and choose Whitehorse to Faro as the destination.
8. Set the travel method as Personal Vehicle for both directions.
9. Fill in the rest as you see fit and continue.
10. In the estimate step, generate the estimate.
11. Check that Transportation -> "Personal Vehicle from Whitehorse to Faro" and "Personal Vehicle from Faro to Whitehorse" both show the same amount.
