### PR TITLE
Add Playwright End-to-End Testing Skeleton

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -18,6 +18,17 @@ jobs:
     env:
       POSTGRES_CACHE_VERSION: v1
       MSSQL_CACHE_VERSION: v1
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: travel_test
+      DB_USER: app
+      DB_PASS: itsallgood
+      TRAVCOM_DB_HOST: localhost
+      TRAVCOM_DB_PORT: 1433
+      TRAVCOM_DB_NAME: trav_com_test
+      TRAVCOM_DB_USER: sa
+      TRAVCOM_DB_PASS: "DevPwd99!"
+      TRAVCOM_DB_TRUST_SERVER_CERTIFICATE_ENABLED: "true"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    env:
+      POSTGRES_CACHE_VERSION: v1
+      MSSQL_CACHE_VERSION: v1
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,8 +28,26 @@ jobs:
         # directive — runtime values come from the x-default-environment anchor in the compose file.
         run: touch api/.env.development
 
+      - name: Cache PostgreSQL data
+        uses: actions/cache@v4
+        with:
+          path: /tmp/e2e-test-db-postgres
+          key: ${{ runner.os }}-e2e-postgres-${{ env.POSTGRES_CACHE_VERSION }}-${{ hashFiles('api/src/db/migrations/**') }}
+
+      - name: Cache MSSQL data
+        uses: actions/cache@v4
+        with:
+          path: /tmp/e2e-test-db-mssql
+          key: ${{ runner.os }}-e2e-mssql-${{ env.MSSQL_CACHE_VERSION }}-${{ hashFiles('api/src/integrations/trav-com-integration/db/migrations/**') }}
+
+      - name: Prepare database directories
+        run: |
+          mkdir -p /tmp/e2e-test-db-postgres /tmp/e2e-test-db-mssql
+          sudo chown -R 999:999 /tmp/e2e-test-db-postgres
+          sudo chown -R 10001:0 /tmp/e2e-test-db-mssql
+
       - name: Start application stack
