### PR TITLE
Issue 270: Expense: Need To Capture Actual Travel Dates and Times

### DIFF
--- a/api/src/db/migrations/20250428210144_add-is-actual-flag-to-stops-table.ts
+++ b/api/src/db/migrations/20250428210144_add-is-actual-flag-to-stops-table.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("stops", (table) => {
+    table.boolean("is_actual").defaultTo(false).notNullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("stops", (table) => {
+    table.dropColumn("is_actual")
+  })
+}

--- a/api/src/db/migrations/20250428211721_add-is-actual-flag-to-travel-segments-table.ts
+++ b/api/src/db/migrations/20250428211721_add-is-actual-flag-to-travel-segments-table.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex"
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("travel_segments", (table) => {
+    table.boolean("is_actual").defaultTo(false).notNullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("travel_segments", (table) => {
+    table.dropColumn("is_actual")
+  })
+}

--- a/api/src/db/seeds/development/040_travel-authorization-seeds.ts
+++ b/api/src/db/seeds/development/040_travel-authorization-seeds.ts
@@ -237,6 +237,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2023-05-12"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[0].id,
@@ -244,6 +245,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2019-05-15"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[1].id,
@@ -251,6 +253,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2023-05-12"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[1].id,
@@ -258,6 +261,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2019-05-15"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[2].id,
@@ -265,6 +269,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2023-05-12"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[2].id,
@@ -272,6 +277,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2019-05-15"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
   ]
   for (const stopAttributes of stopsAttributes) {

--- a/api/src/db/seeds/production/040_travel-authorization-seeds.ts
+++ b/api/src/db/seeds/production/040_travel-authorization-seeds.ts
@@ -237,6 +237,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2023-05-12"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[0].id,
@@ -244,6 +245,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2019-05-15"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[1].id,
@@ -251,6 +253,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2023-05-12"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[1].id,
@@ -258,6 +261,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2019-05-15"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[2].id,
@@ -265,6 +269,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2023-05-12"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
     {
       travelAuthorizationId: travelAuthorizations[2].id,
@@ -272,6 +277,7 @@ export async function seed(_knex: Knex): Promise<void> {
       departureDate: new Date("2019-05-15"),
       departureTime: "12:00:00",
       transport: "Plane",
+      isActual: false,
     },
   ]
   for (const stopAttributes of stopsAttributes) {

--- a/api/src/models/stop.ts
+++ b/api/src/models/stop.ts
@@ -15,9 +15,9 @@ import {
 
 import sequelize from "@/db/db-client"
 
-import Location from "./location"
-import TravelAuthorization from "./travel-authorization"
-import TravelSegment from "./travel-segment"
+import Location from "@/models/location"
+import TravelAuthorization from "@/models/travel-authorization"
+import TravelSegment from "@/models/travel-segment"
 
 /*
 DEPRECATED: Whenever you use this model, try and figure out how to migrate
@@ -38,6 +38,7 @@ export class Stop extends Model<InferAttributes<Stop>, InferCreationAttributes<S
   declare departureTime: string | null
   declare transport: string | null
   declare accommodationType: string | null
+  declare isActual: CreationOptional<boolean>
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
 
@@ -123,6 +124,11 @@ Stop.init(
     accommodationType: {
       type: DataTypes.STRING(255),
       allowNull: true,
+    },
+    isActual: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     createdAt: {
       type: DataTypes.DATE,

--- a/api/src/models/travel-segment.ts
+++ b/api/src/models/travel-segment.ts
@@ -65,6 +65,7 @@ export class TravelSegment extends Model<
   declare modeOfTransportOther: string | null
   declare accommodationType: string | null
   declare accommodationTypeOther: string | null
+  declare isActual: CreationOptional<boolean>
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
 
@@ -135,6 +136,10 @@ export class TravelSegment extends Model<
     departureStop: Stop
     arrivalStop: Stop
   }) {
+    if (departureStop.isActual !== arrivalStop.isActual) {
+      throw new Error("Departure and arrival stops must have the same isActual value")
+    }
+
     if (isNil(departureStop.transport)) {
       throw new Error(`Missing transport on Stop#${departureStop.id}`)
     }
@@ -166,6 +171,7 @@ export class TravelSegment extends Model<
       modeOfTransportOther,
       accommodationType,
       accommodationTypeOther,
+      isActual: departureStop.isActual,
     })
   }
 
@@ -257,6 +263,11 @@ TravelSegment.init(
           }
         },
       },
+    },
+    isActual: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     createdAt: {
       type: DataTypes.DATE,

--- a/api/src/services/qa/scenarios/my-travel-requests-service.ts
+++ b/api/src/services/qa/scenarios/my-travel-requests-service.ts
@@ -50,6 +50,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.AIRCRAFT,
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization1.id,
@@ -57,6 +58,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.AIRCRAFT,
+        isActual: false,
       },
     })
     const [_lastStop] = await Stop.findOrCreate({
@@ -66,6 +68,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.AIRCRAFT,
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization1.id,
@@ -73,6 +76,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.AIRCRAFT,
+        isActual: false,
       },
     })
 
@@ -103,12 +107,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: vancouverLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization2.id,
         locationId: vancouverLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
     const [_lastStop2] = await Stop.findOrCreate({
@@ -117,12 +123,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: vancouverLocation.id,
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization2.id,
         locationId: vancouverLocation.id,
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
 
@@ -157,12 +165,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: edmontonLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization3.id,
         locationId: edmontonLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
     const [_lastStop3] = await Stop.findOrCreate({
@@ -171,12 +181,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: edmontonLocation.id,
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization3.id,
         locationId: edmontonLocation.id,
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
 
@@ -212,12 +224,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: calgaryLocation.id,
         departureDate: lastWeek.clone().subtract(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization4.id,
         locationId: calgaryLocation.id,
         departureDate: lastWeek.clone().subtract(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
     const [_lastStop4] = await Stop.findOrCreate({
@@ -226,12 +240,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: calgaryLocation.id,
         departureDate: lastWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization4.id,
         locationId: calgaryLocation.id,
         departureDate: lastWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
 
@@ -262,12 +278,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: calgaryLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization5.id,
         locationId: calgaryLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
     const [_lastStop5] = await Stop.findOrCreate({
@@ -276,12 +294,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: calgaryLocation.id,
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization5.id,
         locationId: calgaryLocation.id,
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
 
@@ -350,12 +370,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: calgaryLocation.id,
         departureDate: lastWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization6.id,
         locationId: calgaryLocation.id,
         departureDate: lastWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
     const [_lastStop6] = await Stop.findOrCreate({
@@ -364,12 +386,14 @@ export class MyTravelRequestsService extends BaseService {
         locationId: calgaryLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization6.id,
         locationId: calgaryLocation.id,
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
+        isActual: false,
       },
     })
 
@@ -405,6 +429,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.POOL_VEHICLE,
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization7.id,
@@ -412,6 +437,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.POOL_VEHICLE,
+        isActual: false,
       },
     })
     const [_lastStop7] = await Stop.findOrCreate({
@@ -421,6 +447,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.POOL_VEHICLE,
+        isActual: false,
       },
       defaults: {
         travelAuthorizationId: travelAuthorization7.id,
@@ -428,6 +455,7 @@ export class MyTravelRequestsService extends BaseService {
         departureDate: nextWeek.clone().add(2, "days").toDate(),
         departureTime: "00:00:00",
         transport: Stop.TravelMethods.POOL_VEHICLE,
+        isActual: false,
       },
     })
   }

--- a/api/tests/factories/stop-factory.ts
+++ b/api/tests/factories/stop-factory.ts
@@ -23,6 +23,7 @@ export const stopFactory = Factory.define<Stop>(({ associations, onCreate }) => 
     departureTime: anytime(),
     transport: faker.helpers.arrayElement(Object.values(Stop.TravelMethods)),
     accommodationType: faker.helpers.arrayElement(Object.values(Stop.AccommodationTypes)),
+    isActual: false,
   })
   stop.travelAuthorization = associations.travelAuthorization ?? travelAuthorizationFactory.build()
   stop.location = associations.location ?? locationFactory.build()

--- a/api/tests/factories/travel-segment-factory.ts
+++ b/api/tests/factories/travel-segment-factory.ts
@@ -45,6 +45,7 @@ export const travelSegmentFactory = Factory.define<TravelSegment, TransientParam
       modeOfTransport,
       modeOfTransportOther:
         modeOfTransport === TravelSegment.TravelMethods.OTHER ? faker.hacker.ingverb() : null,
+      isActual: false,
     })
 
     travelSegment.travelAuthorization =


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/270

Relates to:
- [Modeling, Expense Actual Travel Start Dates and Times, 2025-04-15](https://docs.google.com/document/d/1v3HUhBpRjVrIwW3Sl7GxAMDXol31nfT25dMQMFey3i0)

# Context

At top of expense form need to capture actual start and end dates of travel.  Recalculate Meals and incidentals based on actual dates and times.  This is to account for flight delays and cancelations.  Flag when dates and times are different than entered.

https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/275/wizard/submit-expenses

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
