### PR TITLE
Issue 304: Ability To Delete a Upload Expense Receipt

### DIFF
--- a/api/src/controllers/expenses/receipt-controller.ts
+++ b/api/src/controllers/expenses/receipt-controller.ts
@@ -2,7 +2,7 @@ import { isNil } from "lodash"
 
 import logger from "@/utils/logger"
 
-import { Expense } from "@/models"
+import { Attachment, Expense } from "@/models"
 import { ExpensesPolicy } from "@/policies"
 import { CreateService } from "@/services/expenses/receipt"
 import BaseController from "@/controllers/base-controller"
@@ -61,6 +61,39 @@ export class ReceiptController extends BaseController {
     }
   }
 
+  async destroy() {
+    try {
+      const expense = await this.loadExpense()
+      if (isNil(expense)) {
+        return this.response.status(404).json({
+          message: "Expense not found.",
+        })
+      }
+
+      const policy = this.buildPolicy(expense)
+      if (!policy.destroy()) {
+        return this.response.status(403).json({
+          message: "You are not authorized to delete receipt from this expense.",
+        })
+      }
+
+      const receipt = await this.loadReceipt()
+      if (isNil(receipt)) {
+        return this.response.status(404).json({
+          message: "Receipt not found.",
+        })
+      }
+
+      await receipt.destroy()
+      return this.response.status(204).send()
+    } catch (error) {
+      logger.error(`Error deleting receipt: ${error}`, { error })
+      return this.response.status(422).json({
+        message: `Failed to delete receipt: ${error}`,
+      })
+    }
+  }
+
   private loadExpense(): Promise<Expense | null> {
     return Expense.findByPk(this.params.expenseId, {
       include: [
@@ -70,6 +103,15 @@ export class ReceiptController extends BaseController {
           order: [["travelSegments", "segmentNumber", "ASC"]],
         },
       ],
+    })
+  }
+
+  private loadReceipt(): Promise<Attachment | null> {
+    return Attachment.findByPk(this.params.receiptId, {
+      where: {
+        targetId: this.params.expenseId,
+        targetType: Attachment.TargetTypes.Expense,
+      },
     })
   }
 