-        run: docker compose -f docker-compose.development.yml up -d db db_trav_com api api_wait web
+        run: docker compose -f docker-compose.development.yml -f docker-compose.e2e-test.yml up -d db db_trav_com api api_wait web
 
       - name: Wait for web to be ready
         run: |

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,0 +1,60 @@
+name: End-to-End Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  end-to-end-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create api env file
+        # api/.env.development is gitignored; an empty file satisfies docker-compose's env_file
+        # directive — runtime values come from the x-default-environment anchor in the compose file.
+        run: touch api/.env.development
+
+      - name: Start application stack
+        run: docker compose -f docker-compose.development.yml up -d db db_trav_com api api_wait web
+
+      - name: Wait for web to be ready
+        run: |
+          echo "Waiting for http://localhost:8080 ..."
+          timeout 120 bash -c 'until curl -sf http://localhost:8080; do sleep 2; done'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install dependencies
+        working-directory: api
+        run: npm install
+
+      - name: Install Playwright browsers
+        working-directory: api
+        run: npx playwright install --with-deps chromium
+
+      - name: Run end-to-end tests
+        working-directory: api
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: api/playwright-report/
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,37 @@ See [`bin/README.md`](bin/README.md#testing) for canonical test commands. Use th
 See [api/tests/README.md](api/tests/README.md) for API test structure, factories, and assertion
 patterns.
 
+### End-to-End Tests
+
+End-to-end tests use [Playwright](https://playwright.dev/) and live in `api/end-to-end-tests/`,
+a sibling of `api/tests/`. They share `api/tests/support/clean-database.ts` and
+`clean-trav-com-database.ts` directly via the `@/tests/support/` path alias — no duplication.
+Tests run against the full development stack (frontend on port 8080).
+
+**Run locally (via Docker — matches CI):**
+
+```bash
+dev up                            # start the app stack first
+dev test end-to-end-tests         # run in Docker (headless), uses test databases
+```
+
+**Run locally (native — for development and debugging):**
+
+```bash
+dev up                            # start the app stack first
+cd api
+npm install
+npx playwright install chromium
+npm run test:e2e                  # headless
+```
+
+**Adding tests:** Place new `*.spec.ts` files in `api/end-to-end-tests/tests/`. Import `test` and
+`expect` from `../fixtures` (not `@playwright/test` directly) to get the auto database cleanup fixture.
+Use `test()` (not `it()`). Prefer `page.getByRole` and `page.getByText` locators over CSS selectors.
+
+**Auth:** Most routes require Auth0 login. Tests that need authentication should use a shared
+storageState auth fixture (to be built) and are currently skipped.
+
 ---
 
 ## Frontend Patterns & Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,9 +185,14 @@ npx playwright install chromium
 npm run test:e2e                  # headless
 ```
 
+See `api/end-to-end-tests/README.md` for the current coverage boundary and local runner details.
+Continuous integration currently enforces unauthenticated smoke checks only; the full wizard spec is a
+skipped skeleton until Auth0 storage-state fixtures exist.
+
 **Adding tests:** Place new `*.spec.ts` files in `api/end-to-end-tests/tests/`. Import `test` and
-`expect` from `../fixtures` (not `@playwright/test` directly) to get the auto database cleanup fixture.
-Use `test()` (not `it()`). Prefer `page.getByRole` and `page.getByText` locators over CSS selectors.
+`expect` from `@playwright/test` so the test TypeScript configuration remaps them through the auto
+database cleanup fixture. Use `test()` (not `it()`). Prefer `page.getByRole` and `page.getByText`
+locators over CSS selectors.
 
 **Auth:** Most routes require Auth0 login. Tests that need authentication should use a shared
 storageState auth fixture (to be built) and are currently skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,9 +168,12 @@ Tests run against the full development stack (frontend on port 8080).
 **Run locally (via Docker — matches CI):**
 
 ```bash
-dev up                            # start the app stack first
-dev test end-to-end-tests         # run in Docker (headless), uses test databases
+dev test end-to-end-tests         # starts the test-mode app stack, runs Playwright, then tears down
 ```
+
+This uses `docker-compose.e2e-test.yml` in a separate Docker Compose project so the application and
+Playwright runner use the test databases, not the development databases. The command removes the e2e
+stack after the run.
 
 **Run locally (native — for development and debugging):**
 

--- a/agents/plans/Plan, Add Playwright End-to-End Testing Infrastructure, 2026-06-11.md
+++ b/agents/plans/Plan, Add Playwright End-to-End Testing Infrastructure, 2026-06-11.md
@@ -1,0 +1,115 @@
+# Plan: Add Playwright End-to-End Testing Infrastructure
+
+## Problem Statement
+
+Issue #124 asks for end-to-end tests to reduce QA overhead on each release. No automated browser
+tests exist today. This plan sets up a minimal Playwright skeleton that follows the project's
+existing Docker Compose test patterns and integrates with `dev test`.
+
+## Current State Analysis
+
+**Already Implemented:**
+- ✅ `end-to-end-tests/` directory at repo root (branch `feature/e2e-testing-playwright`)
+- ✅ `end-to-end-tests/package.json` with `@playwright/test ^1.52.0` and run scripts
+- ✅ `end-to-end-tests/playwright.config.ts` — Chromium, `BASE_URL` env, screenshots/video on failure
+- ✅ `end-to-end-tests/tsconfig.json`
+- ✅ `end-to-end-tests/tests/smoke.spec.ts` — 3 smoke tests (health check, sign-in page, auth redirect)
+- ✅ `end-to-end-tests/.gitignore`, `.env.example`
+- ✅ `.github/workflows/end-to-end-tests.yml` — CI workflow (has a bug, see below)
+- ✅ `end-to-end-tests/development.Dockerfile` — based on `mcr.microsoft.com/playwright:v1.52.0-jammy`
+- ✅ `AGENTS.md` updated with End-to-End Tests section
+- ✅ Draft PR #394 open
+
+**Not Yet Implemented:**
+- ✅ Pin `@playwright/test` to exact `1.52.0` (must match Docker image version)
+- ✅ `end_to_end_tests` service in `docker-compose.development.yml`
+- ✅ `dev test end-to-end-tests` command in `bin/dev`
+- ✅ Fix CI workflow: use `touch api/.env.development` instead of copying non-existent example file
+- ✅ `AGENTS.md` local run section updated with `dev test end-to-end-tests`
+- ✅ `bin/README.md` Testing section documents `dev test end-to-end-tests`
+- [ ] Commit, push, update PR via `create-pull-request` skill
+
+## Key Findings
+
+1. **`api/.env.development.example` does not exist.** The project has `.env.development`
+   (gitignored) but no example file. CI workflow fails on the copy step. Fix: `touch api/.env.development`
+   to satisfy `docker compose`'s `env_file:` requirement without exposing secrets. The
+   `x-default-environment` anchor in docker-compose already provides all runtime values.
+
+2. **`wrap` test pattern (for reference).** The sibling project runs tests directly on the CI
+   runner via `actions/setup-node` + `npm ci` + `npm test -- --run`. No Docker Compose for unit
+   tests. Travel-authorization uses Docker Compose for everything; follow that pattern for
+   end-to-end tests to stay consistent.
+
+3. **Playwright Docker image pins browser version.** `mcr.microsoft.com/playwright:v1.52.0-jammy`
+   has Chromium pre-installed for exactly v1.52.0. The `@playwright/test` package version must be
+   pinned to `1.52.0` (exact, not `^1.52.0`) to avoid drift causing browser/driver mismatches.
+
+4. **`BASE_URL` env var bridges local vs Docker.** `playwright.config.ts` already uses
+   `process.env.BASE_URL ?? "http://localhost:8080"`. The Docker service will set
+   `BASE_URL: http://web:8080` so Docker-internal routing works. No config change needed.
+
+5. **`dev test end-to-end-tests` should run with `--no-deps`.** The end-to-end test service has
+   no `depends_on` entries; the full stack is expected to be up via `dev up` first.
+
+## Implementation Steps
+
+### Step 1: Pin Playwright version and add Dockerfile ✅ (Dockerfile done)
+- `end-to-end-tests/package.json`: change `"@playwright/test": "^1.52.0"` → `"1.52.0"`
+- `end-to-end-tests/development.Dockerfile`: FROM playwright image, npm install ✅
+
+### Step 2: Add `end_to_end_tests` Docker service
+In `docker-compose.development.yml`, after `test_web`:
+```yaml
+end_to_end_tests:
+  build:
+    context: ./end-to-end-tests
+    dockerfile: development.Dockerfile
+  command: /bin/true
+  environment:
+    BASE_URL: http://web:8080
+  tty: true
+  volumes:
+    - ./end-to-end-tests:/usr/src/end-to-end-tests
+```
+
+### Step 3: Update `bin/dev`
+In `test` method, add `elsif service == "end-to-end-tests"` branch.
+Add `test_end_to_end` method:
+```ruby
+def test_end_to_end(*args, **kwargs)
+  run(*%w[--no-deps end_to_end_tests npm run test], *args, **kwargs)
+end
+```
+
+### Step 4: Fix CI workflow
+Replace the failing step:
+```yaml
+# Bad (file doesn't exist):
+run: cp api/.env.development.example api/.env.development
+
+# Good:
+run: touch api/.env.development
+```
+
+Also start `db_trav_com` to prevent API startup errors, and wait for it before proceeding.
+
+### Step 5: Update docs
+- `AGENTS.md`: Replace raw npm commands with `dev test end-to-end-tests`
+- `bin/README.md`: Add `./bin/dev test end-to-end-tests` to Testing section
+
+### Step 6: Commit, push, update PR
+- Commit with `:gear:` emoji
+- Push to `feature/e2e-testing-playwright`
+- Use `create-pull-request` skill to update PR #394
+
+## Out of Scope
+
+- Auth0 test-user fixture for authenticated routes (follow-up issue)
+- Full CI test run verification (needs secrets not in CI)
+- Multiple browser targets (Chromium only for now)
+
+## Related Issues
+
+- https://github.com/icefoganalytics/travel-authorization/issues/124
+- Draft PR: https://github.com/icefoganalytics/travel-authorization/pull/394

--- a/agents/plans/Plan, Stabilize Playwright End-to-End Test Infrastructure, 2026-06-13.md
+++ b/agents/plans/Plan, Stabilize Playwright End-to-End Test Infrastructure, 2026-06-13.md
@@ -1,0 +1,121 @@
+# Plan: Stabilize Playwright End-to-End Test Infrastructure
+
+- **Source**: [Pull Request #394: Add Playwright End-to-End Testing Skeleton](https://github.com/icefoganalytics/travel-authorization/pull/394)
+
+## Problem Statement
+
+The Playwright end-to-end test skeleton adds the right high-level pieces, but the current setup has a
+few reliability gaps that can make local and continuous integration runs test different systems. The
+main goal is to make `dev test end-to-end-tests` run against the full application stack using clean
+test databases, then tighten the smoke tests and documentation around that behavior.
+
+## Current State Analysis
+
+**Already Implemented:**
+
+- A Playwright test runner lives under `api/end-to-end-tests/`.
+- A Docker Compose e2e overlay defines test database names and runner environment variables.
+- Continuous integration starts the app stack with the e2e overlay before running tests.
+- Database cleanup fixtures reuse the existing API test cleanup helpers.
+
+**Not Yet Implemented:**
+
+- The local e2e command does not start the app stack with the e2e overlay before running tests.
+- The documented local flow can point tests at the development app stack and development database.
+- The e2e runner can lose image-installed dependencies when the host `api/` directory is bind-mounted.
+- One smoke test claims to verify the API health endpoint but currently requests the frontend base URL.
+- The skipped wizard skeleton is not clearly separated from runnable smoke coverage.
+
+## Key Findings
+
+1. Local e2e runs should be self-contained and use the test database stack by default.
+2. Docker-based local runs should not depend on host-installed `node_modules`.
+3. Smoke tests should assert the thing they name so failures are actionable.
+4. Skipped future tests are acceptable in a skeleton branch, but the limitation should remain explicit.
+
+## Recommended Solution
+
+### Phase 1: Run Local End-to-End Tests Against The Test Stack
+
+**Implementation:**
+
+- Update `bin/dev` so `dev test end-to-end-tests` runs Playwright through the e2e Compose overlay,
+  then tears the e2e stack down after the run.
+- Run the local e2e command under a separate Docker Compose project name so cleanup does not target a
+  normal development stack.
+- Add e2e-specific service dependencies to `docker-compose.e2e-test.yml` so Compose owns startup
+  ordering instead of duplicating service lists in Ruby.
+- Update `bin/README.md` and `AGENTS.md` so local instructions say the command runs against test
+  databases and does not require `dev up` first.
+
+**Benefits:**
+
+- Local and continuous integration runs exercise the same test-mode application stack.
+- Developers are less likely to mutate development data while running end-to-end tests.
+
+### Phase 2: Make The Docker Runner Independent Of Host Dependencies
+
+**Implementation:**
+
+- Adjust the `end_to_end_tests` service volume strategy so the bind mount does not hide installed
+  dependencies, or install dependencies as part of the command in the mounted workspace.
+- Prefer a pattern consistent with the existing project Docker workflow.
+
+**Benefits:**
+
+- Clean checkouts can run end-to-end tests without a local `npm install`.
+- The Docker path remains the canonical path for local and continuous integration validation.
+
+### Phase 3: Correct Smoke Test Coverage
+
+**Implementation:**
+
+- Change the health-check smoke test to request the real API health endpoint, or rename and rewrite it
+  as a frontend route smoke test.
+- Keep unauthenticated smoke tests minimal until an authentication storage-state fixture exists.
+
+**Benefits:**
+
+- Smoke failures point to the broken subsystem instead of an accidentally related route.
+
+### Phase 4: Clarify Skeleton Coverage And Future Auth Work
+
+**Implementation:**
+
+- Keep skipped wizard tests if they are useful reference scaffolding, but make their status clear in
+  pull request notes and documentation.
+- Defer runnable authenticated coverage until storage-state fixtures and test credentials are in place.
+
+**Benefits:**
+
+- Reviewers know what is actually enforced by continuous integration today.
+- Future authenticated tests have a clear next implementation path.
+
+## Decision Factors
+
+1. The e2e command should prioritize safety over speed by defaulting to test databases.
+2. Local behavior should match continuous integration closely enough that failures reproduce.
+3. Changes should land in small slices so each reliability fix can be reviewed independently.
+
+## Recommended Action
+
+Start with Phase 1. After review, continue through the remaining phases one at a time.
+
+## Files To Review
+
+1. `bin/dev` - Command orchestration for local end-to-end test runs.
+2. `bin/README.md` - Local command documentation.
+3. `AGENTS.md` - Agent-facing test workflow guidance.
+4. `docker-compose.development.yml` - End-to-end runner service definition.
+5. `docker-compose.e2e-test.yml` - Test-stack environment and database volume overlay.
+6. `api/end-to-end-tests/tests/smoke.spec.ts` - Runnable smoke test coverage.
+
+## Out Of Scope
+
+- Building Auth0 storage-state fixtures.
+- Making the skipped wizard tests runnable.
+- Expanding end-to-end coverage beyond stabilizing the current skeleton.
+
+## Related Issues
+
+- [Pull Request #394: Add Playwright End-to-End Testing Skeleton](https://github.com/icefoganalytics/travel-authorization/pull/394)

--- a/api/end-to-end-tests/Dockerfile
+++ b/api/end-to-end-tests/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/playwright:v1.60.0-noble
+
+WORKDIR /usr/src/api
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+CMD ["/bin/true"]

--- a/api/end-to-end-tests/README.md
+++ b/api/end-to-end-tests/README.md
@@ -1,0 +1,33 @@
+# End-to-End Tests
+
+Playwright end-to-end tests for the full application stack live here.
+
+## Current Coverage
+
+The runnable test suite currently covers unauthenticated smoke checks only:
+
+- API health check responds and reports the test database.
+- Sign-in page renders.
+- Root route redirects unauthenticated users away from protected content.
+
+`tests/travel-authorization-wizard.spec.ts` is a skipped skeleton for future authenticated workflow
+coverage. It documents the intended multi-user pattern, but it is not enforced by continuous
+integration until Auth0 storage-state fixtures exist.
+
+## Running Tests
+
+Use the project wrapper from the repository root:
+
+```bash
+./bin/dev test end-to-end-tests
+```
+
+The wrapper starts the application stack in test mode, runs Playwright, and tears the stack down after
+the run.
+
+## Adding Tests
+
+Import `test` and `expect` from `@playwright/test`. The test TypeScript configuration remaps that
+module to `fixtures.ts`, which adds automatic database cleanup around every test.
+
+Prefer locators that match user-visible behavior, such as `page.getByRole()` and `page.getByText()`.

--- a/api/end-to-end-tests/fixtures.ts
+++ b/api/end-to-end-tests/fixtures.ts
@@ -1,0 +1,19 @@
+import { test as base, expect } from "@playwright/test"
+
+import cleanDatabase from "@/tests/support/clean-database"
+import cleanTravComDatabase from "@/tests/support/clean-trav-com-database"
+
+type AutoFixtures = { databaseSetup: void }
+
+export const test = base.extend<AutoFixtures>({
+  databaseSetup: [
+    async ({}, use) => {
+      await cleanDatabase()
+      await cleanTravComDatabase()
+      await use()
+    },
+    { auto: true },
+  ],
+})
+
+export { expect }

--- a/api/end-to-end-tests/fixtures.ts
+++ b/api/end-to-end-tests/fixtures.ts
@@ -1,7 +1,12 @@
-import { test as base, expect } from "@playwright/test"
+import { test as base } from "playwright/test"
 
 import cleanDatabase from "@/tests/support/clean-database"
 import cleanTravComDatabase from "@/tests/support/clean-trav-com-database"
+
+// Re-export the full public surface of @playwright/test so that test files
+// importing from "@playwright/test" (which tsconfig.test.json remaps here)
+// can still access expect, Page, Browser, etc. without a separate import.
+export * from "playwright/test"
 
 type AutoFixtures = { databaseSetup: void }
 
@@ -15,5 +20,3 @@ export const test = base.extend<AutoFixtures>({
     { auto: true },
   ],
 })
-
-export { expect }

--- a/api/end-to-end-tests/playwright.config.ts
+++ b/api/end-to-end-tests/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:8080",
+    screenshot: "only-on-failure",
+    video: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})

--- a/api/end-to-end-tests/playwright.config.ts
+++ b/api/end-to-end-tests/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test"
 
 export default defineConfig({
   testDir: "./tests",
+  tsconfig: "./tsconfig.test.json",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/api/end-to-end-tests/tests/smoke.spec.ts
+++ b/api/end-to-end-tests/tests/smoke.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test"
+
+test("health check endpoint responds", async ({ request }) => {
+  const response = await request.get("/health-check")
+  expect(response.status()).toBe(200)
+  const body = await response.text()
+  expect(body).toContain("Health Check")
+})
+
+test("sign-in page renders", async ({ page }) => {
+  await page.goto("/sign-in")
+  await expect(page.getByText("Yukon Government")).toBeVisible()
+})
+
+test("root redirects when unauthenticated", async ({ page }) => {
+  await page.goto("/")
+  // Auth guard redirects to /sign-in or to Auth0 — either way, not a broken page
+  const url = page.url()
+  expect(url).toMatch(/localhost|auth0\.com/)
+})
+
+test.skip("authenticated travel authorization list loads", async ({ page }) => {
+  // Requires Auth0 test credentials.
+  // Implement a storageState auth fixture, then remove this skip.
+  await page.goto("/travel-authorizations")
+  await expect(page.getByRole("heading", { name: "Travel Authorizations" })).toBeVisible()
+})

--- a/api/end-to-end-tests/tests/smoke.spec.ts
+++ b/api/end-to-end-tests/tests/smoke.spec.ts
@@ -1,10 +1,16 @@
 import { test, expect } from "@playwright/test"
 
+type HealthCheckResponse = {
+  dbHealth: {
+    database: string
+  }
+}
+
 test("health check endpoint responds", async ({ request }) => {
-  const response = await request.get("/health-check")
+  const response = await request.get("/api/health-check")
   expect(response.status()).toBe(200)
-  const body = await response.text()
-  expect(body).toContain("Health Check")
+  const body = (await response.json()) as HealthCheckResponse
+  expect(body.dbHealth.database).toBe("travel_test")
 })
 
 test("sign-in page renders", async ({ page }) => {

--- a/api/end-to-end-tests/tests/smoke.spec.ts
+++ b/api/end-to-end-tests/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../fixtures"
+import { test, expect } from "@playwright/test"
 
 test("health check endpoint responds", async ({ request }) => {
   const response = await request.get("/health-check")

--- a/api/end-to-end-tests/tests/smoke.spec.ts
+++ b/api/end-to-end-tests/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test"
+import { test, expect } from "../fixtures"
 
 test("health check endpoint responds", async ({ request }) => {
   const response = await request.get("/health-check")

--- a/api/end-to-end-tests/tests/travel-authorization-wizard.spec.ts
+++ b/api/end-to-end-tests/tests/travel-authorization-wizard.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Travel Authorization Wizard — full happy-path end-to-end tests.
+ *
+ * ALL TESTS ARE SKIPPED until the Auth0 storageState fixtures exist:
+ *   - tests/.auth/traveller.json
+ *   - tests/.auth/admin.json
+ *
+ * Create them in a global-setup.ts that logs in once per role, calls
+ * `context.storageState({ path: 'end-to-end-tests/tests/.auth/<role>.json' })`,
+ * and closes the context.  Then wire globalSetup into playwright.config.ts.
+ *
+ * Multi-user pattern (from the workflow doc):
+ *   Each role gets its own BrowserContext so both sessions coexist without
+ *   displacing each other's Auth0 cookies.
+ *
+ * @see agents/workflows/create-test-travel-request-workflow.md
+ */
+
+import { test, expect } from "../fixtures"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fill a Vuetify date-picker text field and trigger Vue reactivity. */
+async function fillDate(page: import("@playwright/test").Page, label: string, value: string) {
+  const field = page.getByLabel(label)
+  await field.click()
+  await field.selectText()
+  await field.fill(value)
+  await field.press("Tab")
+}
+
+/** Wait for a Vuetify snackbar containing the given text. */
+async function expectToast(page: import("@playwright/test").Page, text: string) {
+  await expect(page.locator(`.v-snackbar:has-text("${text}")`)).toBeVisible()
+}
+
+/** Select a Vuetify combobox / autocomplete option by label and option text. */
+async function selectCombobox(
+  page: import("@playwright/test").Page,
+  label: string,
+  option: string
+) {
+  await page.getByLabel(label).click()
+  await page.getByRole("option", { name: option }).click()
+}
+
+// ---------------------------------------------------------------------------
+// Wizard — Step 1–6: Traveller creates and submits a travel request
+// ---------------------------------------------------------------------------
+
+test.skip("traveller creates and submits a travel request to supervisor", async ({ browser }) => {
+  // Requires tests/.auth/traveller.json (Auth0 storageState).
+  const travellerContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/traveller.json",
+  })
+  const page = await travellerContext.newPage()
+
+  // Step 2 — create a new request
+  await page.goto("/my-travel-requests")
+  await page.getByRole("button", { name: "New Request" }).click()
+
+  // Extract the travel auth ID from the wizard URL
+  await page.waitForURL(/\/my-travel-requests\/(\d+)\/wizard\/edit-trip-purpose/)
+  const travelAuthId = page.url().match(/my-travel-requests\/(\d+)\/wizard/)![1]
+
+  // Step 3 — Trip Purpose
+  await selectCombobox(page, "Purpose", "Conference")
+  await page.getByLabel("Conference name").fill("Annual Tech Conference 2026")
+  await page.getByLabel("In Territory?").getByRole("radio", { name: "No" }).click()
+  await selectCombobox(page, "Final Destination", "Vancouver (BC)")
+  await page.getByRole("button", { name: "Continue" }).click()
+  await expectToast(page, "Travel request saved.")
+
+  // Step 4 — Trip Details (dates must be in the past)
+  await selectCombobox(page, "From", "Whitehorse (YT)")
+  await selectCombobox(page, "To", "Vancouver (BC)")
+  await fillDate(page, "Date", "2026-06-01")
+  await page.getByLabel("Time").fill("08:00")
+  await selectCombobox(page, "Travel Method", "Aircraft")
+  await selectCombobox(page, "Type of Accommodation", "Hotel")
+
+  // Return segment
+  await selectCombobox(page, "From", "Vancouver (BC)")
+  await selectCombobox(page, "To", "Whitehorse (YT)")
+  await fillDate(page, "Date", "2026-06-04")
+  await page.getByLabel("Time").fill("17:00")
+  await selectCombobox(page, "Travel Method", "Aircraft")
+
+  await page.getByRole("button", { name: "Continue" }).click()
+  await expectToast(page, "Travel request saved.")
+
+  // Step 5 — Trip Estimates (use defaults or pre-populated rows)
+  await page.getByRole("button", { name: "Continue" }).click()
+
+  // Step 6 — Submit to Supervisor
+  await page.getByLabel("Travel Advance").fill("0")
+  await selectCombobox(page, "Submit to", process.env["ADMIN_EMAIL"] ?? "")
+  await page.getByRole("button", { name: "Submit to Supervisor" }).click()
+  await expectToast(page, "Travel request submitted.")
+  await page.waitForURL(/awaiting-supervisor-approval/)
+
+  await travellerContext.close()
+  // Expose travelAuthId for downstream tests by returning it (use a shared file or env var in
+  // a real run — this test is a self-contained demonstration).
+  expect(travelAuthId).toBeTruthy()
+})
+
+// ---------------------------------------------------------------------------
+// Wizard — Step 7: Admin approves the travel request
+// ---------------------------------------------------------------------------
+
+test.skip("admin approves a travel request and traveller advances past supervisor step", async ({
+  browser,
+}) => {
+  // Requires tests/.auth/admin.json and tests/.auth/traveller.json.
+  //
+  // In a real run, travelAuthId would come from a fixture or a shared state
+  // file written by the previous test.  The pattern is shown here for clarity.
+  const travelAuthId = process.env["TRAVEL_AUTH_ID"] ?? "PLACEHOLDER"
+
+  const adminContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/admin.json",
+  })
+  const adminPage = await adminContext.newPage()
+
+  await adminPage.goto(`/manage-travel-requests/${travelAuthId}/details`)
+  await adminPage.getByRole("button", { name: "Approve" }).click()
+  await adminPage.getByRole("button", { name: "Approve" }).click() // confirmation dialog
+  await expectToast(adminPage, "Travel authorization approved!")
+
+  await adminContext.close()
+
+  // Traveller checks status
+  const travellerContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/traveller.json",
+  })
+  const travellerPage = await travellerContext.newPage()
+
+  await travellerPage.goto(
+    `/my-travel-requests/${travelAuthId}/wizard/awaiting-supervisor-approval`
+  )
+  await travellerPage.getByRole("button", { name: "Check status?" }).click()
+  await expectToast(travellerPage, "Travel authorization approved!")
+  await travellerPage.waitForURL(/traveler-details/)
+
+  await travellerContext.close()
+})
+
+// ---------------------------------------------------------------------------
+// Wizard — Steps 8–9: Traveller details and submit to travel desk
+// ---------------------------------------------------------------------------
+
+test.skip("traveller fills in traveler details and submits to travel desk", async ({
+  browser,
+}) => {
+  // Requires tests/.auth/traveller.json.
+  const travelAuthId = process.env["TRAVEL_AUTH_ID"] ?? "PLACEHOLDER"
+
+  const travellerContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/traveller.json",
+  })
+  const page = await travellerContext.newPage()
+
+  await page.goto(`/my-travel-requests/${travelAuthId}/wizard/traveler-details`)
+
+  // Step 8 — Traveler Details (form is pre-populated from the user's profile)
+  await page.getByLabel("Legal First Name").fill("Marlen")
+  await page.getByLabel("Legal Last Name").fill("User")
+  await fillDate(page, "Birth Date", "1990-05-01")
+  await page.getByLabel("Address").fill("1234")
+  await selectCombobox(page, "City", "Whitehorse (YT)")
+  await selectCombobox(page, "Province", "Yukon")
+  await page.getByLabel("Postal Code").fill("A1B C2D")
+  await page.getByRole("button", { name: "Continue" }).click()
+
+  // Step 9 — Submit to Travel Desk
+  await page.getByRole("button", { name: "Submit to Travel Desk" }).click()
+  await page.waitForURL(/awaiting-flight-options/)
+
+  await travellerContext.close()
+})
+
+// ---------------------------------------------------------------------------
+// Wizard — Steps 12–13: Traveller submits expenses
+// ---------------------------------------------------------------------------
+
+test.skip("traveller submits expenses with prefill, receipts, and GL coding", async ({
+  browser,
+}) => {
+  // Requires tests/.auth/traveller.json.
+  // Travel dates (2026-06-01 to 2026-06-04) must be in the past.
+  const travelAuthId = process.env["TRAVEL_AUTH_ID"] ?? "PLACEHOLDER"
+
+  const travellerContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/traveller.json",
+  })
+  const page = await travellerContext.newPage()
+
+  await page.goto(`/my-travel-requests/${travelAuthId}/wizard/confirm-actual-travel-details`)
+
+  // Step 11 — Confirm Actual Travel Details
+  await page.getByRole("button", { name: "Continue" }).click()
+
+  // Step 12 — Submit Expenses
+  // 1. Prefill expenses from estimates
+  await page.getByRole("button", { name: "Prefill from Estimates" }).click()
+
+  // 2. Inject fake receipts via DataTransfer API — the real file picker is hidden
+  await page.evaluate(() => {
+    const pngBytes = new Uint8Array([
+      137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 2,
+      0, 0, 0, 144, 119, 83, 222, 0, 0, 0, 12, 73, 68, 65, 84, 8, 215, 99, 248, 15, 0, 0, 1, 1, 0,
+      5, 24, 213, 78, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ])
+    const blob = new Blob([pngBytes], { type: "image/png" })
+    const fileInputs = document.querySelectorAll<HTMLInputElement>("input[type='file'].d-none")
+    for (let index = 0; index < fileInputs.length; index++) {
+      const file = new File([blob], `receipt_${index + 1}.png`, { type: "image/png" })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(file)
+      fileInputs[index].files = dataTransfer.files
+      fileInputs[index].dispatchEvent(new Event("change", { bubbles: true }))
+    }
+  })
+
+  // Wait for uploads to resolve — each expense row should show "View Receipt"
+  await expect(page.getByRole("button", { name: "View Receipt" }).first()).toBeVisible()
+
+  // 3. Add a GL coding row
+  await page.getByRole("button", { name: "Add Coding" }).click()
+  await page.getByLabel("GL Code").fill("552-503010-0222-0006-09999")
+
+  // 4. Submit
+  await page.getByRole("button", { name: "Submit to Supervisor" }).click()
+  await page.waitForURL(/awaiting-expense-claim-approval/)
+
+  await travellerContext.close()
+})
+
+// ---------------------------------------------------------------------------
+// Wizard — Steps 13–15: Supervisor and finance approve the expense claim
+// ---------------------------------------------------------------------------
+
+test.skip("admin approves expense claim and finance processes expenses", async ({ browser }) => {
+  // Requires tests/.auth/admin.json and tests/.auth/traveller.json.
+  const travelAuthId = process.env["TRAVEL_AUTH_ID"] ?? "PLACEHOLDER"
+
+  const adminContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/admin.json",
+  })
+  const adminPage = await adminContext.newPage()
+
+  // Step 13 — Supervisor approves expense claim via API (avoids native window.confirm freeze)
+  await adminPage.goto(`/manage-travel-requests/${travelAuthId}/expense`)
+  await adminPage.evaluate(async (id: string) => {
+    const app = (document.getElementById("app") as HTMLElement & { __vue_app__?: { config: { globalProperties: { $auth0: { getAccessTokenSilently(): Promise<string> } } } } }).__vue_app__
+    if (!app) throw new Error("Vue app not found")
+    const token = await app.config.globalProperties.$auth0.getAccessTokenSilently()
+    const response = await fetch(
+      `http://localhost:3000/api/travel-authorizations/${id}/approve-expense-claim`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      }
+    )
+    return response.json()
+  }, travelAuthId)
+
+  // Step 14 — Finance processes expenses
+  await adminPage.goto(`/expense-processing/${travelAuthId}/expense`)
+  await adminPage.evaluate(async (id: string) => {
+    const app = (document.getElementById("app") as HTMLElement & { __vue_app__?: { config: { globalProperties: { $auth0: { getAccessTokenSilently(): Promise<string> } } } } }).__vue_app__
+    if (!app) throw new Error("Vue app not found")
+    const token = await app.config.globalProperties.$auth0.getAccessTokenSilently()
+    const response = await fetch(`http://localhost:3000/api/travel-authorizations/${id}/expense`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    })
+    return response.json()
+  }, travelAuthId)
+
+  await adminContext.close()
+
+  // Traveller checks final status
+  const travellerContext = await browser.newContext({
+    storageState: "end-to-end-tests/tests/.auth/traveller.json",
+  })
+  const travellerPage = await travellerContext.newPage()
+
+  await travellerPage.goto(
+    `/my-travel-requests/${travelAuthId}/wizard/awaiting-finance-review-and-processing`
+  )
+  await travellerPage.getByRole("button", { name: "Check status?" }).click()
+  await travellerPage.waitForURL(/review-expenses/)
+
+  // Step 15 — Review Expenses — final state, status is "expensed"
+  await expect(
+    travellerPage.getByRole("heading", { name: "Review Expenses" })
+  ).toBeVisible()
+
+  await travellerContext.close()
+})

