### PR TITLE
refactor: standardize vue imports

### DIFF
--- a/web/src/components/Administration/LookupTableManagement/PlaceType/AddDialog.vue
+++ b/web/src/components/Administration/LookupTableManagement/PlaceType/AddDialog.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script>
-import catalogs from "../../../../controllers/catalogs"
+import catalogs from "@/controllers/catalogs"
 export default {
   props: [],
   data: () => ({

--- a/web/src/components/Administration/LookupTableManagement/PlaceType/EditDialog.vue
+++ b/web/src/components/Administration/LookupTableManagement/PlaceType/EditDialog.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import catalogs from "../../../../controllers/catalogs";
+import catalogs from "@/controllers/catalogs";
 export default {
   props: ["dialog", "data"],
   data: () => ({

--- a/web/src/components/Administration/LookupTableManagement/PlaceType/PlaceType.vue
+++ b/web/src/components/Administration/LookupTableManagement/PlaceType/PlaceType.vue
@@ -82,10 +82,10 @@
 </template>
 
 <script>
-import catalogs from "../../../../controllers/catalogs"
-import Breadcrumbs from "../../../Breadcrumbs"
-import EditDialog from "./EditDialog"
-import AddDialog from "./AddDialog"
+import catalogs from "@/controllers/catalogs"
+import Breadcrumbs from "@/components/Breadcrumbs.vue"
+import EditDialog from "@/components/Administration/LookupTableManagement/PlaceType/EditDialog.vue"
+import AddDialog from "@/components/Administration/LookupTableManagement/PlaceType/AddDialog.vue"
 import _ from "lodash"
 export default {
   name: "placetypegrid",

--- a/web/src/controllers/user.js
+++ b/web/src/controllers/user.js
@@ -1,4 +1,4 @@
-import { api } from "./config";
+import { api } from "@/controllers/config";
 
 export default {
   async get(page, limit, textToMatch, sortBy, sort) {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7,7 +7,7 @@ import SnackPlugin from "@/plugins/snack-plugin"
 import createI18n from "@/plugins/vue-i18n-plugin"
 import Auth0Plugin from "@/plugins/auth0-plugin"
 
-import App from "@/App"
+import App from "@/App.vue"
 import router from "@/router"
 import store from "@/store"
 import "@/filters"

--- a/web/src/modules/reports/router/index.js
+++ b/web/src/modules/reports/router/index.js
@@ -6,7 +6,7 @@ const routes = [
       {
         name: "ReportsHome",
         path: "",
-        component: () => import("../views/Reports.vue"),
+        component: () => import("@/modules/reports/views/Reports.vue"),
       },
     ],
   },

--- a/web/src/modules/reports/views/FlightReport.vue
+++ b/web/src/modules/reports/views/FlightReport.vue
@@ -38,7 +38,7 @@
 <script>
 import Vue from "vue";
 import { ExportToCsv } from 'export-to-csv';
-import PrintReport from "./Common/PrintReport.vue";
+import PrintReport from "@/modules/reports/views/Common/PrintReport.vue";
 
 export default {
 	components: {		

--- a/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensesTable.vue
+++ b/web/src/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpensesTable.vue
@@ -82,10 +82,10 @@ import { DateTime } from "luxon"
 
 import { TYPES, EXPENSE_TYPES } from "@/api/expenses-api"
 
-import AddReceiptButton from "./AddReceiptButton"
-import ExpenseDeleteDialog from "./ExpenseDeleteDialog"
-import ExpenseEditDialog from "./ExpenseEditDialog"
-import ViewRecieptLink from "./ViewRecieptLink"
+import AddReceiptButton from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/AddReceiptButton.vue"
+import ExpenseDeleteDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseDeleteDialog.vue"
+import ExpenseEditDialog from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ExpenseEditDialog.vue"
+import ViewRecieptLink from "@/modules/travel-authorizations/components/edit-my-travel-authorization-expense-page/ViewRecieptLink.vue"
 
 export default {
   name: "ExpensesTable",

--- a/web/src/store/current/index.js
+++ b/web/src/store/current/index.js
@@ -1,4 +1,4 @@
-import user from "./user"
+import user from "@/store/current/user"
 
 export default {
   namespaced: true,

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -1,11 +1,11 @@
 import Vue from "vue"
 import Vuex from "vuex"
 
-import auth from "./auth"
-import current from "./current"
+import auth from "@/store/auth"
+import current from "@/store/current"
 import expenses from "@/store/expenses"
-import reports from "./reports"
-import traveldesk from "./traveldesk"
+import reports from "@/store/reports"
+import traveldesk from "@/store/traveldesk"
 import travelPurposes from "@/store/travel-purposes"
 
 Vue.use(Vuex)

--- a/web/src/urls.js
+++ b/web/src/urls.js
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from "./config"
+import { API_BASE_URL } from "@/config"
 
 // TODO: refactor these into apis/xxx-api.js files
 // The base url can be handled by the axios config.


### PR DESCRIPTION
## Summary
- ensure non-trivial index modules use project alias paths
- enforce absolute routes with `.vue` extensions in module routers
- switch store modules to `@/store/...` imports for clarity

## Testing
- `npm test`
- `npm run lint` *(fails: ReferenceError: Cannot read config file: /workspace/travel-authorization/web/.eslintrc.js)*
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_689faf10d35483319fc2c14d99fb172c