### PR TITLE
Issue-387: Fix Vue 3 Receipt Viewing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,8 @@ This file follows the format from https://agents.md/ for AI agent documentation.
 
 **Documentation philosophy:** This file focuses on patterns, conventions, and architecture rather than documenting specific features or domain models. Examples illustrate patterns, not exhaustive feature documentation.
 Less is more: prefer the smallest guidance, implementation, or abstraction that fully solves the
-problem. A thing is complete not when there is nothing left to add, but when there is nothing left
-to take away.
-Do not remove durable reference material that is hard to rediscover later, such as known-good test
-inputs, sample payloads, or validated reference values.
+problem. A thing is complete not when there is nothing left to add, but when there is nothing left to take away.
+Do not remove durable reference material that is hard to rediscover later, such as known-good test inputs, sample payloads, or validated reference values.
 
 Keep `AGENTS.md` focused on project-wide conventions and high-level concepts. When guidance becomes
 specific to a subsystem or directory, move it into the nearest `README.md` or `agents/` workflow

--- a/COMMITTING.md
+++ b/COMMITTING.md
@@ -12,6 +12,10 @@
 **Simple commits:** Single line when the change is self-explanatory.
 **Complex commits:** Title line followed by one or two plain sentences explaining the non-obvious context: things the diff does not make immediately clear. Each sentence ends with a period.
 
+**Less is more:** Keep commit messages concise. Avoid redundancy and unnecessary detail.
+
+**Avoid markers in prose:** Do not use `Why?`, `What?`, `How?`, `NOTE:`, or similar markers in commit body prose. Write in plain conversational English instead.
+
 ## When to use bullet points
 
 Use bullet points for:
@@ -90,29 +94,6 @@ Also fix secondary thing.
 ## Commit body guidance
 
 Write in plain English for the next developer reading `git log`. Use conversational style and focus on "why" and "what" rather than implementation mechanics.
-
-**Common markers to structure information:**
-
-- `Why?` - Explains the reason for the change
-- `What?` - Explains what was changed or the problem being solved
-- `How?` - Technical implementation details
-- `NOTE:` - Additional context, warnings, or caveats
-- `TODO:` - Future work that needs to be done
-- `See` - References to issues, PRs, external links, or other commits
-- `Undoes` - References to previous commits being reverted
-- `Also` - Additional related changes
-
-**Examples:**
-
-```text
-Why? Simplify non-reusable queries into services to reduce complexity at caller location.
-
-What? Previously if a traveller selected a purpose, the summary chip fetched the label without an authorization token.
-
-NOTE: route-query state should use a unique suffix when multiple tables appear on the same page.
-
-See https://github.com/icefoganalytics/travel-authorization/issues/123
-```
 
 Focus on:
 

--- a/agents/workflows/pull-request-management-workflow.md
+++ b/agents/workflows/pull-request-management-workflow.md
@@ -25,7 +25,7 @@ auto_execution_mode: 1
 - **End-user relevance:** Only include changes that affect end users in the Implementation section. Internal refactoring (component location changes, import updates) should be excluded unless they impact user experience.
 - **Screenshots:** If frontend files changed, write `TODO` and let the human add screenshots. Only use `N/A - backend changes only` when there are truly no UI changes.
 - **Draft mode:** Always create PRs as drafts first
-- **Testing instructions:** Use the `testing-instructions-workflow.md` workflow alongside this one. Never guess UI labels or navigation paths.
+- **Testing instructions:** Follow the `testing-instructions-workflow.md` workflow for detailed guidance on writing testing instructions. Never guess UI labels or navigation paths.
 - **No extra sections:** Do not add sections beyond this workflow's PR body structure unless the
   user asks for them. Validation commands belong in the chat handoff, not in a PR body section.
 
