### PR TITLE
Block Expense Submission Until Travel Is Complete

### DIFF
--- a/api/src/controllers/general-ledger-codings-controller.ts
+++ b/api/src/controllers/general-ledger-codings-controller.ts
@@ -1,115 +1,148 @@
 import { isNil } from "lodash"
-import { WhereOptions } from "sequelize"
 
-import BaseController from "@/controllers/base-controller"
+import logger from "@/utils/logger"
 
 import { GeneralLedgerCoding, TravelAuthorization } from "@/models"
 import { GeneralLedgerCodingsPolicy } from "@/policies"
 import { GeneralLedgerCodingsSerializer } from "@/serializers"
 import { CreateService, UpdateService, DestroyService } from "@/services/general-ledger-codings"
+import BaseController from "@/controllers/base-controller"
 
-export class GeneralLedgerCodingsController extends BaseController {
+export class GeneralLedgerCodingsController extends BaseController<GeneralLedgerCoding> {
   async index() {
-    const where = this.query.where as WhereOptions<GeneralLedgerCoding>
-    return GeneralLedgerCoding.findAll({
-      where,
-    }).then((generalLedgerCodings) => {
+    try {
+      const where = this.buildWhere()
+      const scopes = this.buildFilterScopes()
+      const order = this.buildOrder()
+
+      const scopedGeneralLedgerCodings = GeneralLedgerCodingsPolicy.applyScope(
+        scopes,
+        this.currentUser
+      )
+
+      const totalCount = await scopedGeneralLedgerCodings.count({ where })
+      const generalLedgerCodings = await scopedGeneralLedgerCodings.findAll({
+        where,
+        limit: this.pagination.limit,
+        offset: this.pagination.offset,
+        order,
+      })
       const serializedGeneralLedgerCodings =
         GeneralLedgerCodingsSerializer.asTable(generalLedgerCodings)
-      return this.response.json({ generalLedgerCodings: serializedGeneralLedgerCodings })
-    })
+      return this.response.json({
+        generalLedgerCodings: serializedGeneralLedgerCodings,
+        totalCount,
+      })
+    } catch (error) {
+      logger.error(`Error fetching general ledger codings: ${error}`, { error })
+      return this.response.status(400).json({
+        message: `Failed to retrieve general ledger codings: ${error}`,
+      })
+    }
   }
 
   async create() {
-    const generalLedgerCoding = await this.buildGeneralLedgerCoding()
-    const policy = this.buildPolicy(generalLedgerCoding)
-    if (!policy.create()) {
-      return this.response
-        .status(403)
-        .json({ message: "You are not authorized to create this general ledger coding." })
-    }
+    try {
+      const generalLedgerCoding = await this.buildGeneralLedgerCoding()
+      const policy = this.buildPolicy(generalLedgerCoding)
+      if (!policy.create()) {
+        return this.response.status(403).json({
+          message: "You are not authorized to create this general ledger coding.",
+        })
+      }
 
-    const permittedAttributes = policy.permitAttributesForCreate(this.request.body)
-    return CreateService.perform(permittedAttributes, this.currentUser)
-      .then((generalLedgerCoding) => {
-        return this.response.status(201).json({ generalLedgerCoding })
+      const permittedAttributes = policy.permitAttributesForCreate(this.request.body)
+      const newGeneralLedgerCoding = await CreateService.perform(
+        permittedAttributes,
+        this.currentUser
+      )
+      return this.response.status(201).json({
+        generalLedgerCoding: newGeneralLedgerCoding,
       })
-      .catch((error) => {
-        return this.response
-          .status(422)
-          .json({ message: `General ledger coding creation failed: ${error}` })
+    } catch (error) {
+      logger.error(`Error creating general ledger coding: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `General ledger coding creation failed: ${error}`,
       })
+    }
   }
 
   async update() {
-    const generalLedgerCoding = await this.loadGeneralLedgerCoding()
-    if (isNil(generalLedgerCoding))
-      return this.response.status(404).json({ message: "General ledger coding not found." })
+    try {
+      const generalLedgerCoding = await this.loadGeneralLedgerCoding()
+      if (isNil(generalLedgerCoding)) {
+        return this.response.status(404).json({
+          message: "General ledger coding not found.",
+        })
+      }
 
-    const policy = this.buildPolicy(generalLedgerCoding)
-    if (!policy.update()) {
-      return this.response
-        .status(403)
-        .json({ message: "You are not authorized to update this general ledger coding." })
+      const policy = this.buildPolicy(generalLedgerCoding)
+      if (!policy.update()) {
+        return this.response.status(403).json({
+          message: "You are not authorized to update this general ledger coding.",
+        })
+      }
+
+      const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
+      const updatedGeneralLedgerCoding = await UpdateService.perform(
+        generalLedgerCoding,
+        permittedAttributes,
+        this.currentUser
+      )
+      return this.response.json({
+        generalLedgerCoding: updatedGeneralLedgerCoding,
+      })
+    } catch (error) {
+      logger.error(`Error updating general ledger coding: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `General ledger coding update failed: ${error}`,
+      })
     }
-
-    const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
-    return UpdateService.perform(generalLedgerCoding, permittedAttributes, this.currentUser)
-      .then((generalLedgerCoding) => {
-        return this.response.json({ generalLedgerCoding })
-      })
-      .catch((error) => {
-        return this.response
-          .status(422)
-          .json({ message: `General ledger coding update failed: ${error}` })
-      })
   }
 
   async destroy() {
-    const generalLedgerCoding = await this.loadGeneralLedgerCoding()
-    if (isNil(generalLedgerCoding))
-      return this.response.status(404).json({ message: "GeneralLedgerCoding not found." })
+    try {
+      const generalLedgerCoding = await this.loadGeneralLedgerCoding()
+      if (isNil(generalLedgerCoding)) {
+        return this.response.status(404).json({
+          message: "General ledger coding not found.",
+        })
+      }
 
-    const policy = this.buildPolicy(generalLedgerCoding)
-    if (!policy.destroy()) {
-      return this.response
-        .status(403)
-        .json({ message: "You are not authorized to delete this generalLedgerCoding." })
+      const policy = this.buildPolicy(generalLedgerCoding)
+      if (!policy.destroy()) {
+        return this.response.status(403).json({
+          message: "You are not authorized to delete this general ledger coding.",
+        })
+      }
+
+      await DestroyService.perform(generalLedgerCoding, this.currentUser)
+      return this.response.status(204).end()
+    } catch (error) {
+      logger.error(`Error deleting general ledger coding: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `General ledger coding deletion failed: ${error}`,
+      })
     }
-
-    return DestroyService.perform(generalLedgerCoding, this.currentUser)
-      .then(() => {
-        return this.response.status(204).end()
-      })
-      .catch((error) => {
-        return this.response
-          .status(422)
-          .json({ message: `GeneralLedgerCoding deletion failed: ${error}` })
-      })
   }
 
   private async buildGeneralLedgerCoding() {
     const attributes = this.request.body
     const generalLedgerCoding = GeneralLedgerCoding.build(attributes)
 
+    // TODO: Given this requirement, consider nesting /travel-authorizations/:travelAuthorizationId/general-ledger-codings
     const { travelAuthorizationId } = attributes
-    const travelAuthorization = await this.loadTravelAuthorization(travelAuthorizationId)
-    if (!isNil(travelAuthorization)) {
-      generalLedgerCoding.travelAuthorization = travelAuthorization
-    }
+    const travelAuthorization = await TravelAuthorization.findByPk(travelAuthorizationId, {
+      rejectOnEmpty: true,
+    })
+    generalLedgerCoding.travelAuthorization = travelAuthorization
 
     return generalLedgerCoding
   }
 
-  private loadTravelAuthorization(
-    travelAuthorizationId: number
-  ): Promise<TravelAuthorization | null> {
-    return TravelAuthorization.findByPk(travelAuthorizationId)
-  }
-
   private loadGeneralLedgerCoding(): Promise<GeneralLedgerCoding | null> {
     return GeneralLedgerCoding.findByPk(this.params.generalLedgerCodingId, {
-      include: "travelAuthorization",
+      include: ["travelAuthorization"],
     })
   }
 

--- a/api/src/controllers/travel-authorizations/expense-claim-controller.ts
+++ b/api/src/controllers/travel-authorizations/expense-claim-controller.ts
@@ -44,7 +44,9 @@ export class ExpenseClaimController extends BaseController {
   }
 
   private loadTravelAuthorization(): Promise<TravelAuthorization | null> {
-    return TravelAuthorization.findByPk(this.params.travelAuthorizationId)
+    return TravelAuthorization.findByPk(this.params.travelAuthorizationId, {
+      include: ["travelSegments"],
+    })
   }
 
   private buildPolicy(record: TravelAuthorization): ExpenseClaimPolicy {

--- a/api/src/policies/general-ledger-codings-policy.ts
+++ b/api/src/policies/general-ledger-codings-policy.ts
@@ -1,29 +1,29 @@
+import { FindOptions, Attributes, Op } from "sequelize"
+import { isUndefined } from "lodash"
+
 import { GeneralLedgerCoding, User } from "@/models"
 
-import BasePolicy from "@/policies/base-policy"
+import { ALL_RECORDS_SCOPE } from "@/policies/base-policy"
+import PolicyFactory from "@/policies/policy-factory"
+import TravelAuthorizationsPolicy from "@/policies/travel-authorizations-policy"
 
-export class GeneralLedgerCodingsPolicy extends BasePolicy<GeneralLedgerCoding> {
-  private travelAuthorization: GeneralLedgerCoding["travelAuthorization"]
-
-  constructor(user: User, record: GeneralLedgerCoding) {
-    super(user, record)
-    this.travelAuthorization = record.travelAuthorization
-  }
-
+export class GeneralLedgerCodingsPolicy extends PolicyFactory(GeneralLedgerCoding) {
   create(): boolean {
-    if (this.user.roles.includes(User.Roles.ADMIN)) return true
-    if (this.travelAuthorization?.supervisorEmail === this.user.email) return true
-    if (this.travelAuthorization?.userId === this.user.id) return true
+    if (this.travelAuthorizationPolicy.update()) return true
 
     return false
   }
 
   update(): boolean {
-    return this.create()
+    if (this.travelAuthorizationPolicy.update()) return true
+
+    return false
   }
 
   destroy(): boolean {
-    return this.create()
+    if (this.travelAuthorizationPolicy.update()) return true
+
+    return false
   }
 
   permittedAttributes(): string[] {
@@ -32,6 +32,39 @@ export class GeneralLedgerCodingsPolicy extends BasePolicy<GeneralLedgerCoding> 
 
   permittedAttributesForCreate(): string[] {
     return ["travelAuthorizationId", ...this.permittedAttributes()]
+  }
+
+  static policyScope(user: User): FindOptions<Attributes<GeneralLedgerCoding>> {
+    if (user.isAdmin) {
+      return ALL_RECORDS_SCOPE
+    }
+
+    return {
+      include: [
+        {
+          association: "travelAuthorization",
+          where: {
+            [Op.or]: [
+              {
+                supervisorEmail: user.email,
+              },
+              {
+                userId: user.id,
+              },
+            ],
+          },
+        },
+      ],
+    }
+  }
+
+  private get travelAuthorizationPolicy(): TravelAuthorizationsPolicy {
+    const { travelAuthorization } = this.record
+    if (isUndefined(travelAuthorization)) {
+      throw new Error("Expected record to have pre-loaded travelAuthorization association")
+    }
+
+    return new TravelAuthorizationsPolicy(this.user, travelAuthorization)
   }
 }
 

--- a/api/src/services/travel-authorizations/expense-claim-service.ts
+++ b/api/src/services/travel-authorizations/expense-claim-service.ts
@@ -33,7 +33,7 @@ export class ExpenseClaimService extends BaseService {
       throw new Error("Supervisor email is required for expense claim submission.")
     }
 
-    if (this.isAfterTravelEndDate()) {
+    if (!this.isAfterTravelEndDate()) {
       throw new Error("Can not submit an expense claim before travel is completed.")
     }
 
@@ -71,10 +71,18 @@ export class ExpenseClaimService extends BaseService {
     }
 
     const lastTravelSegment = travelSegments.at(-1)
-    if (isNil(lastTravelSegment)) return false
+    if (isNil(lastTravelSegment)) {
+      throw new Error(
+        "Cannot check if travel authorization is after travel end date without at least one travel segment."
+      )
+    }
 
     const { departureOn } = lastTravelSegment
-    if (isNil(departureOn)) return false
+    if (isNil(departureOn)) {
+      throw new Error(
+        "Cannot check if travel authorization is after travel end date without a departure date."
+      )
+    }
 
     return new Date(departureOn) < new Date()
   }

--- a/api/src/services/travel-authorizations/expense-claim-service.ts
+++ b/api/src/services/travel-authorizations/expense-claim-service.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNil } from "lodash"
+import { isNil, isUndefined } from "lodash"
 
 import db from "@/db/db-client"
 
@@ -33,6 +33,10 @@ export class ExpenseClaimService extends BaseService {
       throw new Error("Supervisor email is required for expense claim submission.")
     }
 
+    if (this.isAfterTravelEndDate()) {
+      throw new Error("Can not submit an expense claim before travel is completed.")
+    }
+
     await db.transaction(async () => {
       const supervisor = await Users.EnsureService.perform(
         {
@@ -58,6 +62,21 @@ export class ExpenseClaimService extends BaseService {
     return this.travelAuthorization.reload({
       include: ["expenses", "stops", "purpose", "user", "travelSegments"],
     })
+  }
+
+  private isAfterTravelEndDate(): boolean {
+    const { travelSegments } = this.travelAuthorization
+    if (isUndefined(travelSegments)) {
+      throw new Error("Expected travelSegments association to be pre-loaded.")
+    }
+
+    const lastTravelSegment = travelSegments.at(-1)
+    if (isNil(lastTravelSegment)) return false
+
+    const { departureOn } = lastTravelSegment
+    if (isNil(departureOn)) return false
+
+    return new Date(departureOn) < new Date()
   }
 }
 

--- a/api/tests/services/travel-authorizations/expense-claim-service.test.ts
+++ b/api/tests/services/travel-authorizations/expense-claim-service.test.ts
@@ -1,0 +1,91 @@
+import { DateTime } from "luxon"
+
+import { TravelAuthorization } from "@/models"
+import { travelAuthorizationFactory, travelSegmentFactory, userFactory } from "@/factories"
+
+import ExpenseClaimService from "@/services/travel-authorizations/expense-claim-service"
+
+describe("api/src/services/travel-authorizations/expense-claim-service.ts", () => {
+  describe("ExpenseClaimService", () => {
+    describe("#perform", () => {
+      test("when provided with valid arguments and state, it correctly updates travel authorization state", async () => {
+        // Arrange
+        const currentUser = await userFactory.create()
+        const supervisor = await userFactory.create({
+          email: "supervisor@example.com",
+        })
+
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          status: TravelAuthorization.Statuses.APPROVED,
+        })
+        const twoDaysAgo = DateTime.now().minus({ days: 2 })
+        await travelSegmentFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureOn: twoDaysAgo.toJSDate(),
+        })
+        await travelAuthorization.reload({
+          include: ["travelSegments"],
+        })
+
+        // Act
+        const updatedTravelAuthorization = await ExpenseClaimService.perform(
+          travelAuthorization,
+          supervisor.email,
+          currentUser
+        )
+
+        // Assert
+        expect(updatedTravelAuthorization).toEqual(
+          expect.objectContaining({
+            id: travelAuthorization.id,
+            status: TravelAuthorization.Statuses.EXPENSE_CLAIM_SUBMITTED,
+          })
+        )
+      })
+
+      test("when travel authorization is not in an approved state, it errors informatively", async () => {
+        // Arrange
+        const currentUser = await userFactory.create()
+        const supervisor = await userFactory.create({
+          email: "supervisor@example.com",
+        })
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          status: TravelAuthorization.Statuses.DENIED,
+        })
+
+        // Assert
+        await expect(
+          // Act
+          ExpenseClaimService.perform(travelAuthorization, supervisor.email, currentUser)
+        ).rejects.toThrow(
+          "Travel authorization must be in an approved state to submit an expense claim."
+        )
+      })
+
+      test("when travel authorization is not after travel end date, it errors informatively", async () => {
+        // Arrange
+        const currentUser = await userFactory.create()
+        const supervisor = await userFactory.create({
+          email: "supervisor@example.com",
+        })
+        const travelAuthorization = await travelAuthorizationFactory.create({
+          status: TravelAuthorization.Statuses.APPROVED,
+        })
+        const twoDaysFromNow = DateTime.now().plus({ days: 2 })
+        await travelSegmentFactory.create({
+          travelAuthorizationId: travelAuthorization.id,
+          departureOn: twoDaysFromNow.toJSDate(),
+        })
+        await travelAuthorization.reload({
+          include: ["travelSegments"],
+        })
+
+        // Assert
+        await expect(
+          // Act
+          ExpenseClaimService.perform(travelAuthorization, supervisor.email, currentUser)
+        ).rejects.toThrow("Can not submit an expense claim before travel is completed.")
+      })
+    })
+  })
+})

--- a/web/src/api/expenses-api.js
+++ b/web/src/api/expenses-api.js
@@ -72,7 +72,10 @@ export const expensesApi = {
   /**
    *
    * @param {ExpenseQueryOptions} [params={}]
-   * @returns
+   * @returns {Promise<{
+   *   expenses: Expense[];
+   *   totalCount: number;
+   * }>}
    */
   async list(params = {}) {
     const { data } = await http.get("/api/expenses", { params })

--- a/web/src/components/common/DatePicker.vue
+++ b/web/src/components/common/DatePicker.vue
@@ -38,7 +38,7 @@ export default {
   props: {
     value: {
       type: String,
-      default: "Pick a Date",
+      default: undefined,
     },
     text: {
       type: String,
@@ -52,7 +52,7 @@ export default {
     },
     label: {
       type: String,
-      default: undefined,
+      default: "Pick a Date",
     },
     rules: {
       type: Array,

--- a/web/src/components/my-travel-request-wizard/SubmitExpensesStep.vue
+++ b/web/src/components/my-travel-request-wizard/SubmitExpensesStep.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from "vue"
+import { computed, ref } from "vue"
 import { isNil } from "lodash"
 
 import useExpenses, { TYPES as EXPENSE_TYPES } from "@/use/use-expenses"
@@ -145,28 +145,21 @@ const travelSegmentsQuery = computed(() => ({
     isActual: true,
   },
 }))
-const { travelSegments } = useTravelSegments(travelSegmentsQuery)
-const isAfterTravelEndDate = computed(() => {
-  const lastTravelSegment = travelSegments.value.at(-1)
-  if (isNil(lastTravelSegment)) return false
-
-  return new Date(lastTravelSegment.departureOn) < new Date()
-})
+const { travelSegments, isReady: isReadyTravelSegments } = useTravelSegments(travelSegmentsQuery)
 
 async function initialize(context) {
   context.setEditableSteps([])
 
-  watch(
-    () => isAfterTravelEndDate.value,
-    (newIsAfterTravelEndDate) => {
-      if (newIsAfterTravelEndDate) {
-        context.setContinueButtonProps({
-          enabled: true,
-        })
-      }
-    },
-    { immediate: true }
-  )
+  await isReadyTravelSegments()
+  const lastTravelSegment = travelSegments.value.at(-1)
+  if (isNil(lastTravelSegment)) return
+
+  const isAfterTravelEndDate = new Date(lastTravelSegment.departureOn) < new Date()
+  if (isAfterTravelEndDate) {
+    context.setContinueButtonProps({
+      enabled: true,
+    })
+  }
 }
 
 // TODO: split submission step into its own page

--- a/web/src/components/travel-desk-travel-requests/TravelDeskInvoiceCard.vue
+++ b/web/src/components/travel-desk-travel-requests/TravelDeskInvoiceCard.vue
@@ -3,7 +3,14 @@
     <v-card-title>
       <h3>Invoice</h3>
     </v-card-title>
-    <v-card-text class="d-flex justify-space-between align-center">
+    <v-skeleton-loader
+      v-if="isLoading"
+      type="card"
+    />
+    <v-card-text
+      v-else
+      class="d-flex justify-space-between align-center"
+    >
       <span class="primary--text body-1">
         Invoice Number: {{ travelDeskTravelRequest.invoiceNumber }}
       </span>

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseCreateDialog.vue
@@ -115,16 +115,16 @@ export default {
     return {
       expenseTypes: [EXPENSE_TYPES.ACCOMMODATIONS, EXPENSE_TYPES.TRANSPORTATION],
       expense: this.newExpense(),
-      showDialog: this.$route.query.showCreate === "true",
+      showDialog: this.$route.query.showCreateExpense === "true",
       loading: false,
     }
   },
   watch: {
     showDialog(value) {
       if (value) {
-        this.$router.push({ query: { showCreate: value } })
+        this.$router.push({ query: { showCreateExpense: value } })
       } else {
-        this.$router.push({ query: { showCreate: undefined } })
+        this.$router.push({ query: { showCreateExpense: undefined } })
       }
     },
   },

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/GeneralLedgerCodingCreateDialog.vue
@@ -118,14 +118,14 @@ const snack = useSnack()
 
 const form = ref(null)
 const generalLedgerCoding = ref(build())
-const showDialog = ref(route.query.showCreate === "true")
+const showDialog = ref(route.query.showCreateGLCoding === "true")
 const isLoading = ref(false)
 
 watch(showDialog, (value) => {
   if (value) {
-    router.push({ query: { showCreate: value } })
+    router.push({ query: { showCreateGLCoding: value } })
   } else {
-    router.push({ query: { showCreate: undefined } })
+    router.push({ query: { showCreateGLCoding: undefined } })
   }
 })
 

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
@@ -23,14 +23,15 @@
 </template>
 
 <script setup>
-import { onMounted, ref, computed } from "vue"
+import { ref, computed } from "vue"
 
 import { required } from "@/utils/validators"
 
+import travelAuthorizationsApi from "@/api/travel-authorizations-api"
+import useExpenses, { TYPES, EXPENSE_TYPES } from "@/use/use-expenses"
+import useGeneralLedgerCodings from "@/use/use-general-ledger-codings"
 import useSnack from "@/use/use-snack"
-import { useTravelAuthorization } from "@/use/use-travel-authorization"
-import { useGeneralLedgerCodings } from "@/use/use-general-ledger-codings"
-import { useExpenses, TYPES, EXPENSE_TYPES } from "@/use/use-expenses"
+import useTravelAuthorization from "@/use/use-travel-authorization"
 
 import UserEmailSearchableCombobox from "@/components/users/UserEmailSearchableCombobox.vue"
 
@@ -47,8 +48,7 @@ const snack = useSnack()
 const {
   travelAuthorization,
   isLoading: isLoadingTravelAuthorization,
-  fetch: fetchTravelAuthorization,
-  expenseClaim,
+  refresh: refreshTravelAuthorization,
 } = useTravelAuthorization(props.travelAuthorizationId)
 
 const generalLedgerCodingOptions = computed(() => ({
@@ -59,7 +59,7 @@ const generalLedgerCodingOptions = computed(() => ({
 const {
   generalLedgerCodings,
   isLoading: isLoadingGeneralLedgerCodings,
-  fetch: fetchGeneralLedgerCodings,
+  refresh: refreshGeneralLedgerCodings,
 } = useGeneralLedgerCodings(generalLedgerCodingOptions)
 
 const expenseOptions = computed(() => ({
@@ -68,7 +68,11 @@ const expenseOptions = computed(() => ({
     type: TYPES.EXPENSE,
   },
 }))
-const { expenses, isLoading: isLoadingExpenses, fetch: fetchExpenses } = useExpenses(expenseOptions)
+const {
+  expenses,
+  isLoading: isLoadingExpenses,
+  refresh: refreshExpenses,
+} = useExpenses(expenseOptions)
 
 const isLoading = computed(
   () =>
@@ -88,15 +92,11 @@ const isReadyToSubmit = computed(
   () => hasGeneralLedgerCodings.value && allRelevantExpensesHaveReceipts.value
 )
 
-onMounted(async () => {
-  await refresh()
-})
-
 async function refresh() {
   await Promise.all([
-    await fetchTravelAuthorization(),
-    await fetchGeneralLedgerCodings(),
-    await fetchExpenses(),
+    await refreshTravelAuthorization(),
+    await refreshGeneralLedgerCodings(),
+    await refreshExpenses(),
   ])
 }
 
@@ -108,15 +108,23 @@ async function requestApprovalForExpenseClaim() {
     return false
   }
 
+  isLoadingTravelAuthorization.isLoading = true
   try {
-    await expenseClaim({
-      supervisorEmail: travelAuthorization.value.supervisorEmail,
-    })
+    const { travelAuthorization } = await travelAuthorizationsApi.expenseClaim(
+      props.travelAuthorizationId,
+      {
+        supervisorEmail: travelAuthorization.value.supervisorEmail,
+      }
+    )
+    isLoadingTravelAuthorization.value = false
     snack.success("Expense claim submitted for approval.")
     return true
   } catch (error) {
+    console.error(`Failed to submit expense claim for travel authorization: ${error}`, { error })
     snack.error(`Failed to submit expense claim: ${error}`)
     return false
+  } finally {
+    isLoadingTravelAuthorization.isLoading = false
   }
 }
 

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/RequestApprovalForm.vue
@@ -110,12 +110,9 @@ async function requestApprovalForExpenseClaim() {
 
   isLoadingTravelAuthorization.isLoading = true
   try {
-    const { travelAuthorization } = await travelAuthorizationsApi.expenseClaim(
-      props.travelAuthorizationId,
-      {
-        supervisorEmail: travelAuthorization.value.supervisorEmail,
-      }
-    )
+    await travelAuthorizationsApi.expenseClaim(props.travelAuthorizationId, {
+      supervisorEmail: travelAuthorization.value.supervisorEmail,
+    })
     isLoadingTravelAuthorization.value = false
     snack.success("Expense claim submitted for approval.")
     return true

--- a/web/src/modules/travelDesk/views/Requests/Components/ItineraryModal.vue
+++ b/web/src/modules/travelDesk/views/Requests/Components/ItineraryModal.vue
@@ -164,7 +164,7 @@ export default {
   },
   props: {
     invoiceNumber: {
-      type: Number,
+      type: [String, Number],
       required: true,
     },
   },

--- a/web/src/pages/administration/users/UserEditPage.vue
+++ b/web/src/pages/administration/users/UserEditPage.vue
@@ -124,6 +124,8 @@
 <script>
 import { pick } from "lodash"
 
+import { required } from "@/utils/validators"
+
 import { USERS_URL, LOOKUP_URL } from "@/urls"
 import http from "@/api/http-client"
 import useSnack from "@/use/use-snack"
@@ -187,6 +189,7 @@ export default {
     alertMsg: "",
     alertType: "",
     isLoading: true,
+    required,
   }),
   async mounted() {
     try {

--- a/web/src/pages/my-travel-requests/MyTravelRequestWizardPage.vue
+++ b/web/src/pages/my-travel-requests/MyTravelRequestWizardPage.vue
@@ -67,7 +67,7 @@
                 class="ml-0 ml-md-3"
                 v-bind="{
                   color: 'secondary',
-                  tooltipText: 'Back',
+                  tooltipText: 'Not available',
                   ...currentStep.backButtonProps,
                 }"
                 @click="backAndGoToPreviousStep"

--- a/web/src/pages/my-travel-requests/MyTravelRequestWizardPage.vue
+++ b/web/src/pages/my-travel-requests/MyTravelRequestWizardPage.vue
@@ -51,26 +51,29 @@
             />
 
             <div class="d-flex flex-column flex-md-row">
-              <v-btn
+              <ConditionalTooltipButton
+                ref="continueButton"
                 v-bind="{
                   color: 'primary',
+                  tooltipText: 'Continue',
                   ...currentStep.continueButtonProps,
                   loading: isLoading,
                 }"
                 @click="continueAndGoToNextStep"
               >
                 {{ currentStep.continueButtonText || "Continue" }}
-              </v-btn>
-              <v-btn
+              </ConditionalTooltipButton>
+              <ConditionalTooltipButton
                 class="ml-0 ml-md-3"
                 v-bind="{
                   color: 'secondary',
+                  tooltipText: 'Back',
                   ...currentStep.backButtonProps,
                 }"
                 @click="backAndGoToPreviousStep"
               >
                 {{ currentStep.backButtonText || "Back" }}
-              </v-btn>
+              </ConditionalTooltipButton>
             </div>
           </v-card-text>
         </v-card>
@@ -93,6 +96,7 @@ import { isNil, isEmpty, isString } from "lodash"
 import useBreadcrumbs from "@/use/use-breadcrumbs"
 import useMyTravelRequestWizard from "@/use/wizards/use-my-travel-request-wizard"
 
+import ConditionalTooltipButton from "@/components/common/ConditionalTooltipButton.vue"
 import StateStepper from "@/components/common/wizards/StateStepper.vue"
 import SummaryHeaderPanel from "@/components/travel-authorizations/SummaryHeaderPanel.vue"
 import TravelAuthorizationActionLogsTable from "@/components/travel-authorization-action-logs/TravelAuthorizationActionLogsTable.vue"
@@ -120,6 +124,8 @@ const {
   goToNextStep,
   goToPreviousStep,
   setEditableSteps,
+  setBackButtonProps,
+  setContinueButtonProps,
 } = useMyTravelRequestWizard(travelAuthorizationIdAsNumber)
 
 const currentStepComponent = ref(null)
@@ -132,6 +138,8 @@ watch(
     if (newStepComponent.initialize) {
       newStepComponent.initialize({
         setEditableSteps,
+        setBackButtonProps,
+        setContinueButtonProps,
       })
     }
 

--- a/web/src/pages/travel-desk/TravelDeskEditPage.vue
+++ b/web/src/pages/travel-desk/TravelDeskEditPage.vue
@@ -113,7 +113,7 @@
         <ItineraryModal
           v-if="hasInvoiceNumber"
           class="ml-auto mr-3"
-          :invoice-number="hasInvoiceNumber"
+          :invoice-number="invoiceNumber"
         />
         <UploadPnrModal
           :travel-request="travelDeskTravelRequest"
@@ -280,9 +280,10 @@ const isBookedState = computed(
 const isCompleteState = computed(
   () => travelDeskTravelRequest.value?.status === TRAVEL_DESK_TRAVEL_REQUEST_STATUSES.COMPLETE
 )
-const hasInvoiceNumber = computed(
-  () => !isNil(travelDeskTravelRequest.value?.travelDeskPassengerNameRecordDocument?.invoiceNumber)
+const invoiceNumber = computed(
+  () => travelDeskTravelRequest.value?.travelDeskPassengerNameRecordDocument?.invoiceNumber
 )
+const hasInvoiceNumber = computed(() => !isNil(invoiceNumber.value))
 
 const savingData = ref(false)
 

--- a/web/src/use/use-general-ledger-codings.js
+++ b/web/src/use/use-general-ledger-codings.js
@@ -14,16 +14,20 @@ import generalLedgerCodingsApi from "@/api/general-ledger-codings-api"
  * @param {import('vue').Ref<{
  *   where: { [key: string]: any },
  * }>} [options={}] - The configuration options for fetching expenses, wrapped in a Vue ref.
+ * @param {{ skipWatchIf?: (options: any) => boolean }} [config={ skipWatchIf: () => false }]
  * @returns {{
  *   generalLedgerCodings: import('vue').Ref<GeneralLedgerCoding[]>,
+ *   totalCount: import('vue').Ref<number>,
  *   isLoading: import('vue').Ref<boolean>,
  *   isErrored: import('vue').Ref<boolean>,
  *   fetch: () => Promise<GeneralLedgerCoding[]>,
+ *   refresh: () => Promise<GeneralLedgerCoding[]>,
  * }}
  */
-export function useGeneralLedgerCodings(options = {}) {
+export function useGeneralLedgerCodings(options = ref({}), { skipWatchIf = () => false } = {}) {
   const state = reactive({
     generalLedgerCodings: [],
+    totalCount: 0,
     isLoading: false,
     isErrored: false,
   })
@@ -31,9 +35,10 @@ export function useGeneralLedgerCodings(options = {}) {
   async function fetch() {
     state.isLoading = true
     try {
-      const { generalLedgerCodings } = await generalLedgerCodingsApi.list(unref(options))
-      state.isErrored = false
+      const { generalLedgerCodings, totalCount } = await generalLedgerCodingsApi.list(unref(options))
       state.generalLedgerCodings = generalLedgerCodings
+      state.totalCount = totalCount
+      state.isErrored = false
       return generalLedgerCodings
     } catch (error) {
       console.error("Failed to fetch general ledger codings:", error)
@@ -45,19 +50,19 @@ export function useGeneralLedgerCodings(options = {}) {
   }
 
   watch(
-    () => unref(options),
-    async () => {
+    () => [skipWatchIf(), unref(options)],
+    async ([skip]) => {
+      if (skip) return
+
       await fetch()
     },
-    {
-      immediate: true,
-      deep: true,
-    }
+    { deep: true, immediate: true }
   )
 
   return {
     ...toRefs(state),
     fetch,
+    refresh: fetch,
   }
 }
 

--- a/web/src/use/use-travel-authorization.js
+++ b/web/src/use/use-travel-authorization.js
@@ -22,14 +22,10 @@ export { STATUSES, TRIP_TYPES }
  *   isLoading: Ref<boolean>,
  *   isErrored: Ref<boolean>,
  *   stops: Ref<Stop[]>,
- *   firstStop: Ref<Stop>,
- *   lastStop: Ref<Stop>,
  *   fetch: () => Promise<TravelAuthorization>,
  *   refresh: () => Promise<TravelAuthorization>,
  *   save: () => Promise<TravelAuthorization>, // save that triggers loading state
  *   saveSilently: () => Promise<TravelAuthorization>, // save that does not trigger loading state
- *   newBlankStop: (attributes: Partial<Stop>) => Stop,
- *   replaceStops: (stops: Stop[]) => Stop[],
  *   approve: () => Promise<TravelAuthorization>,
  *   deny: ({ denialReason: string } = {}) => Promise<TravelAuthorization>,
  * }}
@@ -97,6 +93,7 @@ export function useTravelAuthorization(travelAuthorizationId) {
     }
   }
 
+  // DEPRECATED: prefer inline api calls for state changes.
   // Stateful actions
   async function submit(attributes = state.travelAuthorization) {
     state.isLoading = true
@@ -173,25 +170,6 @@ export function useTravelAuthorization(travelAuthorizationId) {
     state.travelAuthorization.expenses?.filter((expense) => expense.type === EXPENSE_TYPES.ESTIMATE)
   )
   const stops = computed(() => state.travelAuthorization.stops)
-  const firstStop = computed(() => stops.value[0] || {})
-  const lastStop = computed(() => stops.value[stops.value.length - 1] || {})
-
-  function newBlankStop(attributes) {
-    return {
-      travelAuthorizationId: state.travelAuthorization.id,
-      ...attributes,
-    }
-  }
-
-  // In the future it might make sense to directly update stops in the back-end
-  function replaceStops(stops) {
-    state.travelAuthorization = {
-      ...state.travelAuthorization,
-      stops,
-    }
-
-    return stops
-  }
 
   return {
     STATUSES,
@@ -199,15 +177,11 @@ export function useTravelAuthorization(travelAuthorizationId) {
     // computed attributes
     estimates,
     stops,
-    firstStop,
-    lastStop,
     // methods
     fetch,
     refresh: fetch,
     save,
     saveSilently,
-    newBlankStop,
-    replaceStops,
     // stateful action
     submit,
     approve,

--- a/web/src/use/use-travel-authorization.js
+++ b/web/src/use/use-travel-authorization.js
@@ -1,4 +1,5 @@
 import { computed, reactive, toRefs, unref, watch } from "vue"
+import { isNil } from "lodash"
 
 import { TYPES as EXPENSE_TYPES } from "@/api/expenses-api"
 import travelAuthorizationsApi, { STATUSES, TRIP_TYPES } from "@/api/travel-authorizations-api"
@@ -31,7 +32,6 @@ export { STATUSES, TRIP_TYPES }
  *   replaceStops: (stops: Stop[]) => Stop[],
  *   approve: () => Promise<TravelAuthorization>,
  *   deny: ({ denialReason: string } = {}) => Promise<TravelAuthorization>,
- *   expenseClaim: (attributes) => Promise<TravelAuthorization>,
  * }}
  */
 
@@ -156,29 +156,10 @@ export function useTravelAuthorization(travelAuthorizationId) {
     }
   }
 
-  async function expenseClaim(attributes) {
-    state.isLoading = true
-    try {
-      const { travelAuthorization } = await travelAuthorizationsApi.expenseClaim(
-        unref(travelAuthorizationId),
-        attributes
-      )
-      state.isErrored = false
-      state.travelAuthorization = travelAuthorization
-      return travelAuthorization
-    } catch (error) {
-      console.error("Failed to submit expense claim for travel authorization:", error)
-      state.isErrored = true
-      throw error
-    } finally {
-      state.isLoading = false
-    }
-  }
-
   watch(
     () => unref(travelAuthorizationId),
     async (newTravelAuthorizationId) => {
-      if ([undefined, null].includes(newTravelAuthorizationId)) return
+      if (isNil(newTravelAuthorizationId)) return
       // TODO: add some tests and check whether I should abort on loading
       // to avoid infinite loops
       // if (state.isLoading === true) return
@@ -231,7 +212,6 @@ export function useTravelAuthorization(travelAuthorizationId) {
     submit,
     approve,
     deny,
-    expenseClaim,
   }
 }
 

--- a/web/src/use/wizards/my-travel-request-wizard-steps.js
+++ b/web/src/use/wizards/my-travel-request-wizard-steps.js
@@ -163,6 +163,10 @@ export const MY_TRAVEL_REQUEST_WIZARD_STEPS = Object.freeze(
         disabled: true,
       },
       continueButtonText: "Submit to Supervisor",
+      continueButtonProps: {
+        disabled: true,
+        tooltipText: "Cannot submit expenses until travel is completed",
+      },
     },
     {
       id: TRAVEL_AUTHORIZATION_WIZARD_STEP_NAMES.REVIEW_EXPENSES,

--- a/web/src/use/wizards/use-my-travel-request-wizard.js
+++ b/web/src/use/wizards/use-my-travel-request-wizard.js
@@ -130,6 +130,14 @@ export function useMyTravelRequestWizard(travelAuthorizationId) {
     })
   }
 
+  function setBackButtonProps(props) {
+    currentStep.value.backButtonProps = props
+  }
+
+  function setContinueButtonProps(props) {
+    currentStep.value.continueButtonProps = props
+  }
+
   return {
     ...toRefs(state),
     currentWizardStepName,
@@ -142,6 +150,8 @@ export function useMyTravelRequestWizard(travelAuthorizationId) {
     goToPreviousStep,
     goToNextStep,
     setEditableSteps,
+    setBackButtonProps,
+    setContinueButtonProps,
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/308

Relates to:

- https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/292/wizard/review-expenses

# Context

**Describe the bug**
As a traveler I should not be able to submit a travel expense claim until my travel is over.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to Step 15 on the travel wizard
2. Click on submit

**Expected behavior**
Only show submit button on the date travel is over.

# Implementation

1. Disable expense submission until travel is complete in travel request wizard step.
    Upgrade travel request wizard to use tooltips for disabled buttons.
2. Disable expense submission until travel is complete in back-end as well.

# Screenshots

Disabled submit button with tooltip
http://localhost:8080/my-travel-requests/109/wizard/submit-expenses
![image](https://github.com/user-attachments/assets/1d3bf3d2-96d3-4f10-8544-6a8da4938c1e)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
3. Boot the app via `dev up`
4. Log in to the app at http://localhost:8080
5. Go to the "My Travel Requests" page via the left side nav.
6. Create a new travel request.
7. Fill in the details, and be sure to pick dates in the future for travel times.
8. Complete all the steps (with various user accounts), until you get to the submit expenses step.
9. Verify that the submit button is disabled and has a tooltip.