--- a/api/end-to-end-tests/tests/travel-authorization-wizard.spec.ts
+++ b/api/end-to-end-tests/tests/travel-authorization-wizard.spec.ts
@@ -16,14 +16,14 @@
  * @see agents/workflows/create-test-travel-request-workflow.md
  */
 
-import { test, expect } from "../fixtures"
+import { test, expect, type Page } from "@playwright/test"
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /** Fill a Vuetify date-picker text field and trigger Vue reactivity. */
-async function fillDate(page: import("@playwright/test").Page, label: string, value: string) {
+async function fillDate(page: Page, label: string, value: string) {
   const field = page.getByLabel(label)
   await field.click()
   await field.selectText()
@@ -32,16 +32,12 @@ async function fillDate(page: import("@playwright/test").Page, label: string, va
 }
 
 /** Wait for a Vuetify snackbar containing the given text. */
-async function expectToast(page: import("@playwright/test").Page, text: string) {
+async function expectToast(page: Page, text: string) {
   await expect(page.locator(`.v-snackbar:has-text("${text}")`)).toBeVisible()
 }
 
 /** Select a Vuetify combobox / autocomplete option by label and option text. */
-async function selectCombobox(
-  page: import("@playwright/test").Page,
-  label: string,
-  option: string
-) {
+async function selectCombobox(page: Page, label: string, option: string) {
   await page.getByLabel(label).click()
   await page.getByRole("option", { name: option }).click()
 }

--- a/api/end-to-end-tests/tsconfig.json
+++ b/api/end-to-end-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["./*", "./src/*"]
+    }
+  },
+  "include": ["**/*.ts"]
+}

--- a/api/end-to-end-tests/tsconfig.test.json
+++ b/api/end-to-end-tests/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@playwright/test": ["./end-to-end-tests/fixtures"],
+      "@/*": ["./*", "./src/*"]
+    }
+  }
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -45,6 +45,7 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^8.3.1",
+        "@playwright/test": "1.60.0",
         "@types/cls-hooked": "^4.3.8",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