@@ -36,11 +36,11 @@ This workflow covers the process of creating and editing well-structured pull re
 ```bash
 # Create draft PR via gh api (preferred)
 cat <<'EOF' | gh api repos/{owner}/{repo}/pulls -X POST \
-  -F title="Title here" \
-  -F head="branch-name" \
-  -F base="main" \
-  -F draft=true \
-  -F body=@-
+  -f title="Title here" \
+  -f head="branch-name" \
+  -f base="main" \
+  -f draft=true \
+  -f body=@-
 Part of <url>
 
 Relates to:
@@ -271,11 +271,11 @@ git push -u origin HEAD
 
 # Create draft PR via gh api
 cat <<'EOF' | gh api repos/{owner}/{repo}/pulls -X POST \
-  -F title="Title" \
-  -F head="$(git branch --show-current)" \
-  -F base="main" \
-  -F draft=true \
-  -F body=@-
+  -f title="Title" \
+  -f head="$(git branch --show-current)" \
+  -f base="main" \
+  -f draft=true \
+  -f body=@-
 [Body content]
 EOF
 ```
@@ -283,7 +283,7 @@ EOF
 To mark a draft PR as ready for review:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/NUMBER -X PATCH -F draft=false
+gh api repos/{owner}/{repo}/pulls/NUMBER -X PATCH -f draft=false
 ```
 
 ### 5. Edit Existing Pull Requests
@@ -292,19 +292,16 @@ When you need to update an existing PR (add context, fix title, update testing i
 
 ```bash
 # View current PR details
-gh pr view NUMBER
+gh api repos/{owner}/{repo}/pulls/NUMBER
 
 # Edit PR title
-gh pr edit NUMBER --title "New Title"
+gh api repos/{owner}/{repo}/pulls/NUMBER -X PATCH -f title="New Title"
 
 # Edit PR body
-gh pr edit NUMBER --body "$(cat <<'EOF'
+gh api repos/{owner}/{repo}/pulls/NUMBER -X PATCH -f body="$(cat <<'EOF'
 Updated PR body content
 EOF
 )"
-
-# Or edit interactively
-gh pr edit NUMBER
 ```
 
 **Common Scenarios for Editing:**
@@ -329,7 +326,7 @@ gh pr edit NUMBER
 
 ```bash
 # Add missing testing instructions to PR #123
-gh pr edit 123 --body "$(cat <<'EOF'
+gh api repos/{owner}/{repo}/pulls/123 -X PATCH -f body="$(cat <<'EOF'
 Fixes https://github.com/icefoganalytics/travel-authorization/issues/123
 
 # Context
@@ -485,12 +482,6 @@ The current system only supports screen viewing and printing, making it difficul
 | Missing links         | Include Fixes/Relates to URLs                                              |
 | Wrong test commands   | Use the canonical test commands in `bin/README.md`, not generic commands   |
 | Type checking ignored | Always run `dev api npm run check-types` and `dev web npm run check-types` |
-
-## Related Workflows
-
-- `convert-js-api-to-typescript-workflow.md` - Converting JavaScript APIs to TypeScript
-- `convert-js-plural-composable-to-typescript-workflow.md` - Converting composables to TypeScript
-- `convert-dialog-table-to-page-pattern-workflow.md` - Converting dialogs to pages
 
 ---
 

--- a/web/src/api/http-client.ts
+++ b/web/src/api/http-client.ts
@@ -4,6 +4,7 @@ import axios from "axios"
 import { API_BASE_URL } from "@/config"
 import auth0 from "@/plugins/auth0-plugin"
 import ApiError from "@/api/api-error"
