### PR TITLE
Issue-381: Standardize Flight Edit Dialog With Create Dialog

### DIFF
--- a/agents/templates/README.md
+++ b/agents/templates/README.md
@@ -21,6 +21,7 @@ as templates are added, renamed, or removed.
 **Workflows** (in `agents/workflows/`) should contain conversion patterns and process instructions (e.g., "start with this JavaScript file, follow these steps, reference this template").
 
 When creating new documentation:
+
 - Put end-state code examples in `agents/templates/`
 - Put conversion patterns and process steps in `agents/workflows/`
 - Reference templates from workflows: "See template: `backend-index-serializer-template.md`"

--- a/agents/templates/frontend-route-query-create-dialog-template.md
+++ b/agents/templates/frontend-route-query-create-dialog-template.md
@@ -30,34 +30,7 @@ Use this shape for Vue 3 create dialogs that open from a route query parameter.
         </v-card-title>
 
         <v-card-text>
-          <StringDateInput
-            v-model="thing.startedOn"
-            :min="minDate"
-            :max="maxDate"
-            :picker-date="minDate"
-            :rules="[required]"
-            label="Start Date *"
-            type="date"
-            variant="outlined"
-            required
-          />
-
-          <v-radio-group
-            v-model="thing.timePreference"
-            label="Time Preference *"
-            :rules="[required]"
-            inline
-            required
-          >
-            <v-radio
-              label="AM"
-              value="AM"
-            ></v-radio>
-            <v-radio
-              label="PM"
-              value="PM"
-            ></v-radio>
-          </v-radio-group>
+          <!-- Form fields go here. -->
         </v-card-text>
 
         <v-card-actions>
@@ -94,19 +67,9 @@ import thingsApi, { type Thing } from "@/api/things-api"
 import useRouteQuery, { booleanTransformer } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 