@@ -1950,6 +1951,22 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -8300,6 +8317,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plimit-lit": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
@@ -11728,6 +11792,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
+    },
+    "@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.60.0"
+      }
     },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.21.3",
@@ -16489,6 +16562,31 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true
     },
     "plimit-lit": {
       "version": "1.6.1",

--- a/api/package.json
+++ b/api/package.json
@@ -11,6 +11,7 @@
     "ts-node": "ts-node -r tsconfig-paths/register",
     "knex": "ts-node -r tsconfig-paths/register ./node_modules/.bin/knex --knexfile src/config.d/knexfile.ts",
     "test": "vitest",
+    "test:e2e": "playwright test --config=end-to-end-tests/playwright.config.ts",
     "lint": "eslint . --ext .js,.ts --ignore-path ../.gitignore",
     "check-types": "tsc -p tests/tsconfig.json --noEmit"
   },
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
+    "@playwright/test": "1.60.0",
     "@types/cls-hooked": "^4.3.8",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/bin/README.md
+++ b/bin/README.md
@@ -52,15 +52,17 @@ of duplicating test command examples.
 
 Pass Vitest flags after `--` so they are forwarded to the underlying test runner.
 
-**End-to-end tests** require the full app stack to be running first:
+**End-to-end tests** start the app stack in test mode, run against isolated test databases, and tear
+the stack down after the run:
 
 ```bash
-./bin/dev up                       # start the app stack
 ./bin/dev test end-to-end-tests    # run Playwright in Docker against the running stack
 ```
 