+import URLToPathName from "@/utils/url-to-path-name"
 
 export const httpClient = axios.create({
   baseURL: API_BASE_URL,
@@ -23,7 +24,8 @@ export const httpClient = axios.create({
 
 httpClient.interceptors.request.use(async (config) => {
   // Only add the Authorization header to requests that start with "/api"
-  if (config.url?.startsWith("/api")) {
+  const pathname = URLToPathName(config.url)
+  if (pathname?.startsWith("/api")) {
     const accessToken = await auth0.getAccessTokenSilently()
     config.headers["Authorization"] = `Bearer ${accessToken}`
   }

--- a/web/src/components/common/ConditionalTooltipButton.vue
+++ b/web/src/components/common/ConditionalTooltipButton.vue
@@ -5,7 +5,7 @@
   >
     <v-btn
       :disabled="disabled"
-      v-bind="merge($attrs, buttonProps)"
+      v-bind="merge({}, $attrs, buttonProps)"
     >
       <slot></slot>
     </v-btn>
@@ -21,7 +21,7 @@
   <v-btn
     v-else
     :disabled="disabled"
-    v-bind="merge($attrs, buttonProps)"
+    v-bind="merge({}, $attrs, buttonProps)"
   >
     <slot></slot>
   </v-btn>

--- a/web/src/components/common/ImageViewer.vue
+++ b/web/src/components/common/ImageViewer.vue
@@ -65,6 +65,7 @@ async function initializeViewer(newImgRef: HTMLImageElement) {
     },
     rotatable: false,
     scalable: false,
+    zIndex: 20000,
   })
 }
 

--- a/web/src/components/common/PdfViewer.vue
+++ b/web/src/components/common/PdfViewer.vue
@@ -39,6 +39,8 @@ import { supportsPDFs } from "pdfobject"
 
 import VuePdfEmbed from "vue-pdf-embed"
 
+import PageLoader from "@/components/PageLoader.vue"
+
 defineProps<{
   source: string
 }>()

--- a/web/src/utils/url-to-path-name.ts
+++ b/web/src/utils/url-to-path-name.ts
@@ -1,0 +1,20 @@
+import { isUndefined } from "lodash"
+
+/**
+ * Extracts the pathname from a URL string.
+ * Handles both absolute URLs (e.g., "http://localhost:3000/api/path") and
+ * relative URLs (e.g., "/api/path").
+ */
+export function URLToPathName(url: string | undefined): string | undefined {
+  if (isUndefined(url)) return url
+
+  try {
+    const parsedUrl = new URL(url)
+    return parsedUrl.pathname
+  } catch {
+    // If URL parsing fails, it's a relative URL, return as-is
+    return url
+  }
+}
+
+export default URLToPathName

--- a/web/tests/utils/url-to-path-name.test.ts
+++ b/web/tests/utils/url-to-path-name.test.ts
@@ -1,0 +1,112 @@
+import URLToPathName from "@/utils/url-to-path-name"
+
+describe("web/src/utils/url-to-path-name.ts", () => {
+  describe("URLToPathName", () => {
+    describe("when given an absolute URL", () => {
+      test.each([
+        {
+          input: "http://localhost:3000/api/path",
+          output: "/api/path",
+        },
+        {
+          input: "https://example.com/api/downloads/expenses/17/receipt",
+          output: "/api/downloads/expenses/17/receipt",
+        },
+        {
+          input: "http://example.com/",
+          output: "/",
+        },
+        {
+          input: "http://example.com",
+          output: "/",
+        },
+        {
+          input: "https://api.gov.yk.ca/heritage/api/users",
+          output: "/heritage/api/users",
+        },
+        {
+          input: "http://localhost:3000/api/traveldesk/travel-requests/123",
+          output: "/api/traveldesk/travel-requests/123",
+        },
+      ])("when input is $input, returns $output", ({ input, output }) => {
+        const result = URLToPathName(input)
+        expect(result).toEqual(output)
+      })
+    })
+
+    describe("when given a relative URL", () => {
+      test.each([
+        {
+          input: "/api/path",
+          output: "/api/path",
+        },
+        {
+          input: "/api/downloads/expenses/17/receipt",
+          output: "/api/downloads/expenses/17/receipt",
+        },
+        {
+          input: "/api",
+          output: "/api",
+        },
+        {
+          input: "/",
+          output: "/",
+        },
+        {
+          input: "api/path",
+          output: "api/path",
+        },
+      ])("when input is $input, returns $output", ({ input, output }) => {
+        const result = URLToPathName(input)
+        expect(result).toEqual(output)
+      })
+    })
+
+    describe("when given undefined", () => {
+      test("returns undefined", () => {
+        const result = URLToPathName(undefined)
+        expect(result).toBeUndefined()
+      })
+    })
+
+    describe("when given an invalid URL", () => {
+      test.each([
+        {
+          input: "invalid-url",
+          output: "invalid-url",
+        },
+        {
+          input: "not a url",
+          output: "not a url",
+        },
+        {
+          input: "",
+          output: "",
+        },
+      ])("when input is $input, returns $output", ({ input, output }) => {
+        const result = URLToPathName(input)
+        expect(result).toEqual(output)
+      })
+    })
+
+    describe("when given URLs with query parameters and hashes", () => {
+      test.each([
+        {
+          input: "http://localhost:3000/api/path?query=param",
+          output: "/api/path",
+        },
+        {
+          input: "https://example.com/api/downloads/expenses/17/receipt#section",
+          output: "/api/downloads/expenses/17/receipt",
+        },
+        {
+          input: "http://example.com/api/path?query=param#hash",
+          output: "/api/path",
+        },
+      ])("when input is $input, returns $output", ({ input, output }) => {
+        const result = URLToPathName(input)
+        expect(result).toEqual(output)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/387

# Context

Vue 3 migration introduced several issues with receipt viewing functionality:
- Expense receipt downloads failed when using absolute URLs due to http-client not extracting pathname for Authorization header injection
- Vue 3 readonly object warnings appeared when components used lodash merge with $attrs
- Image viewer fullscreen mode appeared behind dialogs due to Vuetify 3's new dynamic z-index management

# Implementation

1. Add URLToPathName utility to extract pathname from absolute and relative URLs for http-client Authorization header injection
2. Fix Vue 3 readonly warnings by passing empty object as first argument to lodash merge to prevent mutation of readonly $attrs
3. Set viewerjs zIndex to 20000 to ensure fullscreen appears above Vuetify 3 dialogs
4. Add PageLoader import to PdfViewer component
5. Update commit message guidelines to include "less is more" principle and avoid markers in prose

# Screenshots

Fixed PDF viewer
http://localhost:8080/my-travel-requests/5/wizard/submit-expenses?previewReceiptPdf=17
<img width="1847" height="986" alt="image" src="https://github.com/user-attachments/assets/9bc783e2-7281-49da-9f4b-3e555962d41e" />
<img width="2455" height="1341" alt="image" src="https://github.com/user-attachments/assets/3a0429c6-2979-4677-b04b-1ce45e34e315" />

Fixed Image viewer fullscreen
http://localhost:8080/my-travel-requests/5/wizard/submit-expenses?previewReceiptImage=16
<img width="2718" height="1563" alt="image" src="https://github.com/user-attachments/assets/9e99d434-c0c4-4661-8d19-9173504b3fc5" />
<img width="2718" height="1563" alt="image" src="https://github.com/user-attachments/assets/b6e5483b-2cd5-441c-a611-e2fc6a96aa68" />

# Testing Instructions

1. Run the relevant test suite using the canonical commands in `bin/README.md`.
2. Boot the app via `dev up`.
3. Log in to the app at http://localhost:8080.

## Test Case 1: View PDF Receipt

4. Log in as a traveler user.
5. Navigate to **Travel Authorizations**.
6. Click on an existing travel authorization that has expenses with PDF receipts.
7. In the travel authorization detail view, locate the **Expenses** section.
8. Find an expense with a PDF receipt and click the receipt preview button.
9. Verify the receipt PDF displays correctly in the dialog.
10. Click the **Fullscreen** button in the dialog.
11. Verify the PDF viewer enters fullscreen mode and appears above the dialog.
12. Press **Esc** to exit fullscreen mode.
13. Click the **Download Receipt** button in the dialog.
14. Verify the receipt downloads successfully to your computer.
15. Close the receipt preview dialog.

## Test Case 2: View Image Receipt

16. Navigate to an existing travel authorization that has expenses with image receipts.
17. In the travel authorization detail view, locate the **Expenses** section.
18. Find an expense with an image receipt and click the receipt preview button.
19. Verify the receipt image displays correctly in the dialog.
20. Click the **Fullscreen** button in the dialog.
21. Verify the image viewer enters fullscreen mode and appears above the dialog.
22. Press **Esc** or click the close button to exit fullscreen mode.
23. Click the **Download Receipt** button in the dialog.
24. Verify the receipt downloads successfully to your computer.
25. Close the receipt preview dialog.

## Test Case 3: Verify No Vue Warnings

26. Open the browser developer console.
27. Navigate through the receipt viewing steps for both PDF and image receipts.
28. Verify there are no Vue 3 readonly object warnings in the console.
29. Verify there are no "Invalid absolute docBaseUrl" warnings from PDF.js (this is a cosmetic warning that can be ignored, but should be minimal).