### PR TITLE
Issue 301: Travel Request Wizard: Autogenerate Estimates

### DIFF
--- a/web/src/components/my-travel-request-wizard/EditTripDetailsStep.vue
+++ b/web/src/components/my-travel-request-wizard/EditTripDetailsStep.vue
@@ -17,6 +17,8 @@
 <script setup>
 import { ref } from "vue"
 
+import generateApi from "@/api/travel-authorizations/estimates/generate-api"
+
 import useSnack from "@/use/use-snack"
 import { capitalize } from "@/utils/formatters"
 
@@ -48,7 +50,7 @@ const isLoading = ref(false)
 const tripDetailsEstimatesEditForm = ref(null)
 const snack = useSnack()
 
-async function validateAndSave() {
+async function validateSaveAndGenerateEstimates() {
   isLoading.value = true
   try {
     if (tripDetailsEstimatesEditForm.value.validate() === false) {
@@ -57,6 +59,7 @@ async function validateAndSave() {
     }
 
     await tripDetailsEstimatesEditForm.value.save()
+    await generateApi.create(props.travelAuthorizationId)
     snack.success("Travel request saved.")
     emit("updated", props.travelAuthorizationId)
     return true
@@ -71,6 +74,6 @@ async function validateAndSave() {
 
 defineExpose({
   initialize,
-  continue: validateAndSave,
+  continue: validateSaveAndGenerateEstimates,
 })
 </script>

--- a/web/src/components/my-travel-request-wizard/EditTripDetailsStep.vue
+++ b/web/src/components/my-travel-request-wizard/EditTripDetailsStep.vue
@@ -17,11 +17,10 @@
 <script setup>
 import { computed, ref } from "vue"
 
-import generateApi from "@/api/travel-authorizations/estimates/generate-api"
-
+import { capitalize } from "@/utils/formatters"
+import travelAuthorizationEstimatesGenerateApi from "@/api/travel-authorizations/estimates/generate-api"
 import useExpenses, { TYPES as EXPENSE_TYPES } from "@/use/use-expenses"
 import useSnack from "@/use/use-snack"
-import { capitalize } from "@/utils/formatters"
 
 import TripDetailsEstimatesEditForm from "@/components/travel-authorizations/TripDetailsEstimatesEditForm.vue"
 
@@ -73,7 +72,7 @@ async function validateSaveAndGenerateEstimatesIfNoneExist() {
 
     await isReadyExpenses()
     if (totalCountExpenses.value === 0) {
-      await generateApi.create(props.travelAuthorizationId)
+      await travelAuthorizationEstimatesGenerateApi.create(props.travelAuthorizationId)
     }
     snack.success("Travel request saved.")
     emit("updated", props.travelAuthorizationId)


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/301

# Context

**Is your feature request related to a problem? Please describe.**
At step 3 the traveler needs to know to hit the generate estimates button on the right.  Since we want all travelers to submit an estimate this seems like an extra step that the traveler needs.

**Describe the solution you'd like**
It would be more usable for the application to generate an estimate upon continuing from step 2.


**Additional context**
https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/292/wizard/generate-estimate
![Image](https://github.com/user-attachments/assets/4f4aa539-7f77-4162-9123-1eb64f8bd363)

# Implementation

1. Move estimate generation trigger to Travel Details step "continue" action.
2. Add `isReady()` promise helper to `useExpenses` to make expenses only generate if none exist.
3. Upgrade current estimate generation modal to latest pattern.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
3. Boot the app via `dev up`
4. Log in to the app at http://localhost:8080
5. Go to the "My Travel Requests" page via the left sidebar nav.
6. Click "New Travel Request" to create a new travel request.
7. Complete the Trip Purpose section.
8. Complete the Trip Details section.
9. Check that estimates have been generated automatically.
10. Go back to the previous step.
11. Continue again, check that estimates have not been double generated.
12. Delete all estimates, check that "create estimate" button still becomes "generate estimates" again, and that this button still works.
13. Delete all estimates again, go back to the previous step, and continue again.
14. Check that estimates have been generated again!