-The `end_to_end_tests` container connects to the running `web` service over Docker's internal
-network (`http://web:8080`). For interactive debugging, run `npm run test:e2e -- --headed` or
+The command starts the dependent services with the e2e test overlay in a separate Docker Compose
+project before running Playwright. The `end_to_end_tests` container connects to the `web` service over
+Docker's internal network (`http://web:8080`). For interactive debugging, run
+`npm run test:e2e -- --headed` or
 `npx playwright test --ui --config=end-to-end-tests/playwright.config.ts` from inside `api/`.
 
 ### Test Container Management

--- a/bin/README.md
+++ b/bin/README.md
@@ -52,6 +52,17 @@ of duplicating test command examples.
 
 Pass Vitest flags after `--` so they are forwarded to the underlying test runner.
 
+**End-to-end tests** require the full app stack to be running first:
+
+```bash
+./bin/dev up                       # start the app stack
+./bin/dev test end-to-end-tests    # run Playwright in Docker against the running stack
+```
+
+The `end_to_end_tests` container connects to the running `web` service over Docker's internal
+network (`http://web:8080`). For interactive debugging, run `npm run test:e2e -- --headed` or
+`npx playwright test --ui --config=end-to-end-tests/playwright.config.ts` from inside `api/`.
+
 ### Test Container Management
 
 **Only one test container can run at a time** — running two causes database deadlocks. Before starting