-import StringDateInput from "@/components/common/StringDateInput.vue"
-
-const props = withDefaults(
-  defineProps<{
-    parentId: number
-    minDate?: string | null
-    maxDate?: string | null
-  }>(),
-  {
-    minDate: null,
-    maxDate: null,
-  }
-)
+const props = defineProps<{
+  parentId: number
+}>()
 
 const emit = defineEmits<{
   created: [thingId: number]
@@ -193,12 +156,27 @@ defineExpose({
 - Keep parent identity values as explicit props, such as `parentId`; do not pass arbitrary
   `attributes` objects just to seed dialog state.
 - Keep route query values for dialog state and record identifiers, not create payloads.
-- Keep optional date boundaries as `string | null` props and default them to `null` when they feed
-  `:min` or `:max`.
-- Use `:picker-date="minDate"` when a date input should open at the lower bound.
-- Put radio group labels on `v-radio-group` with the `label` prop instead of rendering a separate
-  label element above the group.
 - Prefer `useTemplateRef("form")` for form refs.
 - Order the script as props/emits, route-query dialog state, form model state, watchers, template
   refs/composables used by the submit action, primary submit action, reset helper, show/hide
   helpers, then `defineExpose`.
+- Keep the main template generic. Add domain-specific fields only when the real dialog needs them.
+
+## Field Patterns
+
+Keep this template generic. Before adding form fields, search existing Vue components for the same
+field type and follow the closest local pattern.
+
+Useful searches:
+
+- `rg -n "StringDateInput|:min=|:max=" web/src -g "*.vue"`
+- `rg -n "v-radio-group|label=.*\\*" web/src -g "*.vue"`
+- `rg -n "v-autocomplete|v-select|v-text-field" web/src -g "*.vue"`
+
+Rules that still apply:
+
+- Do not add unused props or imports.
+- Put radio group labels on `v-radio-group` with the `label` prop instead of rendering a separate
+  label element above the group.
+- If a field uses optional date bounds with `:min` or `:max`, define those bounds as
+  `string | null` and default them to `null`.

--- a/agents/templates/frontend-route-query-edit-dialog-template.md
+++ b/agents/templates/frontend-route-query-edit-dialog-template.md
@@ -1,40 +1,37 @@
-# Frontend Route-Query Create Dialog Template
+# Frontend Route-Query Edit Dialog Template
 
-Use this shape for Vue 3 create dialogs that open from a route query parameter.
+Use this shape for Vue 3 edit dialogs that open from a route query record id.
 
 ```vue
 <template>
   <v-dialog
-    v-model="showDialog"
+    :model-value="showDialog"
     persistent
     max-width="500px"
     @keydown.esc="hide"
     @update:model-value="hideIfFalse"
   >
-    <template #activator="{ props: activatorProps }">
-      <v-btn
-        color="primary"
-        v-bind="activatorProps"
-      >
-        Add Thing
-      </v-btn>
-    </template>
-
     <v-form
       ref="form"
-      @submit.prevent="createAndHide"
+      @submit.prevent="updateAndHide"
     >
-      <v-card :loading="isLoading">
+      <v-skeleton-loader
+        v-if="isNil(thingId) || isNil(thing)"
+        type="card"
+      />
+      <v-card
+        v-else
+        :loading="isLoading"
+      >
         <v-card-title>
-          <h2>Add Thing</h2>
+          <h2>Edit Thing</h2>
         </v-card-title>
 
         <v-card-text>
-          <StringDateInput
+          <v-text-field
             v-model="thing.startedOn"
             :min="minDate"
             :max="maxDate"
-            :picker-date="minDate"
             :rules="[required]"
             label="Start Date *"
             type="date"
@@ -89,16 +86,14 @@ import { isNil } from "lodash"
 
 import { required } from "@/utils/validators"
 
-import thingsApi, { type Thing } from "@/api/things-api"
+import thingsApi from "@/api/things-api"
 
-import useRouteQuery, { booleanTransformer } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
+import useThing from "@/use/use-thing"
 
-import StringDateInput from "@/components/common/StringDateInput.vue"
-
-const props = withDefaults(
+withDefaults(
   defineProps<{
-    parentId: number
     minDate?: string | null
     maxDate?: string | null
   }>(),
@@ -109,30 +104,37 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  created: [thingId: number]
+  saved: [thingId: number]
 }>()
 
-const showDialog = useRouteQuery("showThingCreate", "false", {
-  transform: booleanTransformer,
+const thingId = useRouteQuery<string | undefined, number | undefined>("showThingEdit", undefined, {
+  transform: integerTransformer,
 })
 
-const thing = ref<Partial<Thing>>({
-  parentId: props.parentId,
-})
+const { thing, isLoading } = useThing(thingId)
+
+const showDialog = ref(false)
+const form = useTemplateRef("form")
 
 watch(
-  () => props.parentId,
-  () => {
-    resetThing()
+  thingId,
+  (newThingId) => {
+    if (isNil(newThingId)) {
+      showDialog.value = false
+      thing.value = null
+      form.value?.resetValidation()
+    } else {
+      showDialog.value = true
+    }
   },
-  { immediate: true }
+  {
+    immediate: true,
+  }
 )
 
-const form = useTemplateRef("form")
 const snack = useSnack()
-const isLoading = ref(false)
 
-async function createAndHide() {
+async function updateAndHide() {
   if (isNil(form.value)) return
 
   const { valid } = await form.value.validate()
@@ -143,34 +145,34 @@ async function createAndHide() {
 
   isLoading.value = true
   try {
-    const { thing: newThing } = await thingsApi.create(thing.value)
+    if (isNil(thingId.value)) {
+      throw new Error("Thing could not be found.")
+    }
+
+    if (isNil(thing.value)) {
+      throw new Error("Thing could not be loaded.")
+    }
+
+    const { thing: updatedThing } = await thingsApi.update(thingId.value, thing.value)
     hide()
 
     await nextTick()
-    emit("created", newThing.id)
-    snack.success("Thing created successfully")
+    emit("saved", updatedThing.id)
+    snack.success("Thing saved.")
   } catch (error) {
-    console.error(`Failed to create thing: ${error}`, { error })
-    snack.error(`Failed to create thing: ${error}`)
+    console.error(`Failed to save thing: ${error}`, { error })
+    snack.error(`Failed to save thing: ${error}`)
   } finally {
     isLoading.value = false
   }
 }
 
-function resetThing() {
-  thing.value = {
-    parentId: props.parentId,
-  }
-}
-
-function show() {
-  showDialog.value = true
+function show(newThingId: number) {
+  thingId.value = newThingId
 }
 
 function hide() {
-  showDialog.value = false
-  resetThing()
-  form.value?.resetValidation()
+  thingId.value = undefined
 }
 
 function hideIfFalse(value: boolean | null) {
@@ -188,17 +190,16 @@ defineExpose({
 
 ## Notes
 
-- Use `booleanTransformer` for boolean route-query dialog state. Do not use `Boolean`, because
-  `Boolean("false")` is true.
-- Keep parent identity values as explicit props, such as `parentId`; do not pass arbitrary
-  `attributes` objects just to seed dialog state.
-- Keep route query values for dialog state and record identifiers, not create payloads.
+- Use `integerTransformer` for route-query record ids.
 - Keep optional date boundaries as `string | null` props and default them to `null` when they feed
   `:min` or `:max`.
-- Use `:picker-date="minDate"` when a date input should open at the lower bound.
 - Put radio group labels on `v-radio-group` with the `label` prop instead of rendering a separate
   label element above the group.
-- Prefer `useTemplateRef("form")` for form refs.
-- Order the script as props/emits, route-query dialog state, form model state, watchers, template
-  refs/composables used by the submit action, primary submit action, reset helper, show/hide
-  helpers, then `defineExpose`.
+- Use `useTemplateRef("form")` for form refs.
+- Keep route query values for dialog state and record identifiers, not edit payloads.
+- Let the singular composable load the record from the route-query id.
+- Render a skeleton state while the route-query id or loaded record is missing.
+- When the route-query id clears, close the dialog, clear the loaded record, and reset validation.
+- Order the script as props/emits, route-query id state, loaded record state, dialog visibility
+  state and form ref, watcher, composables used by the submit action, primary submit action,
+  show/hide helpers, then `defineExpose`.

--- a/agents/templates/frontend-route-query-edit-dialog-template.md
+++ b/agents/templates/frontend-route-query-edit-dialog-template.md
@@ -28,33 +28,7 @@ Use this shape for Vue 3 edit dialogs that open from a route query record id.
         </v-card-title>
 
         <v-card-text>
-          <v-text-field
-            v-model="thing.startedOn"
-            :min="minDate"
-            :max="maxDate"
-            :rules="[required]"
-            label="Start Date *"
-            type="date"
-            variant="outlined"
-            required
-          />
-
-          <v-radio-group
-            v-model="thing.timePreference"
-            label="Time Preference *"
-            :rules="[required]"
-            inline
-            required
-          >
-            <v-radio
-              label="AM"
-              value="AM"
-            ></v-radio>
-            <v-radio
-              label="PM"
-              value="PM"
-            ></v-radio>
-          </v-radio-group>
+          <!-- Form fields go here. -->
         </v-card-text>
 
         <v-card-actions>
@@ -91,17 +65,6 @@ import thingsApi from "@/api/things-api"
 import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 import useThing from "@/use/use-thing"
-
-withDefaults(
-  defineProps<{
-    minDate?: string | null
-    maxDate?: string | null
-  }>(),
-  {
-    minDate: null,
-    maxDate: null,
-  }
-)
 
 const emit = defineEmits<{
   saved: [thingId: number]
@@ -191,10 +154,6 @@ defineExpose({
 ## Notes
 
 - Use `integerTransformer` for route-query record ids.
-- Keep optional date boundaries as `string | null` props and default them to `null` when they feed
-  `:min` or `:max`.
-- Put radio group labels on `v-radio-group` with the `label` prop instead of rendering a separate
-  label element above the group.
 - Use `useTemplateRef("form")` for form refs.
 - Keep route query values for dialog state and record identifiers, not edit payloads.
 - Let the singular composable load the record from the route-query id.
@@ -203,3 +162,23 @@ defineExpose({
 - Order the script as props/emits, route-query id state, loaded record state, dialog visibility
   state and form ref, watcher, composables used by the submit action, primary submit action,
   show/hide helpers, then `defineExpose`.
+- Keep the main template generic. Add domain-specific fields only when the real dialog needs them.
+
+## Field Patterns
+
+Keep this template generic. Before adding form fields, search existing Vue components for the same
+field type and follow the closest local pattern.
+
+Useful searches:
+
+- `rg -n "StringDateInput|:min=|:max=" web/src -g "*.vue"`
+- `rg -n "v-radio-group|label=.*\\*" web/src -g "*.vue"`
+- `rg -n "v-autocomplete|v-select|v-text-field" web/src -g "*.vue"`
+
+Rules that still apply:
+
+- Do not add unused props or imports.
+- Put radio group labels on `v-radio-group` with the `label` prop instead of rendering a separate
+  label element above the group.
+- If a field uses optional date bounds with `:min` or `:max`, define those bounds as
+  `string | null` and default them to `null`.

--- a/agents/workflows/pull-request-management-workflow.md
+++ b/agents/workflows/pull-request-management-workflow.md
@@ -26,6 +26,8 @@ auto_execution_mode: 1
 - **Screenshots:** If frontend files changed, write `TODO` and let the human add screenshots. Only use `N/A - backend changes only` when there are truly no UI changes.
 - **Draft mode:** Always create PRs as drafts first
 - **Testing instructions:** Use the `testing-instructions-workflow.md` workflow alongside this one. Never guess UI labels or navigation paths.
+- **No extra sections:** Do not add sections beyond this workflow's PR body structure unless the
+  user asks for them. Validation commands belong in the chat handoff, not in a PR body section.
 
 This workflow covers the process of creating and editing well-structured pull requests that follow the established patterns in the TravelAuth project.
 
@@ -145,6 +147,8 @@ The GitHub PR template provides the basic structure. Fill in each section follow
 - **Implementation:** List changes in numbered format. List primary issue fixes first (with step references if applicable), then optional cleanup relevant to end users. Bundle related changes under descriptive purposes. Exclude internal refactoring (component location changes, import updates) unless they impact user experience.
 - **Screenshots:** If the diff includes `web/src/pages/` or `web/src/components/`, write `TODO` and let the human add screenshots. Use `N/A - backend changes only` only when there are no UI changes.
 - **Testing Instructions:** Always start with the standard 3 steps using the dev wrapper commands (`dev test`, `dev up`), then add specific steps using exact UI labels verified from the code. Follow the `testing-instructions.md` workflow for detailed guidance.
+- **Additional sections:** Do not add a `Validation`, `Checks`, or similar section unless the user
+  explicitly requests it. Mention commands you ran in the final chat response instead.
 
 ### 4. Section Guidelines
 

--- a/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestCreateDialog.vue
+++ b/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestCreateDialog.vue
@@ -74,11 +74,10 @@
               cols="12"
               md="4"
             >
-              <div class="label">Time Preference *</div>
               <v-radio-group
                 v-model="travelDeskFlightRequest.timePreference"
+                label="Time Preference *"
                 :rules="[required]"
-                class="mt-1"
                 inline
                 required
               >
@@ -154,8 +153,8 @@ const props = withDefaults(
     maxDate?: string | null
   }>(),
   {
-    minDate: "",
-    maxDate: "",
+    minDate: null,
+    maxDate: null,
   }
 )
 
@@ -174,7 +173,7 @@ const travelDeskFlightRequest = ref<Partial<TravelDeskFlightRequest>>({
 watch(
   () => props.travelRequestId,
   () => {
-    resetFlightRequest()
+    resetTravelDeskFlightRequest()
   },
   { immediate: true }
 )
@@ -209,7 +208,7 @@ async function createAndHide() {
   }
 }
 
-function resetFlightRequest() {
+function resetTravelDeskFlightRequest() {
   travelDeskFlightRequest.value = {
     travelRequestId: props.travelRequestId,
   }
@@ -221,7 +220,7 @@ function show() {
 
 function hide() {
   showDialog.value = false
-  resetFlightRequest()
+  resetTravelDeskFlightRequest()
   form.value?.resetValidation()
 }
 

--- a/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestEditDialog.vue
+++ b/web/src/components/travel-desk-flight-requests/TravelDeskFlightRequestEditDialog.vue
@@ -71,11 +71,10 @@
               cols="12"
               md="4"
             >
-              <div class="label">Time Preference *</div>
               <v-radio-group
                 v-model="travelDeskFlightRequest.timePreference"
+                label="Time Preference *"
                 :rules="[required]"
-                class="mt-1"
                 inline
                 required
               >
@@ -127,52 +126,48 @@
   </v-dialog>
 </template>
 
-<script setup>
-import { ref, nextTick, watch } from "vue"
+<script setup lang="ts">
+import { nextTick, ref, useTemplateRef, watch } from "vue"
 import { isNil } from "lodash"
 
 import { required } from "@/utils/validators"
 
 import travelDeskFlightRequestsApi from "@/api/travel-desk-flight-requests-api"
 
-import useRouteQuery, { integerTransformerLegacy } from "@/use/utils/use-route-query"
+import useRouteQuery, { integerTransformer } from "@/use/utils/use-route-query"
 import useSnack from "@/use/use-snack"
 import useTraveDeskFlightRequest from "@/use/use-travel-desk-flight-request"
 
 import LocationsAutocomplete from "@/components/locations/LocationsAutocomplete.vue"
 import SeatPreferenceSelect from "@/components/travel-desk-flight-requests/SeatPreferenceSelect.vue"
 
-defineProps({
-  minDate: {
-    type: String,
-    default: "",
-  },
-  maxDate: {
-    type: String,
-    default: "",
-  },
-})
+withDefaults(
+  defineProps<{
+    minDate?: string | null
+    maxDate?: string | null
+  }>(),
+  {
+    minDate: null,
+    maxDate: null,
+  }
+)
 
-const emit = defineEmits(["saved"])
+const emit = defineEmits<{
+  saved: [travelDeskFlightRequestId: number]
+}>()
 
-const travelDeskFlightRequestId = useRouteQuery("showFlightRequestEdit", undefined, {
-  transform: integerTransformerLegacy,
-})
+const travelDeskFlightRequestId = useRouteQuery<string | undefined, number | undefined>(
+  "showFlightRequestEdit",
+  undefined,
+  {
+    transform: integerTransformer,
+  }
+)
 
 const { travelDeskFlightRequest, isLoading } = useTraveDeskFlightRequest(travelDeskFlightRequestId)
 
 const showDialog = ref(false)
-
-/** @type {import("vue").Ref<InstanceType<typeof import("vuetify/components").VForm> | null>} */
-const form = ref(null)
-
-function show(newTravelDeskFlightRequestId) {
-  travelDeskFlightRequestId.value = newTravelDeskFlightRequestId
-}
-
-function hide() {
-  travelDeskFlightRequestId.value = undefined
-}
+const form = useTemplateRef("form")
 
 watch(
   travelDeskFlightRequestId,
@@ -203,19 +198,24 @@ async function updateAndHide() {
 
   isLoading.value = true
   try {
-    if (travelDeskFlightRequestId.value === undefined) {
+    if (isNil(travelDeskFlightRequestId.value)) {
       throw new Error("Flight request could not be found")
     }
 
-    const { travelDeskFlightRequest: newFlightRequest } = await travelDeskFlightRequestsApi.update(
-      travelDeskFlightRequestId.value,
-      travelDeskFlightRequest.value
-    )
+    if (isNil(travelDeskFlightRequest.value)) {
+      throw new Error("Flight request could not be loaded")
+    }
+
+    const { travelDeskFlightRequest: updatedTravelDeskFlightRequest } =
+      await travelDeskFlightRequestsApi.update(
+        travelDeskFlightRequestId.value,
+        travelDeskFlightRequest.value
+      )
     hide()
 
     await nextTick()
-    emit("saved", newFlightRequest.id)
-    snack.success("Flight request saved")
+    emit("saved", updatedTravelDeskFlightRequest.id)
+    snack.success("Flight request saved.")
   } catch (error) {
     console.error(`Failed to save flight request: ${error}`, { error })
     snack.error(`Failed to save flight request: ${error}`)
@@ -224,7 +224,15 @@ async function updateAndHide() {
   }
 }
 
-function hideIfFalse(value) {
+function show(newTravelDeskFlightRequestId: number) {
+  travelDeskFlightRequestId.value = newTravelDeskFlightRequestId
+}
+
+function hide() {
+  travelDeskFlightRequestId.value = undefined
+}
+
+function hideIfFalse(value: boolean | null) {
   if (value !== false) return
 
   hide()
@@ -232,12 +240,6 @@ function hideIfFalse(value) {
 
 defineExpose({
   show,
+  hide,
 })
 </script>
-
-<style scoped>
-.label {
-  font-weight: 600;
-  font-size: 10pt !important;
-}
-</style>


### PR DESCRIPTION
Part of https://github.com/icefoganalytics/travel-authorization/issues/381

Relates to:

- https://github.com/icefoganalytics/travel-authorization/pull/383

# Context

Issue 381 reports that Step 7 flight entry fails when adding a second flight:

> Failed to create flight request: ApiError: Flight request creation failed: Error: undefined is not a valid primary key

The primary fix for that failed second-flight creation flow occurs in
https://github.com/icefoganalytics/travel-authorization/pull/383. This PR is the follow-up cleanup:
it standardizes the Travel Desk flight edit dialog with the create dialog so both dialogs use the
same route-query, date-boundary, and Vuetify field patterns.

# Implementation

1. Align the flight edit dialog with the create dialog route-query pattern.
2. Keep optional date bounds as null values when they feed date input minimum and maximum props.
3. Use Vuetify radio group labels for the **Time Preference** field in both flight dialogs.
4. Document the matching create and edit route-query dialog patterns for future dialog work.

# Screenshots

N/a - basically the same UI.

# Testing Instructions

1. Run the relevant test suite using the canonical commands in `bin/README.md`.
2. Boot the app via `./bin/dev up`.
3. Log in to the app at http://localhost:8080.

## Test Case 1: Edit an Existing Flight

4. Navigate directly to an existing travel authorization with flight details, such as `http://localhost:8080/my-travel-requests/6/wizard/edit-travel-desk`.
5. Click the **Edit** action for an existing flight.
6. Verify that the **Edit Flight** dialog opens with the saved flight values.
7. Verify that **Time Preference \*** appears as the radio group label.
8. Update any flight field, then click **Save Flight**.
9. Verify that the dialog closes and the flight row shows the saved value.

## Test Case 2: Create Dialog Still Matches the Same Field Pattern

10. Click **Add Flight**.
11. Fill in **Depart Location \***, **Arrive Location \***, **Date \***, **Time Preference \***, and **Seat Preference \***.
12. Click **Create Flight**.
13. Verify that the new flight is added and the dialog closes.
14. Click **Add Flight** again.
15. Verify that the create dialog opens cleanly and **Time Preference \*** appears as the radio group label.