--- a/api/src/controllers/expenses/receipt-controller.ts
+++ b/api/src/controllers/expenses/receipt-controller.ts
@@ -107,7 +107,7 @@ export class ReceiptController extends BaseController {
   }
 
   private loadReceipt(): Promise<Attachment | null> {
-    return Attachment.findByPk(this.params.receiptId, {
+    return Attachment.findOne({
       where: {
         targetId: this.params.expenseId,
         targetType: Attachment.TargetTypes.Expense,

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -117,9 +117,9 @@ router
   .get(ExpensesController.show)
   .patch(ExpensesController.update)
   .delete(ExpensesController.destroy)
-router.route("/api/expenses/:expenseId/receipt").post(Expenses.ReceiptController.create)
 router
-  .route("/api/expenses/:expenseId/receipt/:receiptId")
+  .route("/api/expenses/:expenseId/receipt")
+  .post(Expenses.ReceiptController.create)
   .delete(Expenses.ReceiptController.destroy)
 
 router.route("/api/flight-reconciliations").get(FlightReconciliationsController.index)

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -117,9 +117,10 @@ router
   .get(ExpensesController.show)
   .patch(ExpensesController.update)
   .delete(ExpensesController.destroy)
+router.route("/api/expenses/:expenseId/receipt").post(Expenses.ReceiptController.create)
 router
-  .route("/api/expenses/:expenseId/receipt")
-  .post(Expenses.ReceiptController.create)
+  .route("/api/expenses/:expenseId/receipt/:receiptId")
+  .delete(Expenses.ReceiptController.destroy)
 
 router.route("/api/flight-reconciliations").get(FlightReconciliationsController.index)
 router.route("/api/flight-reconciliations/sync").post(FlightReconciliations.SyncController.create)

--- a/web/src/api/expenses/receipt-api.ts
+++ b/web/src/api/expenses/receipt-api.ts
@@ -21,22 +21,21 @@ export const receiptApi = {
   },
   async update(
     expenseId: number,
-    receiptId: number,
     file: File
   ): Promise<{
     receipt: Attachment
   }> {
     const formData = new FormData()
     formData.append("content", file)
-    const { data } = await http.patch(`/api/expenses/${expenseId}/receipt/${receiptId}`, formData, {
+    const { data } = await http.patch(`/api/expenses/${expenseId}/receipt`, formData, {
       headers: {
         "Content-Type": "multipart/form-data",
       },
     })
     return data
   },
-  async delete(expenseId: number, receiptId: number): Promise<void> {
-    const { data } = await http.delete(`/api/expenses/${expenseId}/receipt/${receiptId}`)
+  async delete(expenseId: number): Promise<void> {
+    const { data } = await http.delete(`/api/expenses/${expenseId}/receipt`)
     return data
   },
 }

--- a/web/src/components/common/DownloadFileForm.vue
+++ b/web/src/components/common/DownloadFileForm.vue
@@ -15,6 +15,7 @@
       :block="smAndDown"
       :color="color"
       :prepend-icon="prependIcon"
+      :loading="loading"
       type="submit"
     >
       <template #default>
@@ -40,11 +41,13 @@ withDefaults(
     downloadUrl: string
     prependIcon?: string
     color?: string
+    loading?: boolean
   }>(),
   {
     text: "Download File",
     prependIcon: "mdi-download",
     color: "primary",
+    loading: false,
   }
 )
 

--- a/web/src/components/common/PdfViewer.vue
+++ b/web/src/components/common/PdfViewer.vue
@@ -44,6 +44,11 @@ defineProps<{
   source: string
 }>()
 
+// TODO: switch to `update:fullscreen: [boolean]` syntax in vue 3
+const emit = defineEmits<{
+  (event: "update:fullscreen", value: boolean): void
+}>()
+
 const page = ref(1)
 const isLoading = ref(true)
 const pageCount = ref(1)
@@ -99,8 +104,10 @@ async function onFullscreenChange() {
 
   if (isNil(document.fullscreenElement)) {
     isFullscreen.value = false
+    emit("update:fullscreen", isFullscreen.value)
   } else {
     isFullscreen.value = document.fullscreenElement === fullscreenDivRef.value
+    emit("update:fullscreen", isFullscreen.value)
   }
 }
 

--- a/web/src/components/expenses/ExpensesEditDataTable.vue
+++ b/web/src/components/expenses/ExpensesEditDataTable.vue
@@ -23,7 +23,10 @@
         ref="receiptGenericPreviewDialogRef"
         @deleted="emitChangedAndRefresh"
       />
-      <ReceiptImagePreviewDialog ref="receiptImagePreviewDialogRef" />
+      <ReceiptImagePreviewDialog
+        ref="receiptImagePreviewDialogRef"
+        @deleted="emitChangedAndRefresh"
+      />
       <ReceiptPdfPreviewDialog ref="receiptPdfPreviewDialogRef" />
     </template>
     <template #item.date="{ value }">

--- a/web/src/components/expenses/ExpensesEditDataTable.vue
+++ b/web/src/components/expenses/ExpensesEditDataTable.vue
@@ -19,7 +19,10 @@
         ref="deleteDialogRef"
         @deleted="emitChangedAndRefresh"
       />
-      <ReceiptGenericPreviewDialog ref="receiptGenericPreviewDialogRef" />
+      <ReceiptGenericPreviewDialog
+        ref="receiptGenericPreviewDialogRef"
+        @deleted="emitChangedAndRefresh"
+      />
       <ReceiptImagePreviewDialog ref="receiptImagePreviewDialogRef" />
       <ReceiptPdfPreviewDialog ref="receiptPdfPreviewDialogRef" />
     </template>

--- a/web/src/components/expenses/ExpensesEditDataTable.vue
+++ b/web/src/components/expenses/ExpensesEditDataTable.vue
@@ -27,7 +27,10 @@
         ref="receiptImagePreviewDialogRef"
         @deleted="emitChangedAndRefresh"
       />
-      <ReceiptPdfPreviewDialog ref="receiptPdfPreviewDialogRef" />
+      <ReceiptPdfPreviewDialog
+        ref="receiptPdfPreviewDialogRef"
+        @deleted="emitChangedAndRefresh"
+      />
     </template>
     <template #item.date="{ value }">
       {{ formatDate(value) }}

--- a/web/src/components/expenses/receipt/ReceiptGenericPreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptGenericPreviewDialog.vue
@@ -151,12 +151,9 @@ async function deleteReceipt() {
   const staticExpenseId = expenseId.value
   if (isNil(staticExpenseId)) return
 
-  const staticReceiptId = receipt.value?.id
-  if (isNil(staticReceiptId)) return
-
   isLoading.value = true
   try {
-    await expenses.receiptApi.delete(staticExpenseId, staticReceiptId)
+    await expenses.receiptApi.delete(staticExpenseId)
 
     await nextTick()
     hide()

--- a/web/src/components/expenses/receipt/ReceiptGenericPreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptGenericPreviewDialog.vue
@@ -45,40 +45,55 @@
       <v-card-actions>
         <DownloadFileForm
           :download-url="downloadUrl"
+          :loading="isLoading"
           color="secondary"
           text="Download Receipt"
           @downloaded="hide"
         />
         <v-btn
           class="ml-2"
+          :loading="isLoading"
           color="warning"
           @click="hide"
           >Close</v-btn
         >
         <v-spacer />
+        <v-btn
+          :loading="isLoading"
+          color="error"
+          @click="deleteReceipt"
+        >
+          <v-icon>mdi-delete</v-icon>
+          Delete
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from "vue"
+import { ref, computed, nextTick, watch } from "vue"
 import { isNil } from "lodash"
 
 import { formatBytes } from "@/utils/formatters"
 
 import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
-import { receiptApi } from "@/api/downloads/expenses"
+import { downloads, expenses } from "@/api"
 import useExpense from "@/use/use-expense"
 
 import DownloadFileForm from "@/components/common/DownloadFileForm.vue"
+
+// TODO: switch to `deleted: [void]` syntax in vue 3
+const emit = defineEmits<{
+  (event: "deleted"): void
+}>()
 
 const showDialog = ref(false)
 
 const expenseId = useRouteQuery("previewReceiptGeneric", undefined, {
   transform: integerTransformer,
 })
-const { expense } = useExpense(expenseId)
+const { expense, isLoading } = useExpense(expenseId)
 
 const receipt = computed(() => expense.value?.receipt ?? null)
 
@@ -114,7 +129,7 @@ const iconName = computed(() => {
 const downloadUrl = computed(() => {
   if (isNil(expenseId.value)) return ""
 
-  return receiptApi.downloadPath(expenseId.value)
+  return downloads.expenses.receiptApi.downloadPath(expenseId.value)
 })
 
 watch(
@@ -131,6 +146,25 @@ watch(
     immediate: true,
   }
 )
+
+async function deleteReceipt() {
+  const staticExpenseId = expenseId.value
+  if (isNil(staticExpenseId)) return
+
+  const staticReceiptId = receipt.value?.id
+  if (isNil(staticReceiptId)) return
+
+  isLoading.value = true
+  try {
+    await expenses.receiptApi.delete(staticExpenseId, staticReceiptId)
+
+    await nextTick()
+    hide()
+    emit("deleted")
+  } finally {
+    isLoading.value = false
+  }
+}
 
 function show(newExpenseId: number) {
   expenseId.value = newExpenseId

--- a/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
@@ -68,7 +68,6 @@ import { isNil } from "lodash"
 
 import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
 import { downloads, expenses } from "@/api"
-import useExpense from "@/use/use-expense"
 
 import DownloadFileForm from "@/components/common/DownloadFileForm.vue"
 import ImageViewer from "@/components/common/ImageViewer.vue"
@@ -126,18 +125,15 @@ function revokeImageObjectUrl() {
   receiptImageObjectUrl.value = null
 }
 
-const { expense, isLoading } = useExpense(expenseId)
+const isLoading = ref(false)
 
 async function deleteReceipt() {
   const staticExpenseId = expenseId.value
   if (isNil(staticExpenseId)) return
 
-  const staticReceiptId = expense.value?.receipt?.id
-  if (isNil(staticReceiptId)) return
-
   isLoading.value = true
   try {
-    await expenses.receiptApi.delete(staticExpenseId, staticReceiptId)
+    await expenses.receiptApi.delete(staticExpenseId)
 
     await nextTick()
     hide()

--- a/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
@@ -99,6 +99,8 @@ function showFullscreenImage() {
 watch(
   expenseId,
   (newExpenseId) => {
+    isFullscreen.value = false
+
     if (isNil(newExpenseId)) {
       showDialog.value = false
       revokeImageObjectUrl()
@@ -124,12 +126,6 @@ function revokeImageObjectUrl() {
   receiptImageObjectUrl.value = null
 }
 
-const isFullscreen = ref(false)
-
-function updateFullScreen(value: boolean) {
-  isFullscreen.value = value
-}
-
 const { expense, isLoading } = useExpense(expenseId)
 
 async function deleteReceipt() {
@@ -149,6 +145,12 @@ async function deleteReceipt() {
   } finally {
     isLoading.value = false
   }
+}
+
+const isFullscreen = ref(false)
+
+function updateFullScreen(value: boolean) {
+  isFullscreen.value = value
 }
 
 function hideIfNotFullscreen() {

--- a/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
@@ -8,7 +8,16 @@
   >
     <v-card>
       <v-card-title>
-        <h2 class="text-h5">Preview Receipt</h2>
+        <h2 class="text-h5 mb-0">Preview Receipt</h2>
+        <v-spacer />
+        <v-btn
+          class="my-0"
+          color="secondary"
+          @click="showFullscreenImage"
+        >
+          Fullscreen
+          <v-icon>mdi-fullscreen</v-icon>
+        </v-btn>
       </v-card-title>
 
       <v-skeleton-loader
@@ -26,12 +35,14 @@
       <v-card-actions class="d-flex flex-column flex-md-row">
         <DownloadFileForm
           :download-url="downloadUrl"
+          :loading="isLoading"
           color="secondary"
           text="Download Receipt"
           @downloaded="hide"
         />
         <v-btn
           class="ml-2"
+          :loading="isLoading"
           color="warning"
           @click="hide"
         >
@@ -39,12 +50,12 @@
         </v-btn>
         <v-spacer />
         <v-btn
-          class="ml-2"
-          color="secondary"
-          @click="showFullscreenImage"
+          :loading="isLoading"
+          color="error"
+          @click="deleteReceipt"
         >
-          Fullscreen
-          <v-icon>mdi-fullscreen</v-icon>
+          <v-icon>mdi-delete</v-icon>
+          Delete
         </v-btn>
       </v-card-actions>
     </v-card>
@@ -52,14 +63,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from "vue"
+import { computed, nextTick, ref, watch } from "vue"
 import { isNil } from "lodash"
 
 import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
-import { receiptApi } from "@/api/downloads/expenses"
+import { downloads, expenses } from "@/api"
+import useExpense from "@/use/use-expense"
 
 import DownloadFileForm from "@/components/common/DownloadFileForm.vue"
 import ImageViewer from "@/components/common/ImageViewer.vue"
+
+// TODO: switch to `deleted: [void]` syntax in vue 3
+const emit = defineEmits<{
+  (event: "deleted"): void
+}>()
 
 const showDialog = ref(false)
 
@@ -69,7 +86,7 @@ const expenseId = useRouteQuery("previewReceiptImage", undefined, {
 const downloadUrl = computed(() => {
   if (isNil(expenseId.value)) return ""
 
-  return receiptApi.downloadPath(expenseId.value)
+  return downloads.expenses.receiptApi.downloadPath(expenseId.value)
 })
 
 const receiptImageObjectUrl = ref<string | null>(null)
@@ -96,7 +113,7 @@ watch(
 )
 
 async function loadReceiptImageObjectUrl(expenseId: number) {
-  const receiptImage = await receiptApi.get(expenseId)
+  const receiptImage = await downloads.expenses.receiptApi.get(expenseId)
   receiptImageObjectUrl.value = URL.createObjectURL(receiptImage)
 }
 
@@ -111,6 +128,27 @@ const isFullscreen = ref(false)
 
 function updateFullScreen(value: boolean) {
   isFullscreen.value = value
+}
+
+const { expense, isLoading } = useExpense(expenseId)
+
+async function deleteReceipt() {
+  const staticExpenseId = expenseId.value
+  if (isNil(staticExpenseId)) return
+
+  const staticReceiptId = expense.value?.receipt?.id
+  if (isNil(staticReceiptId)) return
+
+  isLoading.value = true
+  try {
+    await expenses.receiptApi.delete(staticExpenseId, staticReceiptId)
+
+    await nextTick()
+    hide()
+    emit("deleted")
+  } finally {
+    isLoading.value = false
+  }
 }
 
 function hideIfNotFullscreen() {

--- a/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptImagePreviewDialog.vue
@@ -98,8 +98,6 @@ function showFullscreenImage() {
 watch(
   expenseId,
   (newExpenseId) => {
-    isFullscreen.value = false
-
     if (isNil(newExpenseId)) {
       showDialog.value = false
       revokeImageObjectUrl()

--- a/web/src/components/expenses/receipt/ReceiptPdfPreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptPdfPreviewDialog.vue
@@ -73,7 +73,6 @@ import { isNil } from "lodash"
 
 import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
 import { downloads, expenses } from "@/api"
-import useExpense from "@/use/use-expense"
 
 import DownloadFileForm from "@/components/common/DownloadFileForm.vue"
 import ConditionalTooltipButton from "@/components/common/ConditionalTooltipButton.vue"
@@ -138,18 +137,15 @@ async function showFullscreen() {
   await pdfViewerRef.value.showFullscreen()
 }
 
-const { expense, isLoading } = useExpense(expenseId)
+const isLoading = ref(false)
 
 async function deleteReceipt() {
   const staticExpenseId = expenseId.value
   if (isNil(staticExpenseId)) return
 
-  const staticReceiptId = expense.value?.receipt?.id
-  if (isNil(staticReceiptId)) return
-
   isLoading.value = true
   try {
-    await expenses.receiptApi.delete(staticExpenseId, staticReceiptId)
+    await expenses.receiptApi.delete(staticExpenseId)
 
     await nextTick()
     hide()

--- a/web/src/components/expenses/receipt/ReceiptPdfPreviewDialog.vue
+++ b/web/src/components/expenses/receipt/ReceiptPdfPreviewDialog.vue
@@ -3,7 +3,7 @@
     v-model="showDialog"
     width="600"
     persistent
-    @keydown.esc="hide"
+    @keydown.esc="hideIfNotFullscreen"
     @input="hideIfFalse"
   >
     <v-card>
@@ -33,6 +33,7 @@
         <PdfViewer
           ref="pdfViewerRef"
           :source="receiptObjectUrl"
+          @update:fullscreen="updateFullScreen"
         />
       </v-card-text>
 
@@ -156,6 +157,18 @@ async function deleteReceipt() {
   } finally {
     isLoading.value = false
   }
+}
+
+const isFullscreen = ref(false)
+
+function updateFullScreen(value: boolean) {
+  isFullscreen.value = value
+}
+
+function hideIfNotFullscreen() {
+  if (isFullscreen.value) return
+
+  hide()
 }
 
 function show(newExpenseId: number) {


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/304

Relates to:

- [EXPENSE (Step 13)](https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/292/wizard/submit-expenses)
- https://github.com/icefoganalytics/travel-authorization/issues/304#issuecomment-3220916469

# Context

**Is your feature request related to a problem? Please describe.**
As a traveler I upload accidently the wrong receipt to my expense. The only way I can remedy this is to delete the entire expense and re-enter it.

**Describe the solution you'd like**
On the edit expense pop-up show the uploaded receipt add a delete button
https://travel-auth-dev.ynet.gov.yk.ca/my-travel-requests/292/wizard/submit-expenses?showEdit=1432
![Image](https://github.com/user-attachments/assets/ae68e31d-9c75-41a6-a0b0-323d954c7744)

# Implementation

1. Add expense receipt deletion endpoint.
2. Add expense receipt deletion button to all expense receipt preview dialogs.

# Screenshots

Generic Expense Receipt Preview with new delete button
http://localhost:8080/my-travel-requests/113/wizard/submit-expenses?previewReceiptGeneric=837
<img width="1851" height="2327" alt="image" src="https://github.com/user-attachments/assets/03b06daf-e844-4b21-8bbd-0fb481650e2e" />

Image Expense Receipt Preview with new delete button
http://localhost:8080/my-travel-requests/113/wizard/submit-expenses?previewReceiptImage=832
<img width="1851" height="2327" alt="image" src="https://github.com/user-attachments/assets/3794ffb2-a4da-48c5-b620-ee7794e546db" />

PDF Expense Receipt Preview with new delete button
http://localhost:8080/my-travel-requests/113/wizard/submit-expenses?previewReceiptPdf=835
<img width="1851" height="2327" alt="image" src="https://github.com/user-attachments/assets/c3661882-8b87-4302-bde8-03f94db6561c" />

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create a new travel request.
5. Pick a non airline travel type on the trip details step.
6. Submit to your supervisor account, then log in as that account and approve the request.
7. Log back in as the traveler and continue until you get to the submit expenses step.
8. Add some expenses, and then add an expense image.
9. Click the "View Receipt" button to open the image preview modal.
10. Check that you can delete the receipt.
11. Add a second expense and receipt with a PDF-image type.
12. Check that when you click the "View Receipt" button, for the PDF type receipt, you get a special PDF display dialog.
13. Check that you can delete the PDF type receipt.
14. Add a third expense and receipt with a non-image type.
15. Check that when you click the "View Receipt" button, for the non-image type receipt, you get the generic dialog.
16. Check that you can delete the non-image type receipt.
