### PR TITLE
Ytgov issue 115: Preapproved Drop Down Include Travel Description

### DIFF
--- a/api/src/models/travel-authorization-pre-approval-profile.ts
+++ b/api/src/models/travel-authorization-pre-approval-profile.ts
@@ -5,17 +5,17 @@ import {
   type ForeignKey,
   type InferAttributes,
   type InferCreationAttributes,
-  Model,
   type NonAttribute,
   Op,
 } from "sequelize"
 
 import sequelize from "@/db/db-client"
 
+import BaseModel from "@/models/base-model"
 import TravelAuthorization from "@/models/travel-authorization"
 import TravelAuthorizationPreApproval from "@/models/travel-authorization-pre-approval"
 
-export class TravelAuthorizationPreApprovalProfile extends Model<
+export class TravelAuthorizationPreApprovalProfile extends BaseModel<
   InferAttributes<TravelAuthorizationPreApprovalProfile>,
   InferCreationAttributes<TravelAuthorizationPreApprovalProfile>
 > {
@@ -131,5 +131,8 @@ TravelAuthorizationPreApprovalProfile.init(
     },
   }
 )
+
+// TODO: add better search!
+TravelAuthorizationPreApprovalProfile.addSearchScope(["profile_name"])
 
 export default TravelAuthorizationPreApprovalProfile

--- a/web/src/api/travel-authorization-pre-approval-profiles-api.js
+++ b/web/src/api/travel-authorization-pre-approval-profiles-api.js
@@ -3,6 +3,8 @@ import http from "@/api/http-client"
 /** @typedef {import('@/api/base-api.js').Policy} Policy */
 /** @typedef {import("@/api/base-api").ModelOrder} ModelOrder */
 
+/** @typedef {import("@/api/travel-authorization-pre-approvals-api.js").TravelAuthorizationPreApproval} TravelAuthorizationPreApproval */
+
 /**
  * @typedef {{
  *   id: number;
@@ -13,6 +15,12 @@ import http from "@/api/http-client"
  *   createdAt: string;
  *   updatedAt: string;
  * }} TravelAuthorizationPreApprovalProfile
+ */
+
+/**
+ * @typedef {TravelAuthorizationPreApprovalProfile & {
+ *   preApproval: TravelAuthorizationPreApproval;
+ * }} TravelAuthorizationPreApprovalProfileAsShow
  */
 
 /**
@@ -30,6 +38,7 @@ import http from "@/api/http-client"
  * @typedef {{
  *  approved?: true;
  *  openDateOrBeforeStartDate?: true;
+ *  search?: string;
  * }} TravelAuthorizationPreApprovalProfileFiltersOptions
  */
 
