### PR TITLE
Make Travel Time “Actuals” Completable in Parallel With Expenses

### DIFF
--- a/web/src/components/my-travel-request-wizard/ConfirmActualTravelDetailsStep.vue
+++ b/web/src/components/my-travel-request-wizard/ConfirmActualTravelDetailsStep.vue
@@ -20,6 +20,8 @@ import { ref } from "vue"
 import useSnack from "@/use/use-snack"
 import { capitalize } from "@/utils/formatters"
 
+import { TRAVEL_AUTHORIZATION_WIZARD_STEP_NAMES } from "@/api/travel-authorizations-api"
+
 import TripDetailsActualsEditForm from "@/components/travel-authorizations/TripDetailsActualsEditForm.vue"
 
 const props = defineProps({
@@ -40,7 +42,7 @@ const props = defineProps({
 const emit = defineEmits(["updated"])
 
 async function initialize(context) {
-  context.setEditableSteps([])
+  context.setEditableSteps([TRAVEL_AUTHORIZATION_WIZARD_STEP_NAMES.SUBMIT_EXPENSES])
 }
 
 const isLoading = ref(false)

--- a/web/src/components/my-travel-request-wizard/SubmitExpensesStep.vue
+++ b/web/src/components/my-travel-request-wizard/SubmitExpensesStep.vue
@@ -77,6 +77,8 @@
 import { computed, ref } from "vue"
 import { isNil } from "lodash"
 
+import { TRAVEL_AUTHORIZATION_WIZARD_STEP_NAMES } from "@/api/travel-authorizations-api"
+
 import useExpenses, { TYPES as EXPENSE_TYPES } from "@/use/use-expenses"
 import useTravelSegments from "@/use/use-travel-segments"
 
@@ -148,7 +150,7 @@ const travelSegmentsQuery = computed(() => ({
 const { travelSegments, isReady: isReadyTravelSegments } = useTravelSegments(travelSegmentsQuery)
 
 async function initialize(context) {
-  context.setEditableSteps([])
+  context.setEditableSteps([TRAVEL_AUTHORIZATION_WIZARD_STEP_NAMES.CONFIRM_ACTUAL_TRAVEL_DETAILS])
 
   await isReadyTravelSegments()
   const lastTravelSegment = travelSegments.value.at(-1)

--- a/web/src/use/wizards/my-travel-request-wizard-steps.js
+++ b/web/src/use/wizards/my-travel-request-wizard-steps.js
@@ -159,9 +159,6 @@ export const MY_TRAVEL_REQUEST_WIZARD_STEPS = Object.freeze(
       title: "Submit Expenses",
       subtitle: "Submit trip expenses and receipts to your supervisor",
       component: () => import("@/components/my-travel-request-wizard/SubmitExpensesStep.vue"),
-      backButtonProps: {
-        disabled: true,
-      },
       continueButtonText: "Submit to Supervisor",
       continueButtonProps: {
         disabled: true,


### PR DESCRIPTION
Relates to:

- https://github.com/icefoganalytics/travel-authorization/issues/270
- https://github.com/icefoganalytics/travel-authorization/issues/270#issuecomment-3050459776

# Context

unfortunately the confirmation of travel dates and times may occur before, after or during the entry of expenses. This confirmation of travel should be a part of step 14 the expense form.

# Implementation

1. Make travel time "actuals" completable in parallel with expenses.

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
