### PR TITLE
Issue 303: Automate Step Change on Travel Desk Booking Completion

### DIFF
--- a/api/src/services/travel-desk-travel-requests/book-service.ts
+++ b/api/src/services/travel-desk-travel-requests/book-service.ts
@@ -1,4 +1,6 @@
-import db, { TravelDeskTravelRequest, User } from "@/models"
+import { isUndefined } from "lodash"
+
+import db, { TravelAuthorization, TravelDeskTravelRequest, User } from "@/models"
 
 import BaseService from "@/services/base-service"
 
@@ -24,6 +26,15 @@ export class BookService extends BaseService {
       await this.travelDeskTravelRequest.update({
         ...this.attributes,
         status: TravelDeskTravelRequest.Statuses.BOOKED,
+      })
+
+      const { travelAuthorization } = this.travelDeskTravelRequest
+      if (isUndefined(travelAuthorization)) {
+        throw new Error("Expected travelAuthorization association to be pre-loaded.")
+      }
+
+      await travelAuthorization.update({
+        wizardStepName: TravelAuthorization.WizardStepNames.AWAITING_TRAVEL_START,
       })
 
       return this.travelDeskTravelRequest.reload({


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/303

Relates to:

- https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/292/wizard/awaiting-booking-confirmation
- https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/292/wizard/awaiting-travel-start
- https://github.com/icefoganalytics/travel-authorization/pull/332

# Context

**Is your feature request related to a problem? Please describe.**
If the status has changed to "Booking Complete" Automate the check status to the next step rather than requiring a button press.

**Describe the solution you'd like**
Similar to #302 have the app automate the check status without hitting the budget

**Additional context**

![Image](https://github.com/user-attachments/assets/1aa22448-2541-41dd-b1d0-a7228f436432)

![Image](https://github.com/user-attachments/assets/2fdc78c2-75b4-4562-9bb2-e970d1b390db)

# Implementation

1. Automatically diverted travel request wizard to next step on booking complete. Skip past "awaiting-booking-confirmation" step.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the My Travel Requests via the left side nav.
5. Create a new travel request.
6. Complete steps, making sure to select Aircraft as Travel Method, and submit to an admin account you control.
7. Open the app in a private browsing window and log in as your admin account.
8. Go to Manage Travel Requests via the left side nav.
9. Find the travel request you just created approve it.
10. Go back to your traveller account browser window.
11. Click the "check status" button to continue.
12. Submit your travel request to the travel desk.
13. Back in your "admin" browser window, click on "Travel Desk" in the left side nav.
14. Find the travel request you just created and click on it.
15. Add some flight options and send back to the traveller (see https://github.com/icefoganalytics/travel-authorization/pull/257 for how to do that, the UI is pretty hard to follow).
16. Back in your traveller browser window, and click the "check status" button on the awaiting flight options step.
17. Rank your flight options and send back to the travel desk.
18. Then go back to the main "My Travel Requests" page.
19. Back in your "admin" browser window, upload the PNR and mark the booking as complete.
    > Ignore the 500 error on the page, it's legacy code and needs to be rebuilt.
20. Back in your traveller browser window, click on your travel request and note that it jumps directly to the "awaiting travel start" step.