--- a/bin/README.md
+++ b/bin/README.md
@@ -65,6 +65,10 @@ Docker's internal network (`http://web:8080`). For interactive debugging, run
 `npm run test:e2e -- --headed` or
 `npx playwright test --ui --config=end-to-end-tests/playwright.config.ts` from inside `api/`.
 
+See `api/end-to-end-tests/README.md` for the current coverage boundary. The runnable suite currently
+enforces unauthenticated smoke checks; authenticated wizard coverage is present as skipped skeleton
+tests until Auth0 storage-state fixtures exist.
+
 ### Test Container Management
 
 **Only one test container can run at a time** — running two causes database deadlocks. Before starting

--- a/bin/dev
+++ b/bin/dev
@@ -124,7 +124,16 @@ class DevHelper
   end
 
   def test_end_to_end(*args, **kwargs)
-    compose(*%w[-f docker-compose.e2e-test.yml run --rm end_to_end_tests npm run test:e2e], *args, **kwargs)
+    compose(
+      *%w[-p travel-authorization-e2e-test -f docker-compose.e2e-test.yml run --rm end_to_end_tests npm run test:e2e],
+      *args,
+      **kwargs.merge(execution_mode: WAIT_FOR_PROCESS)
+    )
+  ensure
+    compose(
+      *%w[-p travel-authorization-e2e-test -f docker-compose.e2e-test.yml down --remove-orphans],
+      **kwargs.merge(execution_mode: WAIT_FOR_PROCESS)
+    )
   end
 
   def psql(*args, **kwargs)