@@ -61,7 +70,7 @@ export const travelAuthorizationPreApprovalProfilesApi = {
   /**
    * @param {number} travelAuthorizationPreApprovalProfileId
    * @returns {Promise<{
-   *   travelAuthorizationPreApprovalProfile: TravelAuthorizationPreApprovalProfile;
+   *   travelAuthorizationPreApprovalProfile: TravelAuthorizationPreApprovalProfileAsShow;
    *   policy: Policy;
    * }>}
    */
@@ -87,7 +96,7 @@ export const travelAuthorizationPreApprovalProfilesApi = {
    * @param {number} travelAuthorizationPreApprovalProfileId
    * @param {Partial<TravelAuthorizationPreApprovalProfile>} attributes
    * @returns {Promise<{
-   *   travelAuthorizationPreApprovalProfile: TravelAuthorizationPreApprovalProfile,
+   *   travelAuthorizationPreApprovalProfile: TravelAuthorizationPreApprovalProfileAsShow,
    *   policy: Policy,
    * }>}
    */

--- a/web/src/components/common/TextareaDescriptionElement.vue
+++ b/web/src/components/common/TextareaDescriptionElement.vue
@@ -1,0 +1,75 @@
+<template>
+  <DescriptionElement
+    :label="label"
+    :icon="icon"
+    :vertical="vertical"
+    v-bind="$attrs"
+    v-on="$listeners"
+  >
+    <div
+      class="overflow-auto pa-4 rounded"
+      :style="{
+        height: normalizedHeight,
+        'white-space': 'pre-wrap',
+        border: '1px solid #ccc',
+      }"
+    >
+      <slot>{{ value }}</slot>
+    </div>
+  </DescriptionElement>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
+import { isNumber } from "lodash"
+
+const props = defineProps({
+  /**
+   * The label text to display
+   */
+  label: {
+    type: String,
+    required: true,
+  },
+  /**
+   * Optional icon name from Material Design Icons (e.g., 'mdi-account')
+   */
+  icon: {
+    type: String,
+    default: "",
+  },
+  /**
+   * The value to display. Not required if using slot content
+   */
+  value: {
+    type: [String, Number, Boolean],
+    default: "",
+  },
+  /**
+   * Whether to display label and value horizontally or vertically
+   */
+  vertical: {
+    type: Boolean,
+    default: false,
+  },
+  height: {
+    type: [String, Number],
+    default: "150px",
+  },
+})
+
+const normalizedHeight = computed(() => {
+  const { height } = props
+  if (isNumber(height)) return `${height}px`
+
+  return height
+})
+</script>
+
+<style scoped>
+.gap-2 {
+  gap: 0.5rem; /* 8px */
+}
+</style>

--- a/web/src/components/locations/LocationChip.vue
+++ b/web/src/components/locations/LocationChip.vue
@@ -4,7 +4,6 @@
       v-if="isNil(location)"
       size="20"
       width="2"
-      color="white"
       indeterminate
     />
     <template v-else>

--- a/web/src/components/locations/LocationChip.vue
+++ b/web/src/components/locations/LocationChip.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-chip outlined>
+    <v-progress-circular
+      v-if="isNil(location)"
+      size="20"
+      width="2"
+      color="white"
+      indeterminate
+    />
+    <template v-else>
+      {{ locationText }}
+    </template>
+  </v-chip>
+</template>
+
+<script setup>
+import { computed, toRefs } from "vue"
+import { isNil } from "lodash"
+
+import useLocation from "@/use/use-location"
+
+const props = defineProps({
+  locationId: {
+    type: Number,
+    default: () => null,
+  },
+})
+
+const { locationId } = toRefs(props)
+const { location } = useLocation(locationId)
+
+const locationText = computed(() => {
+  if (isNil(location.value)) return ""
+
+  const { city, province } = location.value
+  return `${city} (${province})`
+})
+</script>

--- a/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileChip.vue
+++ b/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileChip.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-chip
+    ref="chip"
+    outlined
+    link
+    v-bind="$attrs"
+    v-on="$listeners"
+  >
+    <v-progress-circular
+      v-if="isLoading"
+      size="20"
+      width="2"
+      color="white"
+      indeterminate
+    />
+    <template v-else>
+      {{ title }}
+    </template>
+
+    <v-icon right>mdi-menu-down</v-icon>
+    <v-menu
+      :activator="chip?.$el"
+      :close-on-content-click="false"
+      offset-y
+      transition="scale-transition"
+    >
+      <v-card>
+        <v-card-title>{{ title }}</v-card-title>
+        <v-card-text>
+          {{ subtitle }}
+        </v-card-text>
+      </v-card>
+    </v-menu>
+  </v-chip>
+</template>
+
+<script setup>
+import { computed, ref, toRefs } from "vue"
+import { isNil } from "lodash"
+
+import { formatDate } from "@/utils/formatters"
+
+import useTravelAuthorizationPreApprovalProfile from "@/use/use-travel-authorization-pre-approval-profile"
+
+const props = defineProps({
+  travelAuthorizationPreApprovalProfileId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const { travelAuthorizationPreApprovalProfileId } = toRefs(props)
+const { travelAuthorizationPreApprovalProfile, isLoading } =
+  useTravelAuthorizationPreApprovalProfile(travelAuthorizationPreApprovalProfileId)
+
+const title = computed(() => {
+  const profile = travelAuthorizationPreApprovalProfile.value
+  if (isNil(profile)) return "..."
+
+  const { branch, profileName } = profile
+  return [branch, profileName].filter(Boolean).join(" - ")
+})
+
+const subtitle = computed(() => {
+  const profile = travelAuthorizationPreApprovalProfile.value
+  if (isNil(profile) || isNil(profile.preApproval)) return "..."
+
+  const { location, purpose, isOpenForAnyDate, startDate, endDate, month } = profile.preApproval
+  const dateInfo = isOpenForAnyDate
+    ? month
+    : [formatDate(startDate), formatDate(endDate)].filter(Boolean).join(" to ")
+
+  return [location, purpose, dateInfo].filter(Boolean).join(" - ")
+})
+
+/** @typedef {import('vuetify/lib/components').VChip} VChip */
+/** @type {import('vue').Ref<InstanceType<typeof VChip> | null>} */
+const chip = ref(null)
+</script>

--- a/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileChip.vue
+++ b/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileChip.vue
@@ -10,7 +10,6 @@
       v-if="isLoading"
       size="20"
       width="2"
-      color="white"
       indeterminate
     />
     <template v-else>

--- a/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileListItem.vue
+++ b/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileListItem.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-skeleton-loader
+    v-if="isNil(travelAuthorizationPreApprovalProfile)"
+    type="list-item-two-line"
+  />
+  <v-list-item-title v-else>
+    <v-list-item-content>
+      <v-list-item-title>{{ title }}</v-list-item-title>
+      <v-list-item-subtitle>{{ subtitle }}</v-list-item-subtitle>
+    </v-list-item-content>
+  </v-list-item-title>
+</template>
+
+<script setup>
+import { computed, toRefs } from "vue"
+import { isNil } from "lodash"
+
+import { formatDate } from "@/utils/formatters"
+
+import useTravelAuthorizationPreApprovalProfile from "@/use/use-travel-authorization-pre-approval-profile"
+
+const props = defineProps({
+  travelAuthorizationPreApprovalProfileId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const { travelAuthorizationPreApprovalProfileId } = toRefs(props)
+const { travelAuthorizationPreApprovalProfile } = useTravelAuthorizationPreApprovalProfile(
+  travelAuthorizationPreApprovalProfileId
+)
+
+const title = computed(() => {
+  const profile = travelAuthorizationPreApprovalProfile.value
+  if (isNil(profile)) return "..."
+
+  const { branch, profileName } = profile
+  return [branch, profileName].filter(Boolean).join(" - ")
+})
+
+const subtitle = computed(() => {
+  const profile = travelAuthorizationPreApprovalProfile.value
+  if (isNil(profile) || isNil(profile.preApproval)) return "..."
+
+  const { location, purpose, isOpenForAnyDate, startDate, endDate, month } = profile.preApproval
+  const dateInfo = isOpenForAnyDate
+    ? month
+    : [formatDate(startDate), formatDate(endDate)].filter(Boolean).join(" to ")
+
+  return [location, purpose, dateInfo].filter(Boolean).join(" - ")
+})
+</script>

--- a/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSearchableAutocomplete.vue
+++ b/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSearchableAutocomplete.vue
@@ -1,0 +1,183 @@
+<template>
+  <v-autocomplete
+    :model="value"
+    :loading="isLoading"
+    :items="allTravelAuthorizationPreApprovalProfiles"
+    :label="label"
+    :hint="hint"
+    :no-data-text="noDataText"
+    item-value="id"
+    auto-select-first
+    chips
+    clearable
+    hide-selected
+    no-filter
+    persistent-hint
+    small-chips
+    v-bind="$attrs"
+    v-on="$listeners"
+    @input="emit('input', $event)"
+    @update:search-input="debouncedUpdateSearchToken"
+    @click:clear="reset"
+  >
+    <template #selection="{ attrs, item, select }">
+      <TravelAuthorizationPreApprovalProfileChip
+        v-if="!isNil(item.id)"
+        v-bind="attrs"
+        :travel-authorization-pre-approval-profile-id="item.id"
+        @click="select"
+      />
+      <v-chip
+        v-else
+        :text="'Unknown#' + (item.id || JSON.stringify(item))"
+      />
+    </template>
+    <template #item="{ item, on, attrs }">
+      <TravelAuthorizationPreApprovalProfileListItem
+        v-if="!isNil(item.id)"
+        :travel-authorization-pre-approval-profile-id="item.id"
+        v-bind="attrs"
+        v-on="on"
+      />
+      <v-list-item
+        v-else
+        v-bind="attrs"
+        :title="'Unknown#' + (item.id || JSON.stringify(item))"
+      />
+    </template>
+
+    <!-- TODO: triggers => [Vuetify] assert: staticList should not be called if slots are used -->
+    <template
+      v-if="hasMore"
+      #append-item
+    >
+      <v-divider />
+      <v-list-item
+        class="text-primary text-center"
+        @click="nextPage"
+      >
+        <v-list-item-title>Show More</v-list-item-title>
+      </v-list-item>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script setup>
+import { computed, ref, watch } from "vue"
+import { debounce, isEmpty, isNil, uniqBy } from "lodash"
+
+import useTravelAuthorizationPreApprovalProfile from "@/use/use-travel-authorization-pre-approval-profile"
+import useTravelAuthorizationPreApprovalProfiles from "@/use/use-travel-authorization-pre-approval-profiles"
+
+import TravelAuthorizationPreApprovalProfileChip from "@/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileChip.vue"
+import TravelAuthorizationPreApprovalProfileListItem from "@/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileListItem.vue"
+
+const props = defineProps({
+  value: {
+    type: Number,
+    default: null,
+  },
+  where: {
+    type: Object,
+    default: () => ({}),
+  },
+  filters: {
+    type: Object,
+    default: () => ({}),
+  },
+  label: {
+    type: String,
+    default: "Pre-approved travel for (if applicable)",
+  },
+  hint: {
+    type: String,
+    default: "Search for a pre-approval.",
+  },
+  noDataText: {
+    type: String,
+    default: "No pre-approvals available",
+  },
+})
+
+const emit = defineEmits(["input"])
+
+const travelAuthorizationPreApprovalProfileId = computed(() => props.value)
+const { travelAuthorizationPreApprovalProfile } = useTravelAuthorizationPreApprovalProfile(
+  travelAuthorizationPreApprovalProfileId
+)
+
+const searchToken = ref("")
+
+function updateSearchToken(value) {
+  searchToken.value = value
+  page.value = 1
+}
+
+const debouncedUpdateSearchToken = debounce(updateSearchToken, 500)
+
+const searchFilter = computed(() => {
+  if (isNil(searchToken.value) || isEmpty(searchToken.value)) return {}
+
+  return {
+    search: searchToken.value,
+  }
+})
+
+const perPage = computed(() => {
+  if (isNil(searchToken.value) || isEmpty(searchToken.value)) return 100
+
+  return 20
+})
+
+const page = ref(1)
+
+const travelAuthorizationPreApprovalProfilesQuery = computed(() => {
+  return {
+    where: props.where,
+    filters: {
+      ...props.filters,
+      ...searchFilter.value,
+    },
+    perPage: perPage.value,
+    page: page.value,
+  }
+})
+const { travelAuthorizationPreApprovalProfiles, totalCount, isLoading, refresh } =
+  useTravelAuthorizationPreApprovalProfiles(travelAuthorizationPreApprovalProfilesQuery)
+
+const allTravelAuthorizationPreApprovalProfiles = computed(() => {
+  if (isNil(travelAuthorizationPreApprovalProfile.value)) {
+    return travelAuthorizationPreApprovalProfiles.value
+  }
+
+  return uniqBy(
+    [...travelAuthorizationPreApprovalProfiles.value, travelAuthorizationPreApprovalProfile.value],
+    "id"
+  )
+})
+
+async function reset() {
+  searchToken.value = ""
+  travelAuthorizationPreApprovalProfile.value = null
+  await refresh()
+}
+
+watch(
+  () => props.value,
+  async (newModelValue) => {
+    if (isEmpty(newModelValue)) {
+      await reset()
+    }
+  }
+)
+
+const hasMore = computed(() => page.value * perPage.value < totalCount.value)
+
+function nextPage() {
+  page.value += 1
+}
+
+defineExpose({
+  reset,
+})
+</script>

--- a/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSearchableAutocomplete.vue
+++ b/web/src/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSearchableAutocomplete.vue
@@ -1,6 +1,6 @@
 <template>
   <v-autocomplete
-    :model="value"
+    :value="value"
     :loading="isLoading"
     :items="allTravelAuthorizationPreApprovalProfiles"
     :label="label"

--- a/web/src/components/travel-authorizations/ApprovalsCard.vue
+++ b/web/src/components/travel-authorizations/ApprovalsCard.vue
@@ -8,43 +8,20 @@
           md="3"
         >
           <!-- TODO: add tooltip with link to estimate tab explaining where this data comes from -->
-          <v-text-field
-            :value="formatCurrency(estimatedCost)"
+          <EstimatedCostDescriptionElement
             label="Estimated Cost"
-            disabled
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
-          ></v-text-field>
+            :travel-authorization-id="travelAuthorizationId"
+            vertical
+          />
         </v-col>
         <v-col
           cols="12"
           md="3"
         >
-          <v-text-field
-            :value="travelAdvanceInDollars"
+          <DescriptionElement
             label="Travel Advance"
-            prefix="$"
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
-          ></v-text-field>
-        </v-col>
-        <v-col
-          cols="12"
-          md="6"
-        >
-          <!-- TODO: make this a re-usable component -->
-          <v-text-field
-            :value="travelAuthorizationPreApprovalProfileText"
-            :loading="isLoadingTravelAuthorizationPreApprovalProfile"
-            label="Pre-approved travel for (if applicable)"
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
+            :value="formattedTravelAdvanceInDollars"
+            vertical
           />
         </v-col>
       </v-row>
@@ -53,13 +30,28 @@
           cols="12"
           md="6"
         >
-          <v-text-field
+          <DescriptionElement
+            label="Pre-approved travel for (if applicable)"
+            vertical
+          >
+            <TravelAuthorizationPreApprovalProfileChip
+              v-if="travelAuthorizationPreApprovalProfileId"
+              :travel-authorization-pre-approval-profile-id="
+                travelAuthorizationPreApprovalProfileId
+              "
+            />
+          </DescriptionElement>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col
+          cols="12"
+          md="6"
+        >
+          <DescriptionElement
+            label="Submitted to"
             :value="travelAuthorization.supervisorEmail"
-            label="Submit to"
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
+            vertical
           />
         </v-col>
       </v-row>
@@ -69,11 +61,14 @@
 
 <script setup>
 import { computed, toRefs } from "vue"
-import { isNil, sumBy } from "lodash"
 
-import formatCurrency from "@/utils/format-currency"
+import { formatCurrency } from "@/utils/formatters"
+
 import useTravelAuthorization from "@/use/use-travel-authorization"
-import useTravelAuthorizationPreApprovalProfile from "@/use/use-travel-authorization-pre-approval-profile"
+
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
+import EstimatedCostDescriptionElement from "@/components/travel-authorizations/EstimatedCostDescriptionElement.vue"
+import TravelAuthorizationPreApprovalProfileChip from "@/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileChip.vue"
 
 const props = defineProps({
   travelAuthorizationId: {
@@ -83,30 +78,14 @@ const props = defineProps({
 })
 
 const { travelAuthorizationId } = toRefs(props)
-const { travelAuthorization, estimates } = useTravelAuthorization(travelAuthorizationId)
-
-const estimatedCost = computed(() => sumBy(estimates.value, "cost"))
+const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)
 
 const travelAuthorizationPreApprovalProfileId = computed(() => {
   return travelAuthorization.value?.preApprovalProfileId
-})
-const {
-  travelAuthorizationPreApprovalProfile,
-  isLoading: isLoadingTravelAuthorizationPreApprovalProfile,
-} = useTravelAuthorizationPreApprovalProfile(travelAuthorizationPreApprovalProfileId)
-
-const travelAuthorizationPreApprovalProfileText = computed(() => {
-  if (
-    isNil(travelAuthorizationPreApprovalProfile.value) ||
-    isLoadingTravelAuthorizationPreApprovalProfile.value
-  ) {
-    return ""
-  }
-
-  return travelAuthorizationPreApprovalProfile.value.profileName
 })
 
 const travelAdvanceInDollars = computed(() =>
   Math.ceil(travelAuthorization.value.travelAdvanceInCents / 100.0)
 )
+const formattedTravelAdvanceInDollars = computed(() => formatCurrency(travelAdvanceInDollars.value))
 </script>

--- a/web/src/components/travel-authorizations/ApprovalsCard.vue
+++ b/web/src/components/travel-authorizations/ApprovalsCard.vue
@@ -34,12 +34,19 @@
             label="Pre-approved travel for (if applicable)"
             vertical
           >
+            <v-progress-circular
+              v-if="isLoading"
+              size="20"
+              width="2"
+              indeterminate
+            />
             <TravelAuthorizationPreApprovalProfileChip
-              v-if="travelAuthorizationPreApprovalProfileId"
+              v-else-if="travelAuthorizationPreApprovalProfileId"
               :travel-authorization-pre-approval-profile-id="
                 travelAuthorizationPreApprovalProfileId
               "
             />
+            <span v-else>None supplied</span>
           </DescriptionElement>
         </v-col>
       </v-row>
@@ -78,7 +85,7 @@ const props = defineProps({
 })
 
 const { travelAuthorizationId } = toRefs(props)
-const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)
+const { travelAuthorization, isLoading } = useTravelAuthorization(travelAuthorizationId)
 
 const travelAuthorizationPreApprovalProfileId = computed(() => {
   return travelAuthorization.value?.preApprovalProfileId

--- a/web/src/components/travel-authorizations/ApprovalsEditFormCard.vue
+++ b/web/src/components/travel-authorizations/ApprovalsEditFormCard.vue
@@ -1,68 +1,67 @@
 <template>
-  <v-card>
-    <v-card-title> Approvals </v-card-title>
-    <v-card-text>
-      <v-form
-        ref="form"
-        lazy-validation
+  <HeaderActionsFormCard
+    ref="headerActionsFormCard"
+    title="Approvals"
+    lazy-validation
+  >
+    <v-row>
+      <v-col
+        cols="12"
+        md="3"
       >
-        <v-row>
-          <v-col
-            cols="12"
-            md="2"
-          >
-            <EstimatedCostTextField :estimates="travelAuthorizationEstimates" />
-          </v-col>
-          <v-col
-            cols="12"
-            md="2"
-          >
-            <v-text-field
-              v-model="travelAdvanceInDollars"
-              :rules="[required, isInteger]"
-              label="Travel Advance"
-              prefix="$"
-              dense
-              outlined
-              required
-            ></v-text-field>
-          </v-col>
-          <v-col
-            cols="12"
-            md="4"
-          >
-            <TravelAuthorizationPreApprovalProfileSelect
-              v-model="travelAuthorization.preApprovalProfileId"
-              :query-options="{
-                where: { department },
-                filters: {
-                  approved: true,
-                  openDateOrBeforeStartDate: true,
-                },
-              }"
-              dense
-              outlined
-            />
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <UserEmailSearchableCombobox
-              v-model="travelAuthorization.supervisorEmail"
-              :rules="[required]"
-              label="Submit to"
-              dense
-              outlined
-              required
-            />
-          </v-col>
-        </v-row>
-      </v-form>
-    </v-card-text>
-  </v-card>
+        <EstimatedCostDescriptionElement
+          label="Estimated Cost"
+          :travel-authorization-id="travelAuthorizationId"
+          vertical
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="3"
+      >
+        <v-text-field
+          v-model="travelAdvanceInDollars"
+          :rules="[required, isInteger]"
+          label="Travel Advance"
+          prefix="$"
+          outlined
+          required
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <TravelAuthorizationPreApprovalProfileSelect
+          v-model="travelAuthorization.preApprovalProfileId"
+          :query-options="{
+            where: { department },
+            filters: {
+              approved: true,
+              openDateOrBeforeStartDate: true,
+            },
+          }"
+          outlined
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <UserEmailSearchableCombobox
+          v-model="travelAuthorization.supervisorEmail"
+          label="Submit to *"
+          :rules="[required]"
+          outlined
+          required
+        />
+      </v-col>
+    </v-row>
+  </HeaderActionsFormCard>
 </template>
 
 <script setup>
@@ -73,9 +72,10 @@ import { required, isInteger } from "@/utils/validators"
 import useCurrentUser from "@/use/use-current-user"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
+import HeaderActionsFormCard from "@/components/common/HeaderActionsFormCard.vue"
 import UserEmailSearchableCombobox from "@/components/users/UserEmailSearchableCombobox.vue"
 import TravelAuthorizationPreApprovalProfileSelect from "@/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSelect.vue"
-import EstimatedCostTextField from "@/modules/travel-authorizations/components/EstimatedCostTextField.vue"
+import EstimatedCostDescriptionElement from "@/components/travel-authorizations/EstimatedCostDescriptionElement.vue"
 
 const props = defineProps({
   travelAuthorizationId: {
@@ -85,11 +85,7 @@ const props = defineProps({
 })
 
 const { travelAuthorizationId } = toRefs(props)
-const {
-  travelAuthorization,
-  estimates: travelAuthorizationEstimates,
-  submit,
-} = useTravelAuthorization(travelAuthorizationId)
+const { travelAuthorization, submit } = useTravelAuthorization(travelAuthorizationId)
 
 const { currentUser } = useCurrentUser()
 const department = computed(() => {
@@ -106,14 +102,14 @@ const travelAdvanceInDollars = computed({
 })
 
 /** @type {import('vue').Ref<typeof import('vuetify/lib/components').VForm | null>} */
-const form = ref(null)
+const headerActionsFormCard = ref(null)
 
 onMounted(async () => {
-  await form.value?.resetValidation()
+  await headerActionsFormCard.value?.resetValidation()
 })
 
 defineExpose({
   save: submit,
-  validate: () => form.value?.validate(),
+  validate: () => headerActionsFormCard.value?.validate(),
 })
 </script>

--- a/web/src/components/travel-authorizations/ApprovalsEditFormCard.vue
+++ b/web/src/components/travel-authorizations/ApprovalsEditFormCard.vue
@@ -34,15 +34,10 @@
         cols="12"
         md="6"
       >
-        <TravelAuthorizationPreApprovalProfileSelect
+        <TravelAuthorizationPreApprovalProfileSearchableAutocomplete
           v-model="travelAuthorization.preApprovalProfileId"
-          :query-options="{
-            where: { department },
-            filters: {
-              approved: true,
-              openDateOrBeforeStartDate: true,
-            },
-          }"
+          :where="travelAuthorizationPreApprovalProfileWhere"
+          :filters="travelAuthorizationPreApprovalProfileFilters"
           outlined
         />
       </v-col>
@@ -66,6 +61,7 @@
 
 <script setup>
 import { computed, onMounted, ref, toRefs } from "vue"
+import { isNil } from "lodash"
 
 import { required, isInteger } from "@/utils/validators"
 
@@ -73,9 +69,9 @@ import useCurrentUser from "@/use/use-current-user"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
 import HeaderActionsFormCard from "@/components/common/HeaderActionsFormCard.vue"
-import UserEmailSearchableCombobox from "@/components/users/UserEmailSearchableCombobox.vue"
-import TravelAuthorizationPreApprovalProfileSelect from "@/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSelect.vue"
 import EstimatedCostDescriptionElement from "@/components/travel-authorizations/EstimatedCostDescriptionElement.vue"
+import TravelAuthorizationPreApprovalProfileSearchableAutocomplete from "@/components/travel-authorization-pre-approval-profiles/TravelAuthorizationPreApprovalProfileSearchableAutocomplete.vue"
+import UserEmailSearchableCombobox from "@/components/users/UserEmailSearchableCombobox.vue"
 
 const props = defineProps({
   travelAuthorizationId: {
@@ -88,10 +84,20 @@ const { travelAuthorizationId } = toRefs(props)
 const { travelAuthorization, submit } = useTravelAuthorization(travelAuthorizationId)
 
 const { currentUser } = useCurrentUser()
-const department = computed(() => {
-  return currentUser.value?.department
-})
+const travelAuthorizationPreApprovalProfileWhere = computed(() => {
+  const { department } = currentUser.value
+  if (isNil(department)) return {}
 
+  return {
+    department,
+  }
+})
+const travelAuthorizationPreApprovalProfileFilters = computed(() => {
+  return {
+    approved: true,
+    openDateOrBeforeStartDate: true,
+  }
+})
 const travelAdvanceInDollars = computed({
   get() {
     return Math.ceil(travelAuthorization.value.travelAdvanceInCents / 100.0) || 0

--- a/web/src/components/travel-authorizations/DetailsCard.vue
+++ b/web/src/components/travel-authorizations/DetailsCard.vue
@@ -1,80 +1,64 @@
 <template>
-  <v-card>
-    <v-card-title><h3>Details</h3></v-card-title>
-    <v-card-text>
-      <v-row>
-        <v-col cols="12">
-          <DescriptionElement
-            :value="
-              t(`travel_authorization.trip_type.${travelAuthorization.tripType}`, {
-                $default: travelAuthorization.tripType,
-              })
-            "
-            label="Trip Type"
-          />
-        </v-col>
-      </v-row>
+  <HeaderActionsCard title="Details">
+    <v-row>
+      <v-col cols="12">
+        <DescriptionElement label="Trip Type">
+          <TravelAuthorizationTripTypeChip :value="travelAuthorization.tripType" />
+        </DescriptionElement>
+      </v-col>
+    </v-row>
 
-      <component
-        :is="tripTypeComponent"
-        v-if="tripTypeComponent"
-        :travel-authorization-id="travelAuthorizationId"
-        class="mt-3"
-      />
-      <div v-else>Trip type {{ travelAuthorization.tripType }} not implemented!</div>
-      <v-row>
-        <v-col
-          cols="12"
-          md="2"
-        >
-          <v-text-field
-            :value="travelAuthorization.travelDuration"
-            label="# Days"
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
-          ></v-text-field>
-        </v-col>
-        <v-col
-          cols="12"
-          md="2"
-        >
-          <v-text-field
-            :value="travelAuthorization.daysOffTravelStatus"
-            label="Days on non-travel status"
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
-          ></v-text-field>
-        </v-col>
-        <v-col
-          cols="12"
-          md="3"
-        >
-          <v-text-field
-            :value="travelAuthorization.dateBackToWork"
-            label="Expected Date return to work"
-            prepend-icon="mdi-calendar"
-            dense
-            outlined
-            readonly
-            append-icon="mdi-lock"
-          />
-        </v-col>
-      </v-row>
-    </v-card-text>
-  </v-card>
+    <component
+      :is="tripTypeComponent"
+      v-if="tripTypeComponent"
+      :travel-authorization-id="travelAuthorizationId"
+      class="mt-3"
+    />
+    <div v-else>Trip type {{ travelAuthorization.tripType }} not implemented!</div>
+
+    <v-row>
+      <v-col
+        cols="12"
+        md="2"
+      >
+        <DescriptionElement
+          :value="travelAuthorization.travelDuration"
+          label="Travel Days"
+          vertical
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="4"
+      >
+        <DescriptionElement
+          :value="travelAuthorization.daysOffTravelStatus || '0'"
+          label="Days on non-travel status"
+          vertical
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="4"
+      >
+        <DescriptionElement
+          :value="travelAuthorization.dateBackToWork"
+          label="Expected Date return to work"
+          vertical
+        />
+      </v-col>
+    </v-row>
+  </HeaderActionsCard>
 </template>
 
 <script setup>
 import { computed, toRefs } from "vue"
 
-import { useI18n } from "@/plugins/vue-i18n-plugin"
 import useTravelAuthorization, { TRIP_TYPES } from "@/use/use-travel-authorization"
 
 import DescriptionElement from "@/components/common/DescriptionElement.vue"
+import HeaderActionsCard from "@/components/common/HeaderActionsCard.vue"
+import TravelAuthorizationTripTypeChip from "@/components/travel-authorizations/TravelAuthorizationTripTypeChip.vue"
 
 const props = defineProps({
   travelAuthorizationId: {
@@ -82,8 +66,6 @@ const props = defineProps({
     required: true,
   },
 })
-
-const { t } = useI18n()
 
 const { travelAuthorizationId } = toRefs(props)
 const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)

--- a/web/src/components/travel-authorizations/DetailsCard.vue
+++ b/web/src/components/travel-authorizations/DetailsCard.vue
@@ -12,7 +12,7 @@
       :is="tripTypeComponent"
       v-if="tripTypeComponent"
       :travel-authorization-id="travelAuthorizationId"
-      class="mt-3"
+      class="mb-6"
     />
     <div v-else>Trip type {{ travelAuthorization.tripType }} not implemented!</div>
 

--- a/web/src/components/travel-authorizations/DetailsCard.vue
+++ b/web/src/components/travel-authorizations/DetailsCard.vue
@@ -3,7 +3,10 @@
     <v-row>
       <v-col cols="12">
         <DescriptionElement label="Trip Type">
-          <TravelAuthorizationTripTypeChip :value="travelAuthorization.tripType" />
+          <TravelAuthorizationTripTypeChip
+            v-if="travelAuthorization.tripType"
+            :value="travelAuthorization.tripType"
+          />
         </DescriptionElement>
       </v-col>
     </v-row>

--- a/web/src/components/travel-authorizations/EstimatedCostDescriptionElement.vue
+++ b/web/src/components/travel-authorizations/EstimatedCostDescriptionElement.vue
@@ -1,0 +1,56 @@
+<template>
+  <DescriptionElement
+    ref="descriptionElement"
+    label="Estimated Cost"
+    v-bind="$attrs"
+  >
+    <span class="d-flex">
+      {{ formatCurrency(estimatedCost) }}
+      <v-icon
+        right
+        small
+      >
+        mdi-help-circle-outline
+      </v-icon>
+    </span>
+
+    <v-tooltip
+      bottom
+      :activator="descriptionElement?.$el"
+    >
+      <span>This is computed with data from expense estimates.</span>
+    </v-tooltip>
+  </DescriptionElement>
+</template>
+
+<script setup>
+import { computed, ref } from "vue"
+import { sumBy } from "lodash"
+
+import { formatCurrency } from "@/utils/formatters"
+import { MAX_PER_PAGE } from "@/api/base-api"
+import useExpenses, { TYPES } from "@/use/use-expenses"
+
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
+
+const props = defineProps({
+  travelAuthorizationId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const expensesQuery = computed(() => ({
+  where: {
+    travelAuthorizationId: props.travelAuthorizationId,
+    type: TYPES.ESTIMATE,
+  },
+  perPage: MAX_PER_PAGE,
+}))
+const { expenses: estimates } = useExpenses(expensesQuery)
+
+const estimatedCost = computed(() => sumBy(estimates.value, "cost"))
+
+/** @type {import('vue').Ref<InstanceType<typeof DescriptionElement> | null>} */
+const descriptionElement = ref(null)
+</script>

--- a/web/src/components/travel-authorizations/PurposeCard.vue
+++ b/web/src/components/travel-authorizations/PurposeCard.vue
@@ -3,29 +3,23 @@
     <v-row>
       <v-col
         cols="12"
-        md="6"
+        md="3"
       >
-        <v-text-field
-          :value="purposeText"
-          :loading="isLoadingTravelPurposes"
+        <DescriptionElement
           label="Purpose"
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
-        />
+          vertical
+        >
+          <TravelPurposeChip :travel-purpose-id="travelAuthorization.purposeId" />
+        </DescriptionElement>
       </v-col>
       <v-col
         cols="12"
-        xl="6"
+        xl="9"
       >
-        <v-text-field
-          :value="travelAuthorization.eventName"
+        <DescriptionElement
           label="Name of meeting/conference, mission, trade fair or course"
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="travelAuthorization.eventName"
+          vertical
         />
       </v-col>
       <v-col
@@ -33,13 +27,10 @@
         md="3"
         xl="2"
       >
-        <!-- Depending on in territory flag we will load a different list of destinations -->
-        <v-checkbox
-          :value="travelAuthorization.allTravelWithinTerritory"
+        <DescriptionElement
           label="In Territory?"
-          dense
-          readonly
-          append-icon="mdi-lock"
+          :value="travelAuthorization.allTravelWithinTerritory ? 'Yes' : 'No'"
+          vertical
         />
       </v-col>
       <v-col
@@ -48,34 +39,22 @@
         lg="6"
         xl="4"
       >
-        <LocationReadonlyTextField
-          :location-id="finalDestination.locationId"
+        <LocationDescriptionElement
           label="Final Destination"
-          dense
-          outlined
+          :location-id="finalDestination.locationId"
+          vertical
         />
       </v-col>
     </v-row>
     <v-row>
-      <v-col>
-        <h3>Objectives</h3>
-        <ul>
-          <li>Purpose of attendance</li>
-          <li>Relevance and anticipated benefits to branch and Government of Yukon</li>
-        </ul>
-      </v-col>
+      <v-col> </v-col>
     </v-row>
     <v-row>
       <v-col>
-        <v-textarea
-          :value="travelAuthorization.benefits"
+        <TextareaDescriptionElement
           label="Objectives"
-          rows="10"
-          auto-grow
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="travelAuthorization.benefits"
+          vertical
         />
       </v-col>
     </v-row>
@@ -86,12 +65,13 @@
 import { computed, toRefs } from "vue"
 import { last } from "lodash"
 
-import { MAX_PER_PAGE } from "@/api/base-api"
 import useTravelAuthorization from "@/use/use-travel-authorization"
-import useTravelPurposes from "@/use/use-travel-purposes"
 
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
 import HeaderActionsCard from "@/components/common/HeaderActionsCard.vue"
-import LocationReadonlyTextField from "@/components/locations/LocationReadonlyTextField.vue"
+import TextareaDescriptionElement from "@/components/common/TextareaDescriptionElement.vue"
+import LocationDescriptionElement from "@/components/locations/LocationDescriptionElement.vue"
+import TravelPurposeChip from "@/components/travel-purposes/TravelPurposeChip.vue"
 
 const props = defineProps({
   travelAuthorizationId: {
@@ -103,24 +83,11 @@ const props = defineProps({
 const { travelAuthorizationId } = toRefs(props)
 const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)
 
-const travelPurposesQuery = computed(() => {
-  return {
-    perPage: MAX_PER_PAGE,
-  }
-})
-const { travelPurposes, isLoading: isLoadingTravelPurposes } =
-  useTravelPurposes(travelPurposesQuery)
-
 const finalDestination = computed(() => {
   return (
     last(travelAuthorization.value.stops) || {
       travelAuthorizationId: travelAuthorizationId.value,
     }
   )
-})
-
-const purposeText = computed(() => {
-  const purpose = travelPurposes.value.find((p) => p.id === travelAuthorization.value.purposeId)
-  return purpose?.purpose || ""
 })
 </script>

--- a/web/src/components/travel-authorizations/PurposeCard.vue
+++ b/web/src/components/travel-authorizations/PurposeCard.vue
@@ -1,100 +1,85 @@
 <template>
-  <v-card>
-    <v-card-title> Purpose </v-card-title>
-    <v-card-text>
-      <v-row>
-        <v-col
-          cols="12"
-          md="6"
-        >
-          <v-row dense>
-            <v-col
-              cols="12"
-              md="6"
-            >
-              <v-text-field
-                :value="purposeText"
-                :loading="isLoadingTravelPurposes"
-                label="Purpose"
-                dense
-                outlined
-                readonly
-                append-icon="mdi-lock"
-              ></v-text-field>
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                :value="travelAuthorization.eventName"
-                label="Name of meeting/conference, mission, trade fair or course"
-                dense
-                outlined
-                readonly
-                append-icon="mdi-lock"
-              ></v-text-field>
-            </v-col>
-            <v-col
-              cols="12"
-              md="3"
-            >
-              <!-- Depending on in territory flag we will load a different list of destinations -->
-              <v-checkbox
-                :value="travelAuthorization.allTravelWithinTerritory"
-                label="In Territory?"
-                dense
-                readonly
-                append-icon="mdi-lock"
-              >
-              </v-checkbox>
-            </v-col>
-            <v-col
-              cols="12"
-              md="9"
-            >
-              <LocationReadonlyTextField
-                :location-id="finalDestination.locationId"
-                label="Final Destination"
-                dense
-                outlined
-              />
-            </v-col>
-          </v-row>
-        </v-col>
-        <v-col
-          cols="12"
-          md="6"
-        >
-          <v-row>
-            <v-col
-              cols="12"
-              md="3"
-            >
-              <h3>Objectives</h3>
-              <ul>
-                <li>Purpose of attendance</li>
-                <li>Relevance and anticipated benefits to branch and Government of Yukon</li>
-              </ul>
-            </v-col>
-            <v-col
-              cols="12"
-              md="9"
-            >
-              <v-textarea
-                :value="travelAuthorization.benefits"
-                label="Objectives"
-                rows="10"
-                auto-grow
-                dense
-                outlined
-                readonly
-                append-icon="mdi-lock"
-              >
-              </v-textarea>
-            </v-col>
-          </v-row>
-        </v-col>
-      </v-row>
-    </v-card-text>
-  </v-card>
+  <HeaderActionsCard title="Purpose">
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <v-text-field
+          :value="purposeText"
+          :loading="isLoadingTravelPurposes"
+          label="Purpose"
+          dense
+          outlined
+          readonly
+          append-icon="mdi-lock"
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        xl="6"
+      >
+        <v-text-field
+          :value="travelAuthorization.eventName"
+          label="Name of meeting/conference, mission, trade fair or course"
+          dense
+          outlined
+          readonly
+          append-icon="mdi-lock"
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="3"
+        xl="2"
+      >
+        <!-- Depending on in territory flag we will load a different list of destinations -->
+        <v-checkbox
+          :value="travelAuthorization.allTravelWithinTerritory"
+          label="In Territory?"
+          dense
+          readonly
+          append-icon="mdi-lock"
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="9"
+        lg="6"
+        xl="4"
+      >
+        <LocationReadonlyTextField
+          :location-id="finalDestination.locationId"
+          label="Final Destination"
+          dense
+          outlined
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <h3>Objectives</h3>
+        <ul>
+          <li>Purpose of attendance</li>
+          <li>Relevance and anticipated benefits to branch and Government of Yukon</li>
+        </ul>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-textarea
+          :value="travelAuthorization.benefits"
+          label="Objectives"
+          rows="10"
+          auto-grow
+          dense
+          outlined
+          readonly
+          append-icon="mdi-lock"
+        />
+      </v-col>
+    </v-row>
+  </HeaderActionsCard>
 </template>
 
 <script setup>
@@ -105,6 +90,7 @@ import { MAX_PER_PAGE } from "@/api/base-api"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 import useTravelPurposes from "@/use/use-travel-purposes"
 
+import HeaderActionsCard from "@/components/common/HeaderActionsCard.vue"
 import LocationReadonlyTextField from "@/components/locations/LocationReadonlyTextField.vue"
 
 const props = defineProps({

--- a/web/src/components/travel-authorizations/PurposeEditFormCard.vue
+++ b/web/src/components/travel-authorizations/PurposeEditFormCard.vue
@@ -1,115 +1,99 @@
 <template>
-  <v-card>
-    <v-card-title> Purpose </v-card-title>
-    <v-card-text>
-      <v-form
-        ref="form"
-        lazy-validation
+  <HeaderActionsFormCard
+    ref="headerActionsFormCard"
+    title="Purpose"
+    lazy-validation
+  >
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
       >
-        <v-row>
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <v-row dense>
-              <v-col
-                cols="12"
-                md="6"
-              >
-                <TravelPurposeSelect
-                  v-model="travelAuthorization.purposeId"
-                  :rules="[required]"
-                  dense
-                  item-text="purpose"
-                  item-value="id"
-                  label="Purpose *"
-                  outlined
-                  required
-                  validate-on-blur
-                  @input="emit('update:travelPurposeId', $event)"
-                />
-              </v-col>
-              <v-col cols="12">
-                <v-text-field
-                  v-model="travelAuthorization.eventName"
-                  :rules="[required]"
-                  dense
-                  label="Name of meeting/conference, mission, trade fair or course *"
-                  outlined
-                  required
-                  validate-on-blur
-                ></v-text-field>
-              </v-col>
-              <v-col
-                cols="12"
-                md="3"
-              >
-                <!-- Depending on in territory flag we will load a different list of destinations -->
-                <v-checkbox
-                  v-model="travelAuthorization.allTravelWithinTerritory"
-                  label="In Territory?"
-                  dense
-                >
-                </v-checkbox>
-              </v-col>
-              <v-col
-                cols="12"
-                md="9"
-              >
-                <LocationsAutocomplete
-                  :value="lastStop.locationId"
-                  :in-territory="travelAuthorization.allTravelWithinTerritory"
-                  :rules="[required]"
-                  clearable
-                  dense
-                  label="Final Destination *"
-                  outlined
-                  persistent-hint
-                  required
-                  validate-on-blur
-                  @input="updateLastStopLocationId"
-                />
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <v-row>
-              <v-col
-                cols="12"
-                md="3"
-              >
-                <h3>Objectives</h3>
-                <ul>
-                  <li>Purpose of attendance</li>
-                  <li>Relevance and anticipated benefits to branch and Government of Yukon</li>
-                </ul>
-              </v-col>
-              <v-col
-                cols="12"
-                md="9"
-              >
-                <v-textarea
-                  v-model="travelAuthorization.benefits"
-                  :rules="[required]"
-                  auto-grow
-                  dense
-                  label="Objectives *"
-                  outlined
-                  required
-                  rows="10"
-                  validate-on-blur
-                >
-                </v-textarea>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
-      </v-form>
-    </v-card-text>
-  </v-card>
+        <TravelPurposeSelect
+          v-model="travelAuthorization.purposeId"
+          :rules="[required]"
+          dense
+          item-text="purpose"
+          item-value="id"
+          label="Purpose *"
+          outlined
+          required
+          validate-on-blur
+          @input="emit('update:travelPurposeId', $event)"
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        xl="6"
+      >
+        <v-text-field
+          v-model="travelAuthorization.eventName"
+          :rules="[required]"
+          dense
+          label="Name of meeting/conference, mission, trade fair or course *"
+          outlined
+          required
+          validate-on-blur
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="3"
+        xl="2"
+      >
+        <!-- Depending on in territory flag we will load a different list of destinations -->
+        <v-checkbox
+          v-model="travelAuthorization.allTravelWithinTerritory"
+          label="In Territory?"
+          dense
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="9"
+        lg="6"
+        xl="4"
+      >
+        <LocationsAutocomplete
+          :value="lastStop.locationId"
+          :in-territory="travelAuthorization.allTravelWithinTerritory"
+          :rules="[required]"
+          clearable
+          dense
+          label="Final Destination *"
+          outlined
+          persistent-hint
+          required
+          validate-on-blur
+          @input="updateLastStopLocationId"
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <h3>Objectives</h3>
+        <ul>
+          <li>Purpose of attendance</li>
+          <li>Relevance and anticipated benefits to branch and Government of Yukon</li>
+        </ul>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-textarea
+          v-model="travelAuthorization.benefits"
+          :rules="[required]"
+          auto-grow
+          dense
+          label="Objectives *"
+          outlined
+          required
+          rows="10"
+          validate-on-blur
+        />
+      </v-col>
+    </v-row>
+  </HeaderActionsFormCard>
 </template>
 
 <script setup>
@@ -118,6 +102,7 @@ import { ref, toRefs } from "vue"
 import { required } from "@/utils/validators"
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
+import HeaderActionsFormCard from "@/components/common/HeaderActionsFormCard.vue"
 import LocationsAutocomplete from "@/components/locations/LocationsAutocomplete.vue"
 import TravelPurposeSelect from "@/components/travel-purposes/TravelPurposeSelect.vue"
 
@@ -145,10 +130,10 @@ function updateLastStopLocationId(locationId) {
   emit("update:finalDestinationLocationId", locationId)
 }
 
-const form = ref(null)
+const headerActionsFormCard = ref(null)
 
 defineExpose({
   save,
-  validate: () => form.value?.validate(),
+  validate: () => headerActionsFormCard.value?.validate(),
 })
 </script>

--- a/web/src/components/travel-authorizations/TravelAuthorizationTripTypeChip.vue
+++ b/web/src/components/travel-authorizations/TravelAuthorizationTripTypeChip.vue
@@ -1,0 +1,30 @@
+<template>
+  <!-- TODO: add icon for each trip type? -->
+  <v-chip
+    outlined
+    v-bind="$attrs"
+  >
+    {{ formattedStatus }}
+  </v-chip>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+import { useI18n } from "@/plugins/vue-i18n-plugin"
+
+const props = defineProps({
+  value: {
+    type: String,
+    required: true,
+  },
+})
+
+const { t } = useI18n()
+
+const formattedStatus = computed(() => {
+  return t(`travel_authorization.trip_type.${props.value}`, {
+    $default: props.value,
+  })
+})
+</script>

--- a/web/src/components/travel-authorizations/details-card/MultiDestinationStopsSection.vue
+++ b/web/src/components/travel-authorizations/details-card/MultiDestinationStopsSection.vue
@@ -1,248 +1,168 @@
 <template>
+  <!-- TODO: deuglify this UI -->
   <div>
     <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="6"
       >
-        <LocationReadonlyTextField
-          :location-id="stop1.locationId"
-          label="From"
-          dense
-          outlined
-          persistent-hint
-        />
+        <DescriptionElement
+          label="1: From / To"
+          vertical
+        >
+          <LocationChip :location-id="firstStop.locationId" />
+          -
+          <LocationChip :location-id="secondStop.locationId" />
+        </DescriptionElement>
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <LocationReadonlyTextField
-          :location-id="stop2.locationId"
-          label="To"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="stop1.departureDate"
-          label="Date"
-          prepend-icon="mdi-calendar"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="stop1.departureTime"
-          label="Time"
-          prepend-icon="mdi-clock"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-text-field
-          :value="stop1.transport"
-          label="Travel Method"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
-        />
-        <v-text-field
-          :value="stop1.accommodationType"
-          label="Type of Accommodation"
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
+        <DescriptionElement
+          label="Date / Time (24h)"
+          :value="firstStop.departureDate + ' at ' + firstStop.departureTime"
+          vertical
         />
       </v-col>
     </v-row>
     <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <LocationReadonlyTextField
-          :location-id="stop2.locationId"
-          label="To"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <LocationReadonlyTextField
-          :location-id="stop3.locationId"
-          label="From"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="stop2.departureDate"
-          label="Date"
-          prepend-icon="mdi-calendar"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="stop2.departureTime"
-          label="Time (24h)"
-          prepend-icon="mdi-clock"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-text-field
-          :value="stop2.transport"
+        <DescriptionElement
           label="Travel Method"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="firstStop.transport"
+          vertical
         />
-        <v-text-field
-          :value="stop2.accommodationType"
+      </v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
           label="Type of Accommodation"
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="firstStop.accommodationType"
+          vertical
+        />
+      </v-col>
+    </v-row>
+    <v-divider class="my-3" />
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
+          label="2: From / To"
+          vertical
+        >
+          <LocationChip :location-id="secondStop.locationId" />
+          -
+          <LocationChip :location-id="thirdStop.locationId" />
+        </DescriptionElement>
+      </v-col>
+      <v-col
+        cols="12"
+        md="3"
+      >
+        <DescriptionElement
+          label="Date / Time (24h)"
+          :value="secondStop.departureDate + ' at ' + secondStop.departureTime"
+          vertical
         />
       </v-col>
     </v-row>
     <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <LocationReadonlyTextField
-          :location-id="stop3.locationId"
-          label="From"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <LocationReadonlyTextField
-          :location-id="stop4.locationId"
-          label="To"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="stop3.departureDate"
-          text="Date"
-          prepend-icon="mdi-calendar"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="stop3.departureTime"
-          label="Time (24h)"
-          prepend-icon="mdi-clock"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-text-field
-          :value="stop3.transport"
+        <DescriptionElement
           label="Travel Method"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="secondStop.transport"
+          vertical
         />
-        <v-text-field
-          :value="stop3.accommodationType"
+      </v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
           label="Type of Accommodation"
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="secondStop.accommodationType"
+          vertical
         />
       </v-col>
     </v-row>
+
+    <template v-if="stops.length > 3">
+      <template v-for="(_, index) in stops.slice(0, -3)">
+        <v-divider
+          :key="`divider-${index}`"
+          class="my-3"
+        />
+        <v-row :key="`row1-${index}`">
+          <v-col
+            cols="12"
+            md="6"
+          >
+            <DescriptionElement
+              :label="index + 3 + ': From / To'"
+              vertical
+            >
+              <LocationChip :location-id="stops[index + 2].locationId" />
+              -
+              <LocationChip :location-id="stops[index + 3].locationId" />
+            </DescriptionElement>
+          </v-col>
+          <v-col
+            cols="12"
+            md="3"
+          >
+            <DescriptionElement
+              label="Date / Time (24h)"
+              :value="stops[index + 2].departureDate + ' at ' + stops[index + 2].departureTime"
+              vertical
+            />
+          </v-col>
+        </v-row>
+        <v-row :key="`row2-${index}`">
+          <v-col
+            cols="12"
+            md="3"
+          >
+            <DescriptionElement
+              label="Travel Method"
+              :value="stops[index + 2].transport"
+              vertical
+            />
+          </v-col>
+          <v-col
+            cols="12"
+            md="6"
+          >
+            <DescriptionElement
+              label="Type of Accommodation"
+              :value="stops[index + 2].accommodationType || 'N/A'"
+              vertical
+            />
+          </v-col>
+        </v-row>
+      </template>
+    </template>
   </div>
 </template>
 
 <script setup>
 import { toRefs, computed } from "vue"
+import { first, nth } from "lodash"
 
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
-import LocationReadonlyTextField from "@/components/locations/LocationReadonlyTextField.vue"
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
+import LocationChip from "@/components/locations/LocationChip.vue"
 
 const props = defineProps({
   travelAuthorizationId: {
@@ -254,8 +174,8 @@ const props = defineProps({
 const { travelAuthorizationId } = toRefs(props)
 const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)
 
-const stop1 = computed(() => travelAuthorization.value.stops[0] || {})
-const stop2 = computed(() => travelAuthorization.value.stops[1] || {})
-const stop3 = computed(() => travelAuthorization.value.stops[2] || {})
-const stop4 = computed(() => travelAuthorization.value.stops[3] || {})
+const stops = computed(() => travelAuthorization.value.stops || [])
+const firstStop = computed(() => first(stops.value) || {})
+const secondStop = computed(() => nth(stops.value, 1) || {})
+const thirdStop = computed(() => nth(stops.value, 2) || {})
 </script>

--- a/web/src/components/travel-authorizations/details-card/MultiDestinationStopsSection.vue
+++ b/web/src/components/travel-authorizations/details-card/MultiDestinationStopsSection.vue
@@ -1,163 +1,65 @@
 <template>
   <!-- TODO: deuglify this UI -->
   <div>
-    <v-row>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <DescriptionElement
-          label="1: From / To"
-          vertical
+    <template v-for="(_, index) in stops.slice(0, -1)">
+      <v-divider
+        v-if="index > 0"
+        :key="`divider-${index}`"
+        class="my-3"
+      />
+      <v-row :key="`row1-${index}`">
+        <v-col
+          cols="12"
+          md="6"
         >
-          <LocationChip :location-id="firstStop.locationId" />
-          -
-          <LocationChip :location-id="secondStop.locationId" />
-        </DescriptionElement>
-      </v-col>
-      <v-col
-        cols="12"
-        md="3"
-      >
-        <DescriptionElement
-          label="Date / Time (24h)"
-          :value="firstStop.departureDate + ' at ' + firstStop.departureTime"
-          vertical
-        />
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-col
-        cols="12"
-        md="3"
-      >
-        <DescriptionElement
-          label="Travel Method"
-          :value="firstStop.transport"
-          vertical
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <DescriptionElement
-          label="Type of Accommodation"
-          :value="firstStop.accommodationType"
-          vertical
-        />
-      </v-col>
-    </v-row>
-    <v-divider class="my-3" />
-    <v-row>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <DescriptionElement
-          label="2: From / To"
-          vertical
+          <DescriptionElement
+            :label="`${index + 1}: From / To`"
+            vertical
+          >
+            <LocationChip :location-id="stops[index].locationId" />
+            -
+            <LocationChip :location-id="stops[index + 1].locationId" />
+          </DescriptionElement>
+        </v-col>
+        <v-col
+          cols="12"
+          md="3"
         >
-          <LocationChip :location-id="secondStop.locationId" />
-          -
-          <LocationChip :location-id="thirdStop.locationId" />
-        </DescriptionElement>
-      </v-col>
-      <v-col
-        cols="12"
-        md="3"
-      >
-        <DescriptionElement
-          label="Date / Time (24h)"
-          :value="secondStop.departureDate + ' at ' + secondStop.departureTime"
-          vertical
-        />
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-col
-        cols="12"
-        md="3"
-      >
-        <DescriptionElement
-          label="Travel Method"
-          :value="secondStop.transport"
-          vertical
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <DescriptionElement
-          label="Type of Accommodation"
-          :value="secondStop.accommodationType"
-          vertical
-        />
-      </v-col>
-    </v-row>
-
-    <template v-if="stops.length > 3">
-      <template v-for="(_, index) in stops.slice(0, -3)">
-        <v-divider
-          :key="`divider-${index}`"
-          class="my-3"
-        />
-        <v-row :key="`row1-${index}`">
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <DescriptionElement
-              :label="index + 3 + ': From / To'"
-              vertical
-            >
-              <LocationChip :location-id="stops[index + 2].locationId" />
-              -
-              <LocationChip :location-id="stops[index + 3].locationId" />
-            </DescriptionElement>
-          </v-col>
-          <v-col
-            cols="12"
-            md="3"
-          >
-            <DescriptionElement
-              label="Date / Time (24h)"
-              :value="stops[index + 2].departureDate + ' at ' + stops[index + 2].departureTime"
-              vertical
-            />
-          </v-col>
-        </v-row>
-        <v-row :key="`row2-${index}`">
-          <v-col
-            cols="12"
-            md="3"
-          >
-            <DescriptionElement
-              label="Travel Method"
-              :value="stops[index + 2].transport"
-              vertical
-            />
-          </v-col>
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <DescriptionElement
-              label="Type of Accommodation"
-              :value="stops[index + 2].accommodationType || 'N/A'"
-              vertical
-            />
-          </v-col>
-        </v-row>
-      </template>
+          <DescriptionElement
+            label="Date / Time (24h)"
+            :value="stops[index].departureDate + ' at ' + stops[index].departureTime"
+            vertical
+          />
+        </v-col>
+      </v-row>
+      <v-row :key="`row2-${index}`">
+        <v-col
+          cols="12"
+          md="3"
+        >
+          <DescriptionElement
+            label="Travel Method"
+            :value="stops[index].transport"
+            vertical
+          />
+        </v-col>
+        <v-col
+          cols="12"
+          md="6"
+        >
+          <DescriptionElement
+            label="Type of Accommodation"
+            :value="stops[index].accommodationType || 'N/A'"
+            vertical
+          />
+        </v-col>
+      </v-row>
     </template>
   </div>
 </template>
 
 <script setup>
 import { toRefs, computed } from "vue"
-import { first, nth } from "lodash"
 
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
@@ -175,7 +77,4 @@ const { travelAuthorizationId } = toRefs(props)
 const { travelAuthorization } = useTravelAuthorization(travelAuthorizationId)
 
 const stops = computed(() => travelAuthorization.value.stops || [])
-const firstStop = computed(() => first(stops.value) || {})
-const secondStop = computed(() => nth(stops.value, 1) || {})
-const thirdStop = computed(() => nth(stops.value, 2) || {})
 </script>

--- a/web/src/components/travel-authorizations/details-card/OneWayStopsSection.vue
+++ b/web/src/components/travel-authorizations/details-card/OneWayStopsSection.vue
@@ -1,81 +1,50 @@
 <template>
+  <!-- TODO: deuglify this UI -->
   <div>
     <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="6"
       >
-        <LocationReadonlyTextField
-          :location-id="originStop.locationId"
-          label="From"
-          dense
-          outlined
-          persistent-hint
-        />
+        <DescriptionElement
+          label="From / To"
+          vertical
+        >
+          <LocationChip :location-id="originStop.locationId" />
+          -
+          <LocationChip :location-id="destinationStop.locationId" />
+        </DescriptionElement>
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <LocationReadonlyTextField
-          :location-id="destinationStop.locationId"
-          label="To"
-          dense
-          outlined
-          persistent-hint
+        <DescriptionElement
+          label="Date / Time (24h)"
+          :value="originStop.departureDate + ' at ' + originStop.departureTime"
+          vertical
         />
       </v-col>
+    </v-row>
+    <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <v-text-field
-          :value="originStop.departureDate"
-          label="Date"
-          prepend-icon="mdi-calendar"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="originStop.departureTime"
-          label="Time (24h)"
-          prepend-icon="mdi-clock"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-text-field
-          :value="originStop.transport"
+        <DescriptionElement
           label="Travel Method"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="originStop.transport"
+          vertical
         />
-        <v-text-field
-          :value="originStop.accommodationType"
+      </v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
           label="Type of Accommodation"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="originStop.accommodationType"
+          vertical
         />
       </v-col>
     </v-row>
@@ -87,7 +56,8 @@ import { computed, toRefs } from "vue"
 
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
-import LocationReadonlyTextField from "@/components/locations/LocationReadonlyTextField.vue"
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
+import LocationChip from "@/components/locations/LocationChip.vue"
 
 const props = defineProps({
   travelAuthorizationId: {

--- a/web/src/components/travel-authorizations/details-card/OneWayStopsSection.vue
+++ b/web/src/components/travel-authorizations/details-card/OneWayStopsSection.vue
@@ -7,7 +7,7 @@
         md="6"
       >
         <DescriptionElement
-          label="From / To"
+          label="1: From / To"
           vertical
         >
           <LocationChip :location-id="originStop.locationId" />

--- a/web/src/components/travel-authorizations/details-card/RoundTripStopsSection.vue
+++ b/web/src/components/travel-authorizations/details-card/RoundTripStopsSection.vue
@@ -1,161 +1,98 @@
 <template>
+  <!-- TODO: deuglify this UI -->
   <div>
     <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="6"
       >
-        <LocationReadonlyTextField
-          :location-id="originStop.locationId"
-          label="From"
-          dense
-          outlined
-          persistent-hint
-        />
+        <DescriptionElement
+          label="From / To"
+          vertical
+        >
+          <LocationChip :location-id="originStop.locationId" />
+          -
+          <LocationChip :location-id="destinationStop.locationId" />
+        </DescriptionElement>
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <LocationReadonlyTextField
-          :location-id="destinationStop.locationId"
-          label="To"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="originStop.departureDate"
-          label="Date"
-          prepend-icon="mdi-calendar"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="originStop.departureTime"
-          label="Time (24h)"
-          prepend-icon="mdi-clock"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-text-field
-          :value="originStop.transport"
-          label="Travel Method"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
-        />
-        <v-text-field
-          :value="originStop.accommodationType"
-          label="Type of Accommodation"
-          dense
-          outlined
-          readonly
-          append-icon="mdi-lock"
+        <DescriptionElement
+          label="Date / Time (24h)"
+          :value="originStop.departureDate + ' at ' + originStop.departureTime"
+          vertical
         />
       </v-col>
     </v-row>
     <v-row>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
-        <LocationReadonlyTextField
-          :location-id="destinationStop.locationId"
-          label="To"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <LocationReadonlyTextField
-          :location-id="originStop.locationId"
-          label="From"
-          dense
-          outlined
-          persistent-hint
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="destinationStop.departureDate"
-          label="Date"
-          prepend-icon="mdi-calendar"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="2"
-      >
-        <v-text-field
-          :value="destinationStop.departureTime"
-          label="Time (24h)"
-          prepend-icon="mdi-clock"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
-        />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-text-field
-          :value="destinationStop.transport"
+        <DescriptionElement
           label="Travel Method"
-          dense
-          persistent-hint
-          outlined
-          readonly
-          append-icon="mdi-lock"
+          :value="originStop.transport"
+          vertical
         />
-        <v-text-field
-          :value="destinationStop.accommodationType"
+      </v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
           label="Type of Accommodation"
-          hint="Optional, set only if neccessary"
-          placeholder="N/A"
-          dense
-          outlined
-          persistent-hint
-          readonly
-          append-icon="mdi-lock"
+          :value="originStop.accommodationType"
+          vertical
+        />
+      </v-col>
+    </v-row>
+    <v-divider class="my-3" />
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
+          label="From / To"
+          vertical
+        >
+          <LocationChip :location-id="destinationStop.locationId" />
+          -
+          <LocationChip :location-id="originStop.locationId" />
+        </DescriptionElement>
+      </v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
+          label="Date / Time (24h)"
+          :value="destinationStop.departureDate + ' at ' + destinationStop.departureTime"
+          vertical
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col
+        cols="12"
+        md="3"
+      >
+        <DescriptionElement
+          label="Travel Method"
+          :value="destinationStop.transport"
+          vertical
+        />
+      </v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <DescriptionElement
+          label="Type of Accommodation"
+          :value="destinationStop.accommodationType || 'N/A'"
+          vertical
         />
       </v-col>
     </v-row>
@@ -167,7 +104,8 @@ import { computed, toRefs } from "vue"
 
 import useTravelAuthorization from "@/use/use-travel-authorization"
 
-import LocationReadonlyTextField from "@/components/locations/LocationReadonlyTextField.vue"
+import LocationChip from "@/components/locations/LocationChip.vue"
+import DescriptionElement from "@/components/common/DescriptionElement.vue"
 
 const props = defineProps({
   travelAuthorizationId: {

--- a/web/src/components/travel-authorizations/details-card/RoundTripStopsSection.vue
+++ b/web/src/components/travel-authorizations/details-card/RoundTripStopsSection.vue
@@ -7,7 +7,7 @@
         md="6"
       >
         <DescriptionElement
-          label="From / To"
+          label="1: From / To"
           vertical
         >
           <LocationChip :location-id="originStop.locationId" />
@@ -55,7 +55,7 @@
         md="6"
       >
         <DescriptionElement
-          label="From / To"
+          label="2: From / To"
           vertical
         >
           <LocationChip :location-id="destinationStop.locationId" />

--- a/web/src/components/travel-purposes/TravelPurposeChip.vue
+++ b/web/src/components/travel-purposes/TravelPurposeChip.vue
@@ -4,7 +4,6 @@
       v-if="isNil(travelPurpose)"
       size="20"
       width="2"
-      color="white"
       indeterminate
     />
     <template v-else>

--- a/web/src/components/users/UserChip.vue
+++ b/web/src/components/users/UserChip.vue
@@ -10,7 +10,6 @@
       v-if="isLoading"
       size="20"
       width="2"
-      color="white"
       indeterminate
     ></v-progress-circular>
     <template v-else>

--- a/web/src/use/use-travel-authorization-pre-approval-profile.js
+++ b/web/src/use/use-travel-authorization-pre-approval-profile.js
@@ -8,18 +8,18 @@ import travelAuthorizationPreApprovalProfilesApi from "@/api/travel-authorizatio
  * @typedef {import('vue').Ref<T>} Ref
  */
 /** @typedef {import('@/api/base-api.js').Policy} Policy */
-/** @typedef {import('@/api/travel-authorization-pre-approval-profiles-api.js').TravelAuthorizationPreApprovalProfile} TravelAuthorizationPreApprovalProfile */
+/** @typedef {import('@/api/travel-authorization-pre-approval-profiles-api.js').TravelAuthorizationPreApprovalProfileAsShow} TravelAuthorizationPreApprovalProfileAsShow */
 
 /**
  * @callback UseTravelAuthorizationPreApprovalProfile
  * @param {Ref<number>} id
  * @returns {{
- *   travelAuthorizationPreApprovalProfile: Ref<TravelAuthorizationPreApprovalProfile | null | undefined>,
+ *   travelAuthorizationPreApprovalProfile: Ref<TravelAuthorizationPreApprovalProfileAsShow | null | undefined>,
  *   policy: Ref<Policy | null>,
  *   isLoading: Ref<boolean>,
  *   isErrored: Ref<boolean>,
- *   fetch: () => Promise<TravelAuthorizationPreApprovalProfile>,
- *   refresh: () => Promise<TravelAuthorizationPreApprovalProfile>,
+ *   fetch: () => Promise<TravelAuthorizationPreApprovalProfileAsShow>,
+ *   refresh: () => Promise<TravelAuthorizationPreApprovalProfileAsShow>,
  * }}
  */
 


### PR DESCRIPTION
Fixes https://github.com/ytgov/travel-authorization/issues/115

Relates to:

- https://governmentofyukon.slack.com/archives/D05SLKE8XPV/p1744305008833459

# Context

See https://governmentofyukon.slack.com/archives/D05SLKE8XPV/p1744305008833459

> Diedre Davidson
> Yesterday at 10:10 AM
> I think that we need to include further descriptors to help people make a selection. It would not be abnormal for people in branches to go to many conferences in vancouver. We could add month? Or maybe on select it writes the reason to the screen.

> Marlen Brunner
> Yeah, I totally think it needs more info.
> Do you want me to build out something like what WRAP is doing? https://wrap.service.yukon.ca/workflows/2025-KHT-5B2/act/players?page=1&perPage=10
> See Players tab.
> There is a fancier "list item", and there is a fancy "chip" with expandable info once selected.

> Diedre Davidson
> That looks cool if it is easy enough to implement.
>
> Marlen Brunner
> Its not too hard, with most of the time lost due to having to backport from Vuetify 3 to Vuetify 2.
> I also need to know what should go where from a UI perspective, if you have an opinion on that? Otherwise it'll be down to ChatGPT/Grok/Claude :joy:.

> Diedre Davidson
> maybe just right above the submit to line.

> Marlen Brunner
> Does this format work for you?
> TravelAuthorizationPreApprovalProfileListItem.vue
> Title is: branch - profileName
> Subtitle is: location - purpose - dateInfo
>
> Marlen Brunner
> Chip displays same info as list item but is highly customizable as well.
> TravelAuthorizationPreApprovalProfileChip.vue

# Implementation

1. Using patterns from [WRAP project](https://github.com/icefoganalytics/wrap) build a custom autocomplete component for travel authorization pre-approval selection.
2. Make the travel request wizard -> purpose step look better on medium size screens
3. Make the travel request wizard -> submit to supervisor step look better on medium size screens
4. Make the travel request wizard -> review submission to supervisor step look better on medium size screens

# Screenshots

My Travel Request Wizard -> Submit to Supervisor Step -> Pre-Approval Profile Selector
http://localhost:8080/my-travel-requests/79/wizard/submit-to-supervisor
![image](https://github.com/user-attachments/assets/a7373416-ba0f-4167-a9ae-aec68876e76b)

My Travel Request Wizard -> Submit to Supervisor Step -> Pre-Approval Profile Selector -> Chip menu
http://localhost:8080/my-travel-requests/79/wizard/submit-to-supervisor
![image](https://github.com/user-attachments/assets/8508cc05-d898-402b-a808-6d8808b8b189)

My Travel Request Wizard -> Purpose Step (better on medium size screens)
http://localhost:8080/my-travel-requests/79/wizard/edit-purpose-details
![image](https://github.com/user-attachments/assets/d3c70f1f-9e0e-4716-9823-33ae04e9732e)

My Travel Request Wizard -> Submit to Supervisor Step (better on medium size screens)
http://localhost:8080/my-travel-requests/79/wizard/submit-to-supervisor
![image](https://github.com/user-attachments/assets/0e328ee7-53d3-490c-a74c-af5e0240b122)

My Travel Request Wizard -> Review Submission to Supervisor Step (better on medium size screens)
http://localhost:8080/my-travel-requests/79/wizard/review-trip-details
![image](https://github.com/user-attachments/assets/5fc722cd-61f1-4445-b192-dffef3921e19)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Select "My Travel Requests" from the left side nav.
5. Create a new travel request.
6. Note that purpose form has been updated to display better on medium size screens.
7. Fill in and continue.
8. On the next step select round trip type, fill in all required fields, and continue.
9. Prefill your estimates and continue.
10. Note that the submit to supervisor form has been updated to display better on medium size screens.
    Note that the "Purpose" and "Details" sections now have a better readonly mode.
11. Note the enhancements to the "Pre-approved travel for (if applicable)" field.
    It now has a custom list and chip component.
    The chip component is clickable and reveals more details.
12. Submit to your supervisor.
13. Note that the post submission review step has been updated to display better on medium size screens.
14. Revert to draft, and go back to the trip details step. Select a one way trip type.
15. Complete process again, and check that one-way trip's display has been updated.
16. Repeat for multi-destination trip type.