--- a/bin/dev
+++ b/bin/dev
@@ -106,6 +106,8 @@ class DevHelper
       test_api(*args.drop(1), **kwargs)
     elsif service == "web"
       test_web(*args.drop(1), **kwargs)
+    elsif service == "end-to-end-tests"
+      test_end_to_end(*args.drop(1), **kwargs)
     else
       test_api(*args, **kwargs)
     end
@@ -119,6 +121,10 @@ class DevHelper
   def test_web(*args, **kwargs)
     reformat_project_relative_path_filter_for_vitest!(args, "web/")
     run(*%w[test_web npm run test], *args, **kwargs)
+  end
+
+  def test_end_to_end(*args, **kwargs)
+    compose(*%w[-f docker-compose.e2e-test.yml run --rm end_to_end_tests npm run test:e2e], *args, **kwargs)
   end
 
   def psql(*args, **kwargs)

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -105,6 +105,7 @@ services:
     tty: true
     volumes:
       - ./api:/usr/src/api
+      - end_to_end_tests_node_modules:/usr/src/api/node_modules
 
   api_wait:
     image: node:20.19.0-alpine3.21
@@ -157,3 +158,4 @@ services:
 volumes:
   db_data:
   db_trav_com_data:
+  end_to_end_tests_node_modules:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -95,6 +95,17 @@ services:
     volumes:
       - ./web:/usr/src/web
 
+  end_to_end_tests:
+    build:
+      context: ./api
+      dockerfile: end-to-end-tests/Dockerfile
+    command: /bin/true
+    environment:
+      BASE_URL: http://web:8080
+    tty: true
+    volumes:
+      - ./api:/usr/src/api
+
   api_wait:
     image: node:20.19.0-alpine3.21
     depends_on:

--- a/docker-compose.e2e-test.yml
+++ b/docker-compose.e2e-test.yml
@@ -5,7 +5,13 @@ services:
       DB_NAME: travel_test
       TRAVCOM_DB_NAME: trav_com_test
       DEFAULT_LOG_LEVEL: "warn"
+    depends_on:
+      - db
+      - db_trav_com
   end_to_end_tests:
+    depends_on:
+      web:
+        condition: service_started
     environment:
       DB_HOST: db
       DB_PORT: 5432

--- a/docker-compose.e2e-test.yml
+++ b/docker-compose.e2e-test.yml
@@ -5,6 +5,19 @@ services:
       DB_NAME: travel_test
       TRAVCOM_DB_NAME: trav_com_test
       DEFAULT_LOG_LEVEL: "warn"
+  end_to_end_tests:
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: travel_test
+      DB_USER: app
+      DB_PASS: itsallgood
+      TRAVCOM_DB_HOST: db_trav_com
+      TRAVCOM_DB_PORT: 1433
+      TRAVCOM_DB_NAME: trav_com_test
+      TRAVCOM_DB_USER: sa
+      TRAVCOM_DB_PASS: "DevPwd99!"
+      TRAVCOM_DB_TRUST_SERVER_CERTIFICATE_ENABLED: "true"
   db:
     volumes:
       - /tmp/e2e-test-db-postgres:/var/lib/postgresql/data

--- a/docker-compose.e2e-test.yml
+++ b/docker-compose.e2e-test.yml
@@ -1,0 +1,13 @@
+services:
+  api:
+    environment:
+      NODE_ENV: test
+      DB_NAME: travel_test
+      TRAVCOM_DB_NAME: trav_com_test
+      DEFAULT_LOG_LEVEL: "warn"
+  db:
+    volumes:
+      - /tmp/e2e-test-db-postgres:/var/lib/postgresql/data
+  db_trav_com:
+    volumes:
+      - /tmp/e2e-test-db-mssql:/var/opt/mssql/data


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/travel-authorization/issues/124

# Context

Issue #124 asks for end-to-end testing to reduce release QA overhead. This PR adds a Playwright skeleton that can run against the full application stack with isolated test databases, giving the project a safe place to build automated critical-path coverage.

# Implementation

1. Add Playwright end-to-end test infrastructure under `api/end-to-end-tests/`, including a Docker runner, Playwright config, TypeScript config, and a fixture that cleans the PostgreSQL and TravCom test databases before each test.
2. Add runnable unauthenticated smoke coverage for the API health check, sign-in page, and unauthenticated root-route redirect. The health smoke test verifies the API is connected to `travel_test`.
3. Add a skipped travel authorization wizard skeleton that documents the intended authenticated, multi-user workflow until Auth0 storage-state fixtures and test credentials are available.
4. Integrate the runner with `dev test end-to-end-tests` so local Docker runs start an isolated e2e Compose project, use the test database overlay, preserve runner dependencies under bind mounts, and tear the e2e stack down after the run.
5. Add a GitHub Actions workflow for end-to-end tests on pushes and pull requests to `main`. The workflow is currently disabled manually until the smoke suite is confirmed stable enough to enforce in CI.
6. Document the local runner, current coverage boundary, and stabilization plan in the project docs.

# Screenshots

N/A — this PR adds end-to-end test infrastructure, Docker/CI wiring, and documentation. It does not change product UI.

# Testing Instructions

1. Run the relevant test suite using the canonical commands in `bin/README.md`.
2. From the repo root, run `dev test end-to-end-tests`.
3. Verify the command starts the e2e Docker Compose project, runs the Playwright smoke tests, and tears the e2e stack down afterward.
4. Verify the smoke test output includes the health check, sign-in page, and unauthenticated redirect tests.
5. For native debugging, run `cd api`, `npm install`, `npx playwright install chromium`, then `npm run test:e2e`.

# Future Authenticated Coverage

The wizard test skeleton is intentionally skipped until Auth0 storage-state fixtures exist. The intended next step is to add dedicated Auth0 test accounts, save per-role storage state during global setup, and reuse those sessions for authenticated Playwright tests.
